### PR TITLE
Only ignore the expected exception in method lookup.

### DIFF
--- a/pljava-so/src/main/c/Exception.c
+++ b/pljava-so/src/main/c/Exception.c
@@ -36,6 +36,8 @@ jmethodID SQLException_getSQLState;
 jclass    UnsupportedOperationException_class;
 jmethodID UnsupportedOperationException_init;
 
+jclass    NoSuchMethodError_class;
+
 void
 Exception_featureNotSupported(const char* requestedFeature, const char* introVersion)
 {
@@ -186,6 +188,8 @@ void Exception_initialize(void)
 
 	UnsupportedOperationException_class = (jclass)JNI_newGlobalRef(PgObject_getJavaClass("java/lang/UnsupportedOperationException"));
 	UnsupportedOperationException_init = PgObject_getJavaMethod(UnsupportedOperationException_class, "<init>", "(Ljava/lang/String;)V");
+
+	NoSuchMethodError_class = (jclass)JNI_newGlobalRef(PgObject_getJavaClass("java/lang/NoSuchMethodError"));
 
 	Class_getName = PgObject_getJavaMethod(Class_class, "getName", "()Ljava/lang/String;");
 }

--- a/pljava-so/src/main/c/JNICalls.c
+++ b/pljava-so/src/main/c/JNICalls.c
@@ -750,10 +750,16 @@ jmethodID JNI_getStaticMethodID(jclass clazz, const char* name, const char* sig)
 jmethodID JNI_getStaticMethodIDOrNull(jclass clazz, const char* name, const char* sig)
 {
 	jmethodID result;
+	jobject exh;
 	BEGIN_CALL
 	result = (*env)->GetStaticMethodID(env, clazz, name, sig);
-	if(result == 0)
-		(*env)->ExceptionClear(env);
+	if(result == 0) {
+		exh = (*env)->ExceptionOccurred(env);
+		if ( 0 == exh
+			||  (*env)->IsInstanceOf(env, exh, NoSuchMethodError_class) )
+			(*env)->ExceptionClear(env); /* NoSuch... is only thing to ignore */
+		(*env)->DeleteLocalRef(env, exh);
+	}
 	END_CALL
 	return result;
 }

--- a/pljava-so/src/main/include/pljava/JNICalls.h
+++ b/pljava-so/src/main/include/pljava/JNICalls.h
@@ -55,6 +55,8 @@ extern jmethodID SQLException_getSQLState;
 extern jclass    UnsupportedOperationException_class;
 extern jmethodID UnsupportedOperationException_init;
 
+extern jclass    NoSuchMethodError_class;
+
 /*
  * Misc JNIEnv mappings. See <jni.h> for more info.
  */


### PR DESCRIPTION
That way other exceptions (like a problem in a class initializer, or
out of memory) will not be hidden from view. Closes #54.