### PR TITLE
Fix obsoleted query in sqlj.replace_jar.

### DIFF
--- a/pljava/src/main/java/org/postgresql/pljava/management/Commands.java
+++ b/pljava/src/main/java/org/postgresql/pljava/management/Commands.java
@@ -1041,7 +1041,9 @@ public class Commands
 		PreparedStatement stmt = SQLUtils
 			.getDefaultConnection()
 			.prepareStatement(
-				"UPDATE sqlj.jar_repository SET jarOrigin = ?, jarOwner = ?, jarManifest = NULL, deploymentDesc = NULL WHERE jarId = ?");
+				"UPDATE sqlj.jar_repository "
+				+ "SET jarOrigin = ?, jarOwner = ?, jarManifest = NULL "
+				+ "WHERE jarId = ?");
 		try
 		{
 			stmt.setString(1, urlString);


### PR DESCRIPTION
Ken Olson caught this a year ago in his pull request #29, but
it was my oversight; when rearranging the sqlj relations back
in #10 to accommodate more than one deployment descriptor, I
updated the sql in install_jar and remove_jar (and deployInstall
and deployRemove), but I just totally overlooked replace_jar. Oops.