### PR TITLE
Run deployment descriptors in correct order.

### DIFF
--- a/pljava/src/main/java/org/postgresql/pljava/internal/Backend.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/Backend.java
@@ -1,8 +1,14 @@
 /*
- * Copyright (c) 2004, 2005, 2006 TADA AB - Taby Sweden
- * Distributed under the terms shown in the file COPYRIGHT
- * found in the root folder of this project or at
- * http://eng.tada.se/osprojects/COPYRIGHT.html
+ * Copyright (c) 2004-2015 Tada AB and other contributors, as listed below.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Tada AB
+ *   Purdue University
  */
 package org.postgresql.pljava.internal;
 
@@ -11,6 +17,7 @@ import java.io.FilePermission;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.net.URLConnection;
 import java.security.Permission;
 import java.sql.SQLException;
 import java.util.PropertyPermission;
@@ -208,8 +215,11 @@ public class Backend
 		try
 		{
 			URL url = new URL(urlString);
-			urlStream = url.openStream();
-			Commands.addClassImages(jarId, urlStream);
+			URLConnection uc = url.openConnection();
+			uc.connect();
+			int sz = uc.getContentLength(); // once java6 obsolete, use ...Long
+			urlStream = uc.getInputStream();
+			Commands.addClassImages(jarId, urlStream, sz);
 		}
 		catch(IOException e)
 		{


### PR DESCRIPTION
Previously determined the order of multiple deployment descriptors in
a single jar according to the order of those entries as stored in the jar
(used in that order for install, and that order reversed for remove).

But that wasn't correct. I got my hands on 2003 and 2006 drafts of the
SQL/JRT spec and they both clearly say it is the order _as the entries
are listed in the manifest_ that matters (again, in that order for install,
and the reverse for remove).

This should be a welcome improvement, because I had noted back in
commit 0edc9e5f that maven doesn't always put things in a jar in
the same order, and that was causing the pljava-examples jar to be
broken about half the time (for autodeployment anyway). But the manifest
is a static file listing the ddrs in the right order, so as long as
maven doesn't reorder it while putting it in the jar, that behavior
should now be stable.

Now there still seems to be a lingering problem (for me anyway) where
unexpected class not found errors appear during autodeployment, suggesting
maybe `assertInPath` isn't doing something right, but that's a question for
another day.