### PR TITLE
Enable maven features to build a basic tech-detail site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 /.classpath
 /.project
 /.settings
+target/site
+target/staging
+target/javadoc-bundle-options
 pljava-so/pgsql.properties
 pljava-so/target/

--- a/pljava-ant/src/main/java/org/postgresql/pljava/tasks/package-info.java
+++ b/pljava-ant/src/main/java/org/postgresql/pljava/tasks/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * {@link JarLoaderTask} is a task for deploying a jar to a specified database
+ * as part of an <a href='http://ant.apache.org/' target='_parent'>Ant</a>
+ * build.
+ */
+package org.postgresql.pljava.tasks;

--- a/pljava-api/src/main/java/org/postgresql/pljava/ObjectPool.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/ObjectPool.java
@@ -1,17 +1,31 @@
 /*
- * Copyright (c) 2004, 2005, 2006 TADA AB - Taby Sweden
- * Distributed under the terms shown in the file COPYRIGHT
- * found in the root directory of this distribution or at
- * http://eng.tada.se/osprojects/COPYRIGHT.html
+ * Copyright (c) 2004-2015 Tada AB and other contributors, as listed below.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Tada AB
+ *   Purdue University
  */
 package org.postgresql.pljava;
 
 import java.sql.SQLException;
 
+/**
+ * A pool of objects of a single class.
+ * Obtain an <code>ObjectPool</code> from the {@link Session} by calling
+ * {@link Session#getObjectPool getObjectPool} with a {@link Class} object
+ * for the class to be pooled, which must implement {@link PooledObject}.
+ * @author Thomas Hallgren
+ */
 public interface ObjectPool
 {
 	/**
-	 * Obtain a pooled object. A new instance is created if needed. The pooled
+	 * Obtain a pooled object, calling its {@link PooledObject#activate()}
+	 * method. A new instance is created if needed. The pooled
 	 * object is removed from the pool and activated.
 	 * 
 	 * @return A new object or an object found in the pool.

--- a/pljava-api/src/main/java/org/postgresql/pljava/ResultSetHandle.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/ResultSetHandle.java
@@ -1,8 +1,14 @@
 /*
- * Copyright (c) 2004, 2005, 2006 TADA AB - Taby Sweden
- * Distributed under the terms shown in the file COPYRIGHT
- * found in the root directory of this distribution or at
- * http://eng.tada.se/osprojects/COPYRIGHT.html
+ * Copyright (c) 2004-2015 Tada AB and other contributors, as listed below.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Tada AB
+ *   Purdue University
  */
 package org.postgresql.pljava;
 
@@ -15,6 +21,11 @@ import java.sql.SQLException;
  * of a {@link java.sql.ResultSet}. The primary motivation for this interface is
  * that an implementation that returns a ResultSet must be able to close the
  * connection and statement when no more rows are requested.
+ *
+ * A function returning a <code>SET OF</code> a complex type generated on the
+ * fly (rather than obtained from a query) would return
+ * {@link ResultSetProvider} instead. One returning a <code>SET OF</code> a
+ * simple type should simply return an {@link java.util.Iterator}.
  * @author Thomas Hallgren
  */
 public interface ResultSetHandle

--- a/pljava-api/src/main/java/org/postgresql/pljava/ResultSetProvider.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/ResultSetProvider.java
@@ -1,8 +1,14 @@
 /*
- * Copyright (c) 2004, 2005, 2006 TADA AB - Taby Sweden
- * Distributed under the terms shown in the file COPYRIGHT
- * found in the root folder of this project or at
- * http://eng.tada.se/osprojects/COPYRIGHT.html
+ * Copyright (c) 2004-2015 Tada AB and other contributors, as listed below.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Tada AB
+ *   Purdue University
  */
 package org.postgresql.pljava;
 
@@ -11,7 +17,10 @@ import java.sql.SQLException;
 
 /**
  * An implementation of this interface is returned from functions and procedures
- * that are declared to return <code>SET OF</code> a complex type. Functions that
+ * that are declared to return <code>SET OF</code> a complex type. This
+ * interface is appropriate when the function will be generating the returned
+ * set on the fly; if it will have a {@link ResultSet} obtained from a query,
+ * it should just return {@link ResultSetHandle} instead. Functions that
  * return <code>SET OF</code> a simple type should simply return an
  * {@link java.util.Iterator Iterator}.
  * @author Thomas Hallgren

--- a/pljava-api/src/main/java/org/postgresql/pljava/SavepointListener.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/SavepointListener.java
@@ -1,8 +1,14 @@
 /*
- * Copyright (c) 2004, 2005, 2006 TADA AB - Taby Sweden
- * Distributed under the terms shown in the file COPYRIGHT
- * found in the root folder of this project or at
- * http://eng.tada.se/osprojects/COPYRIGHT.html
+ * Copyright (c) 2004-2015 Tada AB and other contributors, as listed below.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Tada AB
+ *   Purdue University
  */
 package org.postgresql.pljava;
 
@@ -10,6 +16,16 @@ import java.sql.SQLException;
 import java.sql.Savepoint;
 
 /**
+ * Interface for a listener to be notified of the start and commit or abort of
+ * savepoints. To receive such notifications, implement this interface, with
+ * the three methods that will be called in those three cases, and pass an
+ * instance to {@link Session#addSavepointListener}.
+ *
+ * <code>SavepointListener</code> exposes a
+ * <a href=
+'http://doxygen.postgresql.org/xact_8h.html#aceb46988cbad720cc8a2d7ac6951f0ef'
+>PostgreSQL-specific function</a> that is more internal than the documented
+<a href='http://www.postgresql.org/docs/current/static/spi.html'>SPI</a>.
  * @author Thomas Hallgren
  */
 public interface SavepointListener

--- a/pljava-api/src/main/java/org/postgresql/pljava/Session.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/Session.java
@@ -46,9 +46,10 @@ public interface Session
 	Object getAttribute(String attributeName);
 
 	/**
-	 * Return an object pool for the given class. The class must implement
-	 * the interface {@link PooledObject}.
-	 * @param cls
+	 * Return an object pool for the given class.
+	 * @param cls The class of object to be managed by this pool. It must
+	 * implement the interface {@link PooledObject} and have an accessible
+	 * constructor for one argument of type <code>ObjectPool</code>.
 	 * @return An object pool that pools object of the given class.
 	 */
 	ObjectPool getObjectPool(Class cls);

--- a/pljava-api/src/main/java/org/postgresql/pljava/TransactionListener.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/TransactionListener.java
@@ -1,14 +1,30 @@
 /*
- * Copyright (c) 2004, 2005, 2006 TADA AB - Taby Sweden
- * Distributed under the terms shown in the file COPYRIGHT
- * found in the root folder of this project or at
- * http://eng.tada.se/osprojects/COPYRIGHT.html
+ * Copyright (c) 2004-2015 Tada AB and other contributors, as listed below.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Tada AB
+ *   Purdue University
  */
 package org.postgresql.pljava;
 
 import java.sql.SQLException;
 
 /**
+ * Interface for a listener to be notified of prepare, and commit or abort, of
+ * distributed transactions. To receive such notifications, implement this
+ * interface, with the three methods that will be called in those three cases,
+ * and pass an instance to {@link Session#addTransactionListener}.
+ *
+ * <code>TransactionListener</code> exposes a
+ * <a href=
+'http://doxygen.postgresql.org/xact_8h.html#ac0fc861f3ec869429aba4bb97a5b72b8'
+>PostgreSQL-specific function</a> that is more internal than the documented
+<a href='http://www.postgresql.org/docs/current/static/spi.html'>SPI</a>.
  * @author Thomas Hallgren
  */
 public interface TransactionListener

--- a/pljava-api/src/main/java/org/postgresql/pljava/TriggerData.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/TriggerData.java
@@ -1,8 +1,14 @@
 /*
- * Copyright (c) 2004, 2005, 2006 TADA AB - Taby Sweden
- * Distributed under the terms shown in the file COPYRIGHT
- * found in the root folder of this project or at
- * http://eng.tada.se/osprojects/COPYRIGHT.html
+ * Copyright (c) 2004-2015 Tada AB and other contributors, as listed below.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Tada AB
+ *   Purdue University
  */
 package org.postgresql.pljava;
 
@@ -10,6 +16,8 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 
 /**
+ * The data passed to an ordinary (insert/update/delete/truncate) trigger
+ * function.
  * The SQL 2003 spec. does not stipulate a standard way of mapping
  * triggers to functions. The PLJava mapping use this interface. All
  * functions that are intended to be triggers must be public, static,

--- a/pljava-api/src/main/java/org/postgresql/pljava/annotation/Function.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/annotation/Function.java
@@ -31,12 +31,37 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.CLASS)
 public @interface Function
 {
+	/**
+	 * Whether the function is called even for null input,
+	 * or known to return null in that case and therefore not called.
+	 */
 	enum OnNullInput { CALLED, RETURNS_NULL };
 
+	/**
+	 * Whether the function executes with the same identity and
+	 * permissions as the role that has invoked it (the usual case), or
+	 * with the rights of the role that <em>defined</em> it (such as to
+	 * offer controlled access to data the invoker would otherwise have
+	 * no access to). A function should be annotated <code>SECURITY
+	 * DEFINER</code> only after carefully <a href=
+'http://www.postgresql.org/docs/current/static/sql-createfunction.html#SQL-CREATEFUNCTION-SECURITY'
+>considering the implications</a>.
+	 */
 	enum Security { INVOKER, DEFINER };
 
+	/**
+	 * The <a href=
+'http://www.postgresql.org/docs/current/static/xfunc-volatility.html'>volatility
+category</a>
+	 * of the function.
+	 */
 	enum Type { IMMUTABLE, STABLE, VOLATILE };
 
+	/**
+	 * Whether the function only needs restricted capabilities and can
+	 * run in the "trusted" language instance, or requires an unrestricted
+	 * environment and has to run in an "untrusted" language instance.
+	 */
 	enum Trust { RESTRICTED, UNRESTRICTED };
 
 	/**
@@ -84,9 +109,10 @@ public @interface Function
 	 * invoker (the usual case) or with those of its definer (the special
 	 * case for a function that needs to access objects with the authority
 	 * of the user who declared it). Security.DEFINER functions must be coded
-	 * and declared carefully; see at least "Writing SECURITY DEFINER Functions
-	 * Safely" in the SQL Commands reference for CREATE FUNCTION, and the
-	 * settings element of this annotation.
+	 * and declared carefully; see at least <a href=
+'http://www.postgresql.org/docs/current/static/sql-createfunction.html#SQL-CREATEFUNCTION-SECURITY'
+>Writing SECURITY DEFINER Functions Safely</a> in the PostgreSQL docs, and the
+	 * {@link #settings} element of this annotation.
 	 */
 	Security security() default Security.INVOKER;
 	
@@ -114,7 +140,10 @@ public @interface Function
 	
 	/**
 	 * Whether the function can be safely pushed inside the evaluation of views
-	 * created with the security_barrier option. This should only be set true on
+	 * created with the <a href=
+'http://www.postgresql.org/docs/current/static/rules-privileges.html'
+>security_barrier option.</a>
+	 * This should only be set true on
 	 * a function known not to leak data under any circumstances (even, for
 	 * example, throwing errors for certain parameter values and not others).
 	 * Appeared in PostgreSQL 9.2.

--- a/pljava-api/src/main/java/org/postgresql/pljava/annotation/SQLActions.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/annotation/SQLActions.java
@@ -19,8 +19,8 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Container for multiple SQLAction annotations (in case it is convenient to
- * hang more than one on a given program element).
+ * Container for multiple {@link SQLAction} annotations (in case it is
+ * convenient to hang more than one on a given program element).
  *
  * @author Thomas Hallgren - pre-Java6 version
  * @author Chapman Flack (Purdue Mathematics) - updated to Java6,

--- a/pljava-api/src/main/java/org/postgresql/pljava/annotation/SQLType.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/annotation/SQLType.java
@@ -24,7 +24,7 @@ import java.lang.annotation.Target;
  * automatically mapped type, and/or to supply an SQL default value.
  *
  * This annotation cannot be used to supply the SQL declaration's return type,
- * but the complexType element in the Function annotation can.
+ * but {@link Function#complexType @Function(complexType=...)} can.
  *
  * @author Thomas Hallgren - pre-Java6 version
  * @author Chapman Flack (Purdue Mathematics) - updated to Java6, added SQLType

--- a/pljava-api/src/main/java/org/postgresql/pljava/annotation/Trigger.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/annotation/Trigger.java
@@ -17,15 +17,27 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
+ * Annotation, only used in {@link Function#triggers @Function(triggers=...)},
+ * to specify what trigger(s) the function will be called for.
  * @author Thomas Hallgren
  */
 @Target({}) @Retention(RetentionPolicy.CLASS)
 public @interface Trigger
 {
+	/**
+	 * Whether the trigger is invoked before or after the specified event.
+	 */
 	enum When { BEFORE, AFTER };
 
+	/**
+	 * Types of event that can occasion a trigger.
+	 */
 	enum Event { DELETE, INSERT, UPDATE, TRUNCATE };
 
+	/**
+	 * Whether the trigger will occur only once for a statement of interest,
+	 * or once for each row affected by the statement.
+	 */
 	enum Scope { STATEMENT, ROW };
 
 	/**
@@ -45,7 +57,7 @@ public @interface Trigger
 	String name() default "";
 
 	/**
-	 * The name of the schema where containing the table for
+	 * The name of the schema containing the table for
 	 * this trigger.
 	 */
 	String schema() default "";
@@ -56,7 +68,7 @@ public @interface Trigger
 	String table();
 
 	/**
-	 * Scope, i.e. statement or row.
+	 * Scope: statement or row.
 	 */
 	Scope scope() default Scope.STATEMENT;
 	

--- a/pljava-api/src/main/java/org/postgresql/pljava/annotation/package-info.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/annotation/package-info.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2015 Tada AB and other contributors, as listed below.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Tada AB
+ *   Purdue University
+ */
+/**
+ * Annotations for use in Java code to generate the SQLJ Deployment Descriptor
+ * automatically.
+ * <p>
+ * To define functions or types in PL/Java requires more than one step. The
+ * Java code must be written, compiled to a jar, and made available to the
+ * PostgreSQL server. Before the server can use the objects in the jar, the
+ * corresponding PostgreSQL declarations of functions/types/triggers/operators,
+ * and so on, must be made in SQL. This often lengthy SQL script (and the
+ * version that undoes it when uninstalling the jar) can be written in a
+ * prescribed form and stored inside the jar itself as an "SQLJ Deployment
+ * Descriptor", and processed automatically when the jar is installed in or
+ * removed from the backend.
+ * <p>
+ * To write the deployment descriptor by hand can be tedious and error-prone,
+ * as it must largely duplicate the method and type declarations in the
+ * Java code, but using SQL's syntax and types in place of Java's. Instead,
+ * when the annotations in this package are used in the Java code, the Java
+ * compiler itself will generate a deployment descriptor file, ready to include
+ * with the compiled classes to make a complete SQLJ jar.
+ * <p>
+ * Automatic descriptor generation requires attention to a few things.
+ * <ul>
+ * <li>A Java 6 or later Java compiler is required, and at least the
+ * <code>pljava-api</code> jar must be on its class path. (The full
+ * <code>pljava.jar</code> would also work, but only <code>pljava-api</code>
+ * is required.) The jar must be on the class path in any case in order to
+ * compile PL/Java code.
+ * <li>When recompiling after changing only a few sources, it is possible the
+ * Java compiler will only process a subset of the source files containing
+ * annotations. If so, it may generate an incomplete deployment descriptor,
+ * and a clean build may be required to ensure the complete descriptor is
+ * written.
+ * <li>Additional options are available when invoking the Java compiler, and
+ * can be specified with <code>-Aoption=value</code> on the command line:
+ * <dl>
+ * <dt><code>ddr.output</code>
+ * <dd>The file name to be used for the generated deployment descriptor.
+ * If not specified, the file will be named <code>pljava.ddr</code> and found
+ * in the top directory of the tree where the compiled class files are written.
+ * <dt><code>ddr.name.trusted</code>
+ * <dd>The language name that will be used to declare methods that are
+ * annotated to have {@link Function.Trust#RESTRICTED} behavior. If not
+ * specified, the name <code>java</code> will be used. It must match the name
+ * used for the "trusted" language declaration when PL/Java was installed.
+ * <dt><code>ddr.name.untrusted</code>
+ * <dd>The language name that will be used to declare methods that are
+ * annotated to have {@link Function.Trust#UNRESTRICTED} behavior. If not
+ * specified, the name <code>javaU</code> will be used. It must match the name
+ * used for the "untrusted" language declaration when PL/Java was installed.
+ * </dl>
+ * <li>The deployment descriptor may contain statements that cannot succeed if
+ * placed in the wrong order, and to keep a manually-edited script in a workable
+ * order while adding and modifying code can be difficult. Most of the
+ * annotations in this package accept arbitrary <code>requires</code> and
+ * <code>provides</code> strings, which can be used to control the order of
+ * statements in the generated descriptor. The strings given for
+ * <code>requires</code> and <code>provides</code> have no meaning to the
+ * compiler, except that it will make sure not to write anything that
+ * <code>requires</code> some string <em>X</em> into the generated script
+ * before whatever <code>provides</code> it.
+ * </ul>
+ */
+package org.postgresql.pljava.annotation;

--- a/pljava-api/src/main/java/org/postgresql/pljava/package-info.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2015 Tada AB and other contributors, as listed below.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Tada AB
+ *   Purdue University
+ */
+/**
+ * The PL/Java API for use in writing database procedures, functions, and types
+ * using PL/Java.
+ *
+ * Along with the API in this package, PL/Java code will mosty interact with
+ * the database using the specialized, direct version of the
+ * {@linkplain java.sql JDBC API}, obtained (as decreed in the SQL/JRT specs)
+ * from {@link java.sql.DriverManager#getConnection(String)} by passing it
+ * the magic URL <code>jdbc:default:connection</code>.
+ * @author Thomas Hallgren
+ */
+package org.postgresql.pljava;

--- a/pljava-api/src/main/java/org/postgresql/pljava/sqlgen/TriggerNamer.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/sqlgen/TriggerNamer.java
@@ -23,7 +23,7 @@ import static org.postgresql.pljava.annotation.Trigger.Event.TRUNCATE;
  * @author Chapman Flack (Purdue Mathematics) - update to Java6
  */
 
-public class TriggerNamer
+class TriggerNamer
 {
 	static String synthesizeName( Trigger t)
 	{

--- a/pljava-api/src/main/java/org/postgresql/pljava/sqlgen/package-info.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/sqlgen/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2015 Tada AB and other contributors, as listed below.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Tada AB
+ *   Purdue University
+ */
+/**
+ * Not strictly part of the API, this package contains the compiler extension
+ * itself that recognizes
+ * {@linkplain org.postgresql.pljava.annotation PL/Java annotations} and
+ * generates the deployment descriptor. It is part of this module so that the
+ * <code>pljava-api</code> jar will be all that is needed on the class path
+ * when compiling PL/Java code, even with annotations.
+ */
+package org.postgresql.pljava.sqlgen;

--- a/pljava-deploy/src/main/java/org/postgresql/pljava/deploy/package-info.java
+++ b/pljava-deploy/src/main/java/org/postgresql/pljava/deploy/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * One approach to completing the SQL steps of PL/Java installation; will build
+ * a normal, standalone Java app to connect to the database over a vanilla
+ * JDBC connection and install, remove, or reinstall the necessary objects.
+ * See {@link Deployer} for usage.
+ * @author Thomas Hallgren
+ */
+package org.postgresql.pljava.deploy;

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/package-info.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/package-info.java
@@ -1,0 +1,9 @@
+/**
+ * The first examples that were converted to test the <a href=
+"{@docRoot}/../../pljava-api/apidocs/org/postgresql/pljava/annotation/package-summary.html"
+>annotation-driven SQL generator</a> instead of using hand-written SQL
+ * deployment code.
+ * @author Thomas Hallgren
+ * @author Chapman Flack
+ */
+package org.postgresql.pljava.example.annotation;

--- a/pljava/src/main/java/org/postgresql/pljava/internal/package-info.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/package-info.java
@@ -1,0 +1,11 @@
+/**
+ * Java classes implementing core PL/Java behavior. Many of these are the
+ * concrete implementations of classes in the
+ * <a href="{@docRoot}/../../pljava-api/apidocs/index.html" target="_parent"
+>pljava-api</a> module,
+ * and many have corresponding native code in
+ * <a href="{@docRoot}/../../pljava-so/index.html" target="_parent"
+>pljava-so</a>.
+ * @author Thomas Hallgren
+ */
+package org.postgresql.pljava.internal;

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/package-info.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/package-info.java
@@ -1,0 +1,10 @@
+/**
+ * PL/Java's specialized JDBC implementation that interacts directly with the
+ * backend over SPI.
+ * <p>
+ * Some classes and methods here have departures from strict JDBC behavior
+ * that should be covered in their javadoc, or resolved; for now,
+ * comments in the code may be helpful in case of any question.
+ * @author Thomas Hallgren
+ */
+package org.postgresql.pljava.jdbc;

--- a/pljava/src/main/java/org/postgresql/pljava/management/package-info.java
+++ b/pljava/src/main/java/org/postgresql/pljava/management/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * Implementation of the functions specified by the SQL/JRT spec in the
+ * <code>sqlj</code> schema, and related PL/Java-specific ones. See
+ * {@link Commands} for their descriptions.
+ * @author Thomas Hallgren
+ */
+package org.postgresql.pljava.management;

--- a/pljava/src/main/java/org/postgresql/pljava/sqlj/package-info.java
+++ b/pljava/src/main/java/org/postgresql/pljava/sqlj/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * PL/Java's classloading from the jars managed by
+ * {@link org.postgresql.pljava.management.Commands#installJar(String,String,
+boolean) installJar}.
+ * @author Thomas Hallgren
+ */
+package org.postgresql.pljava.sqlj;

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,11 @@
 			<name>PL/Java Snapshots</name>
 			<url>http://nexus.tada.se/content/repositories/snapshots/</url>
 		</snapshotRepository>
+		<site>
+			<id>site.pljava.tada.se</id>
+			<name>PL/Java Developer Info</name>
+			<url>http://tada.github.io/pljava/</url>
+		</site>
 	</distributionManagement>
 
 	<repositories>
@@ -98,4 +103,20 @@
 			</plugin>
 		</plugins>
 	</build>
+	<reporting>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-javadoc-plugin</artifactId>
+				<version>2.10.3</version>
+				<reportSets>
+					<reportSet>
+						<reports>
+							<report>javadoc-no-fork</report>
+						</reports>
+					</reportSet>
+				</reportSets>
+			</plugin>
+		</plugins>
+	</reporting>
 </project>


### PR DESCRIPTION
Now `mvn clean package site site:stage` will produce a (very basic, uncustomized) directory tree representing a web site under `target/staging`. It includes generated javadocs for everything (and I've also spent a bit of time completing javadocs, at least the ones I noticed missing and felt competent to write).

In order to make maven do this, I had to put a site URL into `pom.xml` and you will see that I used `http://tada.github.io/pljava/` which is (I think) what the project's [GitHub Pages](https://help.github.com/articles/creating-project-pages-manually/) URL would be, if you were to enable that feature. So, you may detect in this pull request a faint, implicit suggestion about doing that. :)

I can see in the repository that there already is a `gh-pages` branch where you did some experimenting in early 2013, but that seems to have been just the same content that is now the wiki. What I would suggest is to keep the wiki, and enable the `gh-pages` site for nothing but maven autogenerated technical docs. User Guide content on the wiki could then link to them when appropriate.

Although I haven't tried it, I believe there is a [GitHub-supplied plugin](https://github.github.com/maven-plugins/site-plugin/site-mojo.html) for maven that completes the process, so that a `mvn` command similar to mine above would build all the docs and put them on the GitHub Pages site.

While I'm not sure how you feel about enabling the GitHub Pages site for that purpose, in any case merging this branch will allow anyone who downloads pljava to run the `mvn` command above and get a local set of the same docs.