### PR TITLE
Cull gcc warnings to a comprehensible number.

### DIFF
--- a/pljava-so/pom.xml
+++ b/pljava-so/pom.xml
@@ -12,6 +12,11 @@
 		Generates the pljava (.so, .dll, etc.) library which gets loaded		by the PostgreSQL backend
 	</description>
 	<packaging>nar</packaging>
+	
+	<properties>
+		<!-- use -Dnar.cores=1 if non-interleaved warning messages wanted -->
+		<nar.cores>0</nar.cores>
+	</properties>
 
 	<profiles>
 		<profile>
@@ -146,6 +151,7 @@
 				<extensions>true</extensions>
 
 				<configuration>
+					<maxCores>${nar.cores}</maxCores>
 					<!-- Generates C header files from Java class files. -->
 					<javah>
 						<classPaths>

--- a/pljava-so/pom.xml
+++ b/pljava-so/pom.xml
@@ -58,6 +58,7 @@
 				<plugins>
 					<plugin>
 						<groupId>com.github.maven-nar</groupId>
+						<artifactId>nar-maven-plugin</artifactId>
 							<configuration>
 								<c>
 									<options>
@@ -65,7 +66,6 @@
 									</options>
 								</c>
 							</configuration>
-						<artifactId>nar-maven-plugin</artifactId>
 					</plugin>
 				</plugins>
 			</build>

--- a/pljava-so/pom.xml
+++ b/pljava-so/pom.xml
@@ -51,6 +51,25 @@
 				</plugins>
 			</build>
 		</profile>
+
+		<profile>
+			<id>wnosign</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>com.github.maven-nar</groupId>
+							<configuration>
+								<c>
+									<options>
+										<option>-Wno-sign-conversion</option>
+									</options>
+								</c>
+							</configuration>
+						<artifactId>nar-maven-plugin</artifactId>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
 	</profiles>
 	
 	<build>

--- a/pljava-so/pom.xml
+++ b/pljava-so/pom.xml
@@ -254,8 +254,8 @@
 								</pluginExecution>
 								<pluginExecution>
 									<pluginExecutionFilter>
-										<groupId>org.apache.maven.plugins</groupId>
-										<artifactId>maven-nar-plugin</artifactId>
+										<groupId>com.github.maven-nar</groupId>
+										<artifactId>nar-maven-plugin</artifactId>
 										<versionRange>[3.1.0]</versionRange>
 										<goals>
 											<goal>nar-compile</goal>

--- a/pljava-so/src/main/c/Exception.c
+++ b/pljava-so/src/main/c/Exception.c
@@ -88,7 +88,7 @@ void Exception_throw(int errCode, const char* errMessage, ...)
 		 */
 		for (idx = 0; idx < 5; ++idx)
 		{
-			buf[idx] = PGUNSIXBIT(errCode);
+			buf[idx] = (char)PGUNSIXBIT(errCode);
 			errCode >>= 6;
 		}
 		buf[idx] = 0;

--- a/pljava-so/src/main/c/Function.c
+++ b/pljava-so/src/main/c/Function.c
@@ -818,8 +818,8 @@ bool Function_isCurrentReadOnly(void)
 	/* function will be 0 during resolve of class and java function. At
 	 * that time, no updates are allowed (or needed).
 	 */
-	return (currentInvocation->function == 0)
-		? true
-		: currentInvocation->function->readOnly;
+	if (currentInvocation->function == 0)
+		return true;
+	return currentInvocation->function->readOnly;
 }
 

--- a/pljava-so/src/main/c/type/Array.c
+++ b/pljava-so/src/main/c/type/Array.c
@@ -166,7 +166,9 @@ static Datum _Array_coerceObject(Type self, jobject objArray)
 static bool _Array_canReplaceType(Type self, Type other)
 {
 	Type oe = Type_getElementType(other);
-	return oe == 0 ? false : Type_canReplaceType(Type_getElementType(self), oe);
+	if ( oe == 0 )
+		return false;
+	return Type_canReplaceType(Type_getElementType(self), oe);
 }
 
 Type Array_fromOid(Oid typeId, Type elementType)

--- a/pljava-so/src/main/c/type/Array.c
+++ b/pljava-so/src/main/c/type/Array.c
@@ -17,10 +17,7 @@ void arraySetNull(bits8* bitmap, int offset, bool flag)
 	{
 		int bitmask = 1 << (offset % 8);	
 		bitmap += offset / 8;
-		if(flag)
-			*bitmap &= ~bitmask;
-		else
-			*bitmap |= bitmask;
+		*bitmap = (bits8)(flag? *bitmap & ~bitmask : *bitmap | bitmask);
 	}
 }
 

--- a/pljava-so/src/main/c/type/Array.c
+++ b/pljava-so/src/main/c/type/Array.c
@@ -32,7 +32,7 @@ ArrayType* createArrayType(jsize nElems, size_t elemSize, Oid elemType)
 #endif
 {
 	ArrayType* v;
-	int nBytes = elemSize * nElems;
+	Size nBytes = elemSize * nElems;
 	MemoryContext currCtx = Invocation_switchToUpperContext();
 
 #if (PGSQL_MAJOR_VER == 8 && PGSQL_MINOR_VER < 2)
@@ -41,7 +41,7 @@ ArrayType* createArrayType(jsize nElems, size_t elemSize, Oid elemType)
 	v = (ArrayType*)palloc0(nBytes);
 	v->flags &= ~LEAFKEY;
 #else
-	int dataoffset;
+	Size dataoffset;
 	if(withNulls)
 	{
 		dataoffset = ARR_OVERHEAD_WITHNULLS(1, nElems);
@@ -53,7 +53,8 @@ ArrayType* createArrayType(jsize nElems, size_t elemSize, Oid elemType)
 		nBytes += ARR_OVERHEAD_NONULLS(1);
 	}
 	v = (ArrayType*)palloc0(nBytes);
-	v->dataoffset = dataoffset;
+	AssertVariableIsOfType(v->dataoffset, int32);
+	v->dataoffset = (int32)dataoffset;
 #endif
 	MemoryContextSwitchTo(currCtx);
 

--- a/pljava-so/src/main/c/type/ErrorData.c
+++ b/pljava-so/src/main/c/type/ErrorData.c
@@ -191,7 +191,7 @@ JNIEXPORT jstring JNICALL Java_org_postgresql_pljava_internal_ErrorData__1getSql
 	errCode = ((ErrorData*)p2l.ptrVal)->sqlerrcode;
 	for (idx = 0; idx < 5; ++idx)
 	{
-		buf[idx] = PGUNSIXBIT(errCode);
+		buf[idx] = (char)PGUNSIXBIT(errCode); /*why not cast in macro?*/
 		errCode >>= 6;
 	}
 	buf[idx] = 0;

--- a/pljava-so/src/main/c/type/Float.c
+++ b/pljava-so/src/main/c/type/Float.c
@@ -126,7 +126,7 @@ static jvalue _Float_coerceDatum(Type self, Datum arg)
 
 static Datum _Float_coerceObject(Type self, jobject floatObj)
 {
-	return _asDatum(floatObj == 0 ? 0.0 : JNI_callFloatMethod(floatObj, s_Float_floatValue));
+	return _asDatum(floatObj == 0 ? 0.0f : JNI_callFloatMethod(floatObj, s_Float_floatValue));
 }
 
 static Type _float_createArrayType(Type self, Oid arrayTypeId)

--- a/pljava-so/src/main/c/type/Timestamp.c
+++ b/pljava-so/src/main/c/type/Timestamp.c
@@ -172,7 +172,7 @@ extern DLLIMPORT pg_tz* global_timezone;
 #endif
 #endif
 
-static int Timestamp_getTimeZone(pg_time_t time)
+static int32 Timestamp_getTimeZone(pg_time_t time)
 {
 #if (PGSQL_MAJOR_VER == 8 && PGSQL_MINOR_VER == 0)
 	struct pg_tm* tx = pg_localtime(&time);
@@ -181,7 +181,7 @@ static int Timestamp_getTimeZone(pg_time_t time)
 #else
 	struct pg_tm* tx = pg_localtime(&time, session_timezone);
 #endif
-	return -tx->tm_gmtoff;
+	return -(int32)tx->tm_gmtoff;
 }
 
 int32 Timestamp_getTimeZone_id(int64 dt)

--- a/pljava-so/src/main/c/type/Type.c
+++ b/pljava-so/src/main/c/type/Type.c
@@ -228,7 +228,7 @@ jclass Type_getJavaClass(Type self)
 			/* L<object name>; should be just <object name>. Strange
 			 * since the L and ; are retained if its an array.
 			 */
-			int len = strlen(cp) - 2;
+			size_t len = strlen(cp) - 2;
 			char* bp = palloc(len + 1);
 			memcpy(bp, cp + 1, len);
 			bp[len] = 0;
@@ -428,7 +428,7 @@ Type Type_fromJavaType(Oid typeId, const char* javaTypeName)
 	CacheEntry ce = (CacheEntry)HashMap_getByString(s_obtainerByJavaName, javaTypeName);
 	if(ce == 0)
 	{
-		int jtlen = strlen(javaTypeName) - 2;
+		size_t jtlen = strlen(javaTypeName) - 2;
 		if(jtlen > 0 && strcmp("[]", javaTypeName + jtlen) == 0)
 		{
 			Type type;

--- a/pljava-so/src/main/c/type/UDT.c
+++ b/pljava-so/src/main/c/type/UDT.c
@@ -307,7 +307,7 @@ UDT UDT_registerUDT(jclass clazz, Oid typeId, Form_pg_type pgType, TupleDesc td,
 	Form_pg_namespace nspStruct;
 	TypeClass udtClass;
 	UDT udt;
-	int signatureLen;
+	Size signatureLen;
 	jstring sqlTypeName;
 	char* className;
 	char* classSignature;

--- a/pljava-so/src/main/c/type/UDT.c
+++ b/pljava-so/src/main/c/type/UDT.c
@@ -28,7 +28,7 @@
 static jobject coerceScalarDatum(UDT self, Datum arg)
 {
 	jobject result;
-	int16 dataLen = Type_getLength((Type)self);
+	int32 dataLen = Type_getLength((Type)self);
 	jclass javaClass = Type_getJavaClass((Type)self);
 
 	if(dataLen == -2)
@@ -92,7 +92,7 @@ static jobject coerceTupleDatum(UDT udt, Datum arg)
 static Datum coerceScalarObject(UDT self, jobject value)
 {
 	Datum result;
-	int16 dataLen = Type_getLength((Type)self);
+	int32 dataLen = Type_getLength((Type)self);
 	if(dataLen == -2)
 	{
 		jstring jstr = (jstring)JNI_callObjectMethod(value, self->toString);

--- a/pljava-so/src/main/include/pljava/pljava.h
+++ b/pljava-so/src/main/include/pljava/pljava.h
@@ -35,6 +35,14 @@ extern int vsnprintf(char* buf, size_t count, const char* format, va_list arg);
 #include <tcop/tcopprot.h>
 
 /*
+ * AssertVariableIsOfType appeared in PG9.3. Can test for the macro directly.
+ */
+#ifndef AssertVariableIsOfType
+#define AssertVariableIsOfType(varname, typename)
+#endif
+
+
+/*
  * GETSTRUCT require "access/htup_details.h" to be included in PG9.3
  */
 #if (PGSQL_MAJOR_VER > 9 || (PGSQL_MAJOR_VER == 9 && PGSQL_MINOR_VER >= 3))


### PR DESCRIPTION
The `nar-maven-plugin` enables pretty much the whole artillery of `gcc` warnings. The `sign-conversion` ones just aren't practical because macros included from PostgreSQL headers produce floods of them. To deal with that I just created the `wnosign` profile in the POM to turn them off:

    mvn -P wnosign compile

(which uses a `gcc`-specific option, so using `-P wnosign` with any other compiler will probably just fail). Then I could concentrate on the remaining diagnostics. Also added the property `nar.cores` which can be set to `1` if intermingled messages from _n_ compile threads are hard to follow:

    mvn -Dnar.cores=1 -P wnosign compile

Then it's pretty much manageable, and a matter of tracking the warnings down. Some were just matters of convincing the compiler something was correct. Then again, the exercise has identified (and fixed) issue #52.

Warnings not fixed in this PR|` `
---|---
`Backend`|still in the shop for issue #9
`String`|still in the shop for issue #21
`XactListener`/`SubXactListener`|in the shop because PG9.3 added event types