### PR TITLE
PG9.3 Fix

### DIFF
--- a/pljava-api/src/main/java/org/postgresql/pljava/sqlgen/DDRProcessor.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/sqlgen/DDRProcessor.java
@@ -98,7 +98,7 @@ import org.postgresql.pljava.annotation.Trigger;
 ({
   "ddr.name.trusted",    // default "java"
   "ddr.name.untrusted",  // default "javaU"
-  "ddr.output",          // name of ddr file to write
+  "ddr.output"          // name of ddr file to write
 })
 @SupportedSourceVersion(SourceVersion.RELEASE_6)
 public class DDRProcessor extends AbstractProcessor

--- a/pljava-so/src/main/include/pljava/pljava.h
+++ b/pljava-so/src/main/include/pljava/pljava.h
@@ -34,6 +34,14 @@ extern int vsnprintf(char* buf, size_t count, const char* format, va_list arg);
 #include <utils/memutils.h>
 #include <tcop/tcopprot.h>
 
+/*
+ * GETSTRUCT require "access/htup_details.h" to be included in PG9.3
+ */
+#if (PGSQL_MAJOR_VER > 9 || (PGSQL_MAJOR_VER == 9 && PGSQL_MINOR_VER >= 3))
+#include "access/htup_details.h"
+#endif
+
+
 /* The errorOccured will be set when a call from Java into one of the
  * backend functions results in a elog that causes a longjmp (Levels >= ERROR)
  * that was trapped using the PLJAVA_TRY/PLJAVA_CATCH macros.


### PR DESCRIPTION
Changes are required because of move of GETSTRUCT() and timeout handling framework changes done in PG 9.3. Along with that I fixes minor issue in DDRProcessor.java that is causing "illegal start of expression" error. Maven did not worked for me to build it and hang endlessly while building c source code (pljava-so). As a workaround I temporarily fixed makefiles to test PG9.3 related fix that seems worked and generated pljava.jar and pljava.so files and their basic sanity seems working fine.
