### PR TITLE
Refactor/master/msvc build

### DIFF
--- a/pljava-so/pom.xml
+++ b/pljava-so/pom.xml
@@ -12,19 +12,6 @@
 		Generates the pljava (.so, .dll, etc.) library which gets loaded		by the PostgreSQL backend
 	</description>
 	<packaging>nar</packaging>
-	
-	<properties>
-		<!-- default values when NOT using Microsoft Visual C compiler -->
-		<pkglibdir>"target/lib/"</pkglibdir>
-		<msvc.rint>msvc.rint</msvc.rint>
-		<pgsql.include.extradir1></pgsql.include.extradir1>
-		<pgsql.include.extradir2></pgsql.include.extradir2>
-		<!-- TODO: Check how this works for gcj. -->
-		<jvm.lib.dir>${sun.boot.library.path}/server</jvm.lib.dir>
-		<!-- MSVC requires postgres.lib, so supply dummy reference for other platforms -->
-		<postgres.lib.name>jvm</postgres.lib.name>
-		<postgres.lib.path>${jvm.lib.dir}</postgres.lib.path>
-	</properties>
 
 	<profiles>
 		<profile>
@@ -34,18 +21,40 @@
 					<name>env.VCINSTALLDIR</name>
 				</property>
 			</activation>
-			<properties>
-				<!-- override values when using Microsoft Visual C compiler -->
-				<pkglibdir>\"target/lib/\"</pkglibdir>
-				<!-- add only the additional suffix to avoid injecting empty entries in command line -->
-				<pgsql.include.extradir1>port/win32</pgsql.include.extradir1>
-				<pgsql.include.extradir2>port/win32_msvc</pgsql.include.extradir2>
-				<jvm.lib.dir>${JAVA6_HOME}/lib</jvm.lib.dir>
-				<postgres.lib.name>postgres</postgres.lib.name>
-				<postgres.lib.path>${PGSQL_PKGLIBDIR}</postgres.lib.path>
-				<!-- Need this for Visual Studio 2013 and Postgresql v9.3 and below -->
-				<msvc.rint>${MSVC_RINT}</msvc.rint>
-			</properties>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>com.github.maven-nar</groupId>
+						<artifactId>nar-maven-plugin</artifactId>
+						<configuration>
+							<c>
+								<defines combine.children='append'>
+									<!-- Need this for Visual Studio 2013 and Postgresql v9.3 and below -->
+									<define>${MSVC_RINT}</define>
+								</defines>
+								<includePaths combine.children='append'>
+									<includePath>${PGSQL_INCLUDEDIR-SERVER}/port/win32</includePath>
+									<includePath>${PGSQL_INCLUDEDIR-SERVER}/port/win32_msvc</includePath>
+								</includePaths>
+							</c>
+							<linker>
+								<libs combine.children='append'>
+									<lib>
+										<name>jvm</name>
+										<type>shared</type>
+										<directory>${java.home}/lib</directory>
+									</lib>
+									<lib>
+										<name>postgres</name>
+										<type>shared</type>
+										<directory>${PGSQL_PKGLIBDIR}</directory>
+									</lib>
+								</libs>
+							</linker>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
 		</profile>
 	</profiles>
 	
@@ -130,7 +139,6 @@
 							<classPath>${basedir}/../pljava-api/target/classes/</classPath>
 						</classPaths>
 						<classDirectory>${basedir}/../pljava/target/classes/</classDirectory>
-						<!-- The following needs https://github.com/maven-nar/maven-nar-plugin/pull/22 -->
 						<extraClasses>
 							<extraClass>java.sql.Types</extraClass>
 						</extraClasses>
@@ -142,20 +150,18 @@
 						<name>${CPP_COMPILER}</name>
 				-->
 						<defines>
-							<define>PKGLIBDIR=${pkglibdir}</define>
+							<!-- What PKGLIBDIR controls is the expansion of
+							     $libdir if used in pljava.classpath
+							-->
+							<define>PKGLIBDIR=${PGSQL_PKGLIBDIR}</define>
 							<define>PGSQL_MAJOR_VER=${PGSQL_MAJOR_VER}</define>
 							<define>PGSQL_MINOR_VER=${PGSQL_MINOR_VER}</define>
 							<define>PGSQL_PATCH_VER=${PGSQL_PATCH_VER}</define>
-							<!-- for MSVC -->
-							<define>${msvc.rint}</define>
 						</defines>
 						<includePaths>
 							<!-- TODO: hardcoded paths -->
 							<includePath>${PGSQL_INCLUDEDIR}</includePath>
 							<includePath>${PGSQL_INCLUDEDIR-SERVER}</includePath>
-							<!-- include paths for MSVC required headers -->
-							<includePath>${PGSQL_INCLUDEDIR-SERVER}/${pgsql.include.extradir1}</includePath>
-							<includePath>${PGSQL_INCLUDEDIR-SERVER}/${pgsql.include.extradir2}</includePath>
 							<includePath>${basedir}/src/main/include/</includePath>
 							<includePath>${basedir}/target/nar/javah-include/</includePath>
 						</includePaths>
@@ -167,12 +173,8 @@
 							<lib>
 								<name>jvm</name>
 								<type>shared</type>
-								<directory>${jvm.lib.dir}</directory>
-							</lib>
-							<lib>
-								<name>${postgres.lib.name}</name>
-								<type>shared</type>
-								<directory>${postgres.lib.path}</directory>
+								<!-- Never mind gcj. pipermail/pljava-dev/2013/002081.html -->
+								<directory>${sun.boot.library.path}/server</directory>
 							</lib>
 							<lib>
 								<name>ecpg</name>

--- a/pljava-so/pom.xml
+++ b/pljava-so/pom.xml
@@ -40,11 +40,6 @@
 							<linker>
 								<libs combine.children='append'>
 									<lib>
-										<name>jvm</name>
-										<type>shared</type>
-										<directory>${java.home}/lib</directory>
-									</lib>
-									<lib>
 										<name>postgres</name>
 										<type>shared</type>
 										<directory>${PGSQL_PKGLIBDIR}</directory>
@@ -167,15 +162,16 @@
 						</includePaths>
 					</c>
 
+					<java>
+						<!-- This is supposed to be the same as adding the
+						     exact right <lib> specification under <linker>
+							 to refer to libjvm.
+						-->
+						<link>true</link>
+					</java>
 					<!-- Defines linker flags "-ljvm -L.../server" -->
 					<linker>
 						<libs>
-							<lib>
-								<name>jvm</name>
-								<type>shared</type>
-								<!-- Never mind gcj. pipermail/pljava-dev/2013/002081.html -->
-								<directory>${sun.boot.library.path}/server</directory>
-							</lib>
 							<lib>
 								<name>ecpg</name>
 								<type>shared</type>


### PR DESCRIPTION
Some changes to improve DRYness of the pljava-so pom, getting the MSVC and non-msvc cases to share more and be less intertwined. @kenolson has tested under MSVC. Discussion has been in comments on #29.

Also changes the expansion of `$libdir` back to the real value from `pg_config --pkglibdir`. Somebody must have hardcoded it one day to do some testing in the maven `target` directory and it must have gotten committed that way, but that could have caused some headscratching for anyone trying to use it for real.

What this change does _not_ do is remove the explicit references to libs pq, ecpg, and pgtypes, even though I have not found them to be necessary on linux and Ken hasn't found them necessary with MSVC. Best current information seems to be that they helped on OS X for some reason and I don't have that story yet, so I haven't touched them.