### PR TITLE
The rest of "Bugfix 1011181"

### DIFF
--- a/pljava-so/src/main/c/Backend.c
+++ b/pljava-so/src/main/c/Backend.c
@@ -897,37 +897,6 @@ JNICALL Java_org_postgresql_pljava_internal_Backend__1log(JNIEnv* env, jclass cl
 	char* str = String_createNTS(jstr);
 	if(str != 0)
 	{
-		/* elog uses printf formatting but the logger does not so we must escape all
-		 * '%' in the string.
-		 */
-		char c;
-		const char* cp;
-		int percentCount = 0;
-		for(cp = str; (c = *cp) != 0; ++cp)
-		{
-			if(c == '%')
-				++percentCount;
-		}
-	
-		if(percentCount > 0)
-		{
-			/* Make room to expand all "%" to "%%"
-			 */
-			char* str2 = palloc((cp - str) + percentCount + 1);
-			char* cp2 = str2;
-	
-			/* Expand... */
-			for(cp = str; (c = *cp) != 0; ++cp)
-			{
-				if(c == '%')
-					*cp2++ = c;
-				*cp2++ = c;
-			}
-			*cp2 = 0;
-			pfree(str);
-			str = str2;
-		}
-	
 		PG_TRY();
 		{
 			elog(logLevel, "%s", str);


### PR DESCRIPTION
This was one problem being solved two ways. First there was code
to double any percent signs in a string that would be passed to elog.
But then myrkraverk in 2012 (622d0ac) got a compiler warning about
using a non-constant format string, and changed the elog call to
pass the supplied string as an argument to `%s` format, which is the
cleaner solution anyway, but didn't remove the old code, so `%` signs
were printing out doubled.