### PR TITLE
Deployment descriptor conditionals as proposed on pljava-dev.

### DIFF
--- a/pljava-api/src/main/java/org/postgresql/pljava/annotation/Function.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/annotation/Function.java
@@ -187,4 +187,12 @@ category</a>
 	 * later for remove actions.
 	 */
 	String[] requires() default {};
+
+	/**
+	 * The {@code <implementor name>} to be used around SQL code generated
+	 * for this function (and for its triggers, if any, and not overridden for
+	 * them). Defaults to {@code PostgreSQL}. Set explicitly to {@code ""} to
+	 * emit code not wrapped in an {@code <implementor block>}.
+	 */
+	String implementor() default "";
 }

--- a/pljava-api/src/main/java/org/postgresql/pljava/annotation/SQLAction.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/annotation/SQLAction.java
@@ -67,4 +67,11 @@ public @interface SQLAction
 	 * later for remove actions.
 	 */
 	String[] requires() default {};
+
+	/**
+	 * The {@code <implementor name>} to be used around SQL code generated
+	 * here. Defaults to {@code PostgreSQL}. Set explicitly to {@code ""} to
+	 * emit code not wrapped in an {@code <implementor block>}.
+	 */
+	String implementor() default "";
 }

--- a/pljava-api/src/main/java/org/postgresql/pljava/annotation/package-info.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/annotation/package-info.java
@@ -52,12 +52,12 @@
  * in the top directory of the tree where the compiled class files are written.
  * <dt><code>ddr.name.trusted</code>
  * <dd>The language name that will be used to declare methods that are
- * annotated to have {@link Function.Trust#RESTRICTED} behavior. If not
+ * annotated to have {@link org.postgresql.pljava.annotation.Function.Trust#RESTRICTED} behavior. If not
  * specified, the name <code>java</code> will be used. It must match the name
  * used for the "trusted" language declaration when PL/Java was installed.
  * <dt><code>ddr.name.untrusted</code>
  * <dd>The language name that will be used to declare methods that are
- * annotated to have {@link Function.Trust#UNRESTRICTED} behavior. If not
+ * annotated to have {@link org.postgresql.pljava.annotation.Function.Trust#UNRESTRICTED} behavior. If not
  * specified, the name <code>javaU</code> will be used. It must match the name
  * used for the "untrusted" language declaration when PL/Java was installed.
  * </dl>

--- a/pljava-api/src/main/java/org/postgresql/pljava/sqlgen/DDRProcessor.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/sqlgen/DDRProcessor.java
@@ -488,6 +488,14 @@ class DDRProcessorImpl
 				a[i++] = k.cast(av.getValue());
 			return a;
 		}
+
+		/**
+		 * Supply the required implementor() method for those subclasses
+		 * that will implement {@link Snippet}.
+		 */
+		public String implementor() { return _implementor; }
+
+		String _implementor = "PostgreSQL";
 	}
 
 	/**
@@ -1473,6 +1481,12 @@ class DDRProcessorImpl
  */
 interface Snippet
 {
+	/**
+	 * An {@code <implementor name>} that will be used to wrap each command
+	 * from this Snippet as an {@code <implementor block>}. If null, the
+	 * commands will be emitted as plain {@code <SQL statement>}s.
+	 */
+	public String implementor();
 	/**
 	 * Return an array of SQL commands (one complete command to a string) to
 	 * be executed in order during deployment.

--- a/pljava-api/src/main/java/org/postgresql/pljava/sqlgen/DDRProcessor.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/sqlgen/DDRProcessor.java
@@ -539,9 +539,10 @@ queuerunning: for ( int i = 0 ; ; )
 
 		String _implementor = "PostgreSQL";
 
-		public void setImplementor( String imp)
+		public void setImplementor( Object o, boolean explicit, Element e)
 		{
-			_implementor = "".equals( imp) ? null : imp;
+			if ( explicit )
+				_implementor = "".equals( o) ? null : (String)o;
 		}
 
 		/**

--- a/pljava-api/src/main/java/org/postgresql/pljava/sqlgen/Lexicals.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/sqlgen/Lexicals.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2015- Tada AB and other contributors, as listed below.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Chapman Flack
+ */
+package org.postgresql.pljava.sqlgen;
+
+import java.util.regex.Pattern;
+
+/**
+ * A few useful SQL lexical definitions supplied as {@link Pattern} objects.
+ *
+ * The idea is not to go overboard and reimplement an SQL lexer, but to
+ * capture in one place the rules for those bits of SQL snippets that are
+ * likely to be human-supplied in annotations and need to be checked for
+ * correctness when emitted into deployment descriptors. For starters, that
+ * means regular (not quoted, not Unicode escaped) identifiers.
+ *
+ * Supplied in the API module so they are available to {@code javac} to
+ * compile and generate DDR when the rest of PL/Java is not necessarily
+ * present. Of course backend code such as {@code SQLDeploymentDescriptor}
+ * can also refer to these.
+ */
+public interface Lexicals {
+
+	/** Allowed as the first character of a regular identifier by ISO.
+	 */
+	Pattern ISO_REGULAR_IDENTIFIER_START = Pattern.compile(
+		"[\\p{Lu}\\p{Ll}\\p{Lt}\\p{Lm}\\p{Lo}\\p{Nl}]"
+	);
+
+	/** Allowed as any non-first character of a regular identifier by ISO.
+	 */
+	Pattern ISO_REGULAR_IDENTIFIER_PART = Pattern.compile(String.format(
+		"[\\xb7\\p{Mn}\\p{Mc}\\p{Nd}\\p{Pc}\\p{Cf}%1$s]",
+		ISO_REGULAR_IDENTIFIER_START.pattern()
+	));
+
+	/** A complete regular identifier as allowed by ISO.
+	 */
+	Pattern ISO_REGULAR_IDENTIFIER = Pattern.compile(String.format(
+		"%1$s%2$s*",
+		ISO_REGULAR_IDENTIFIER_START.pattern(),
+		ISO_REGULAR_IDENTIFIER_PART.pattern()
+	));
+
+	/** A complete ISO regular identifier in a single capturing group.
+	 */
+	Pattern ISO_REGULAR_IDENTIFIER_CAPTURING = Pattern.compile(String.format(
+		"(%1$s)", ISO_REGULAR_IDENTIFIER.pattern()
+	));
+
+	/** Allowed as the first character of a regular identifier by PostgreSQL
+	 * (PG 7.4 -).
+	 */
+	Pattern PG_REGULAR_IDENTIFIER_START = Pattern.compile(
+		"[A-Za-z\\P{ASCII}_]" // hasn't seen a change since PG 7.4
+	);
+
+	/** Allowed as any non-first character of a regular identifier by PostgreSQL
+	 * (PG 7.4 -).
+	 */
+	Pattern PG_REGULAR_IDENTIFIER_PART = Pattern.compile(String.format(
+		"[0-9$%1$s]", PG_REGULAR_IDENTIFIER_START.pattern()
+	));
+
+	/** A complete regular identifier as allowed by PostgreSQL (PG 7.4 -).
+	 */
+	Pattern PG_REGULAR_IDENTIFIER = Pattern.compile(String.format(
+		"%1$s%2$s*",
+		PG_REGULAR_IDENTIFIER_START.pattern(),
+		PG_REGULAR_IDENTIFIER_PART.pattern()
+	));
+
+	/** A complete PostgreSQL regular identifier in a single capturing group.
+	 */
+	Pattern PG_REGULAR_IDENTIFIER_CAPTURING = Pattern.compile(String.format(
+		"(%1$s)", PG_REGULAR_IDENTIFIER.pattern()
+	));
+
+	/** A regular identifier that satisfies both ISO and PostgreSQL rules.
+	 */
+	Pattern ISO_AND_PG_REGULAR_IDENTIFIER = Pattern.compile(String.format(
+		"(?:(?=%1$s)%2$s)(?:(?=%3$s)%4$s)*",
+		ISO_REGULAR_IDENTIFIER_START.pattern(),
+		PG_REGULAR_IDENTIFIER_START.pattern(),
+		ISO_REGULAR_IDENTIFIER_PART.pattern(),
+		PG_REGULAR_IDENTIFIER_PART.pattern()
+	));
+
+	/** A regular identifier that satisfies both ISO and PostgreSQL rules,
+	 * in a single capturing group.
+	 */
+	Pattern ISO_AND_PG_REGULAR_IDENTIFIER_CAPTURING = Pattern.compile(
+		String.format( "(%1$s)", ISO_AND_PG_REGULAR_IDENTIFIER.pattern())
+	);
+
+	/** An identifier by ISO SQL, PostgreSQL, <em>and</em> Java (not SQL at all)
+	 * rules. (Not called {@code REGULAR} because Java allows no other form of
+	 * identifier.) This restrictive form is the safest for identifiers being
+	 * generated into a deployment descriptor file that an old version of
+	 * PL/Java might load, because through 1.4.3 PL/Java used the Java
+	 * identifier rules to recognize identifiers in deployment descriptors.
+	 */
+	Pattern ISO_PG_JAVA_IDENTIFIER = Pattern.compile(String.format(
+		"(?:(?=%1$s)(?=\\p{%5$sStart})%2$s)(?:(?=%3$s)(?=\\p{%5$sPart})%4$s)*",
+		ISO_REGULAR_IDENTIFIER_START.pattern(),
+		PG_REGULAR_IDENTIFIER_START.pattern(),
+		ISO_REGULAR_IDENTIFIER_PART.pattern(),
+		PG_REGULAR_IDENTIFIER_PART.pattern(),
+		"javaJavaIdentifier"
+	));
+}

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/ConditionalDDR.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/ConditionalDDR.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2015- Tada AB and other contributors, as listed below.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Chapman Flack
+ */
+package org.postgresql.pljava.example.annotation;
+
+import org.postgresql.pljava.annotation.SQLAction;
+import org.postgresql.pljava.annotation.SQLActions;
+
+/**
+ * Test of a very simple form of conditional execution in the deployment
+ * descriptor using only the {@code <implementor name>} specified for an
+ * {@code <implementor block>}.
+ * <p>
+ * When a deployment descriptor is executed, the config setting
+ * {@code pljava.implementors} determines which {@code <implementor block>}s
+ * will be executed (in addition to all of the plain {@code <SQL statement>}s
+ * that are not tagged with an implementor name). The default setting of
+ * {@code pljava.implementors} is simply {@code postgresql}.
+ * <p>
+ * In this example, an SQLAction (with the default implementor name PostgreSQL
+ * so it should always execute) tests some condition and, based on the result,
+ * adds {@code LifeIsGood} to the list of recognized implementor names.
+ * <p>
+ * Later SQLActions with that implementor name should also be executed, while
+ * those with a different, unrecognized implementor should not.
+ * <p>
+ * That is what happens at <em>deployment</em> (or undeployment) time, when the
+ * jar has been loaded into the target database and the deployment descriptor is
+ * being processed.
+ * <p>
+ * The {@code provides} and {@code requires} attributes matter at
+ * <em>compile</em> time: they are hints to the DDR generator so it will be sure
+ * to write the SQLAction that tests the condition ahead of the ones that
+ * depend on the condition having been tested. The example illustrates that an
+ * SQLAction's {@code implementor} is treated as an implicit {@code requires}.
+ * Unlike an explicit one, it is weak: if there is nothing declared that
+ * {@code provides} it, that's not an error; affected SQLActions will just be
+ * placed as late in the generated DDR as other dependencies allow, in case
+ * something in the preceding actions will be setting those implementor tags.
+ * <p>
+ * This example adds {@code LifeIsGood} ahead of the prior content of
+ * {@code pljava.implementors}. Simply replacing the value would stop the
+ * default implementor PostgreSQL being recognized, probably not what's wanted.
+ * The final {@code true} argument to {@code set_config} makes the setting
+ * local, so it is reverted when the transaction completes.
+ */
+@SQLActions({
+	@SQLAction(provides={"LifeIsGood","LifeIsNotGood"}, install=
+		"SELECT CASE 42 WHEN 42 THEN " +
+		" set_config('pljava.implementors', 'LifeIsGood,' || " +
+		"  current_setting('pljava.implementors'), true) " +
+		"ELSE " +
+		" set_config('pljava.implementors', 'LifeIsNotGood,' || " +
+		"  current_setting('pljava.implementors'), true) " +
+		"END"
+	),
+	
+	@SQLAction(implementor="LifeIsGood", install=
+		"SELECT javatest.logmessage('INFO', 'Looking good!')"
+	),
+	
+	@SQLAction(implementor="LifeIsNotGood", install=
+		"SELECT javatest.logmessage('WARNING', 'This should not be executed')"
+	)
+})
+public class ConditionalDDR { }

--- a/pljava-examples/src/main/resources/deployment/examples.ddr
+++ b/pljava-examples/src/main/resources/deployment/examples.ddr
@@ -299,7 +299,7 @@ SQLActions[ ] = {
 		CREATE FUNCTION javatest.logMessage(varchar, varchar)
 			RETURNS void
 			AS 'org.postgresql.pljava.example.LoggerTest.logMessage'
-			IMMUTABLE LANGUAGE java;
+			LANGUAGE java;
 
 		CREATE TYPE javatest.BinaryColumnPair
 			AS (col1 bytea, col2 bytea);

--- a/pljava-so/src/main/c/Backend.c
+++ b/pljava-so/src/main/c/Backend.c
@@ -88,6 +88,7 @@ static jclass  s_Backend_class;
 static jmethodID s_setTrusted;
 static char* vmoptions;
 static char* classpath;
+static char* implementors;
 static int   statementCacheSize;
 static bool  pljavaDebug;
 static bool  pljavaReleaseLingeringSavepoints;
@@ -691,7 +692,24 @@ static void initializeJavaVM(void)
 				NULL,
 			#endif
 			NULL, NULL);
-	
+
+		DefineCustomStringVariable(
+			"pljava.implementors",
+			"Implementor names recognized in deployment descriptors",
+			NULL,
+			&implementors,
+			#if (PGSQL_MAJOR_VER > 8 || (PGSQL_MAJOR_VER == 8 && PGSQL_MINOR_VER > 3))
+				"postgresql",
+			#endif
+			PGC_USERSET,
+			#if (PGSQL_MAJOR_VER > 8 || (PGSQL_MAJOR_VER == 8 && PGSQL_MINOR_VER > 3))
+				GUC_LIST_INPUT | GUC_LIST_QUOTE,
+			#endif
+			#if (PGSQL_MAJOR_VER > 9 || (PGSQL_MAJOR_VER == 9 && PGSQL_MINOR_VER > 0))
+				NULL,
+			#endif
+			NULL, NULL);
+
 		EmitWarningsOnPlaceholders("pljava");
 			s_firstTimeInit = false;
 	}

--- a/pljava/src/main/java/org/postgresql/pljava/management/Commands.java
+++ b/pljava/src/main/java/org/postgresql/pljava/management/Commands.java
@@ -903,8 +903,8 @@ public class Commands
 				// According to the SQLJ standard, this entry must be
 				// UTF8 encoded.
 				//
-				sdds.add(new SQLDeploymentDescriptor(new String(bytes, "UTF8"),
-					"postgresql"));
+				sdds.add(
+					new SQLDeploymentDescriptor(new String(bytes, "UTF8")));
 			}
 			return sdds.toArray( new SQLDeploymentDescriptor[sdds.size()]);
 		}

--- a/pljava/src/main/java/org/postgresql/pljava/management/DDRExecutor.java
+++ b/pljava/src/main/java/org/postgresql/pljava/management/DDRExecutor.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2015- Tada AB and other contributors, as listed below.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Chapman Flack
+ */
+package org.postgresql.pljava.management;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import java.util.ArrayList;
+
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
+
+import org.postgresql.pljava.Session;
+import org.postgresql.pljava.SessionManager;
+
+import org.postgresql.pljava.internal.Backend;
+
+import static org.postgresql.pljava.sqlgen.Lexicals.ISO_PG_JAVA_IDENTIFIER;
+
+/**
+ * Abstract class for executing one deployment descriptor {@code <command>}
+ * on a connection.
+ * <p>
+ * The {@link #forImplementor forImplementor} method returns an executor
+ * according to the
+ * {@code <implementor name>} associated with the command. The two possibilities
+ * that support standard behavior are a "plain" executor, which simply
+ * executes the SQL text (with any {@code SECURITY DEFINER} identity dropped),
+ * and a "no-op" executor, which (you'll be shocked) does nothing.
+ * Normally, a plain executor is returned if the implementor name is
+ * null (command is for all implementations) or in the list recognized as being
+ * for this implementation (normally just PostgreSQL, case-insensitively, but
+ * adjustable as described below). A no-op executor is returned if there
+ * is an implementor name and it is anything not on the recognized list.
+ * <p><strong>Adjusting the recognized implementor names:</strong>
+ * <p>
+ * The recognized implementor names are taken from the (comma-separated) string
+ * configuration option {@code pljava.implementors}, which can be set from
+ * ordinary SQL using
+ * {@code SET LOCAL pljava.implementors TO thing, thing, thing}.
+ * It is re-parsed each time {@code forImplementor} is called, which happens
+ * for every {@code <command>} in a deployment descriptor, so that SQL code
+ * early in a deployment descriptor <em>can influence which code blocks later
+ * are executed</em>.
+ * <p>
+ * The {@code SET LOCAL} command shown above only accepts a literal list of
+ * elements. It will ordinarily be better for SQL code to <em>add</em> another
+ * element to whatever is currently in the list, which is fussier in SQL:
+ * <pre>
+ *  SELECT set_config('pljava.implementors', 'NewThing,' ||
+ *                    current_setting('pljava.implementors'), true)
+ * </pre>
+ * where the final {@code true} gives the setting the same lifetime as
+ * {@code SET LOCAL}, that is, it reverts when the transaction is over.
+ * <p>
+ * The possibility that, for certain implementor names, {@code forImplementor}
+ * could return other subclasses of {@code DDRExecutor} with specialized
+ * behavior, is definitely contemplated.
+ */
+public abstract class DDRExecutor
+{
+	protected DDRExecutor() { }
+
+	private static final DDRExecutor PLAIN = new Plain();
+
+	private static final DDRExecutor NOOP = new Noop();
+
+	/*
+	 * Capture group 1 is an identifier. Presence/absence of group 2 (comma-
+	 * whitespace) indicates whether to parse more.
+	 */
+	private static final Pattern settingsRx = Pattern.compile(String.format(
+		"\\G(%1$s)(,\\s*)?", ISO_PG_JAVA_IDENTIFIER
+	));
+
+	/**
+	 * Execute the command {@code sql} using the connection {@code conn},
+	 * according to whatever meaning of "execute" the target {@code DDRExecutor}
+	 * subclass implements.
+	 *
+	 * @param sql The command to execute
+	 * @param conn The connection to use
+	 * @throws SQLException Anything thrown in the course of executing
+	 * {@code sql}
+	 */
+	public abstract void execute( String sql, Connection conn)
+	throws SQLException;
+
+	/**
+	 * Return a {@code DDRExecutor} instance chosen according to the supplied
+	 * implementor name and current {@code pljava.implementors} value.
+	 * See the class description for more.
+	 *
+	 * @param name The {@code <implementor name>} associated with the deployment
+	 * descriptor {@code <command>}, or {@code null} if the {@code <command>} is
+	 * an unadorned {@code <SQL statement>} instead of an
+	 * {@code <implementor block>}.
+	 */
+	public static DDRExecutor forImplementor( String name)
+	throws SQLException
+	{
+		if ( null == name )
+			return PLAIN;
+
+		String[] imps = implementors();
+
+		for ( String i : imps )
+			if ( name.equalsIgnoreCase( i) )
+				return PLAIN;
+
+		return NOOP;
+	}
+
+	private static String[] implementors() throws SQLException
+	{
+		String settingString = Backend.getConfigOption( "pljava.implementors");
+		ArrayList<String> al = new ArrayList<String>();
+		Matcher m = settingsRx.matcher( settingString);
+		while ( m.find() )
+		{
+			al.add( m.group( 1));
+			if ( -1 != m.start( 2) )
+				continue;
+			if ( m.hitEnd() )
+				return al.toArray( new String [ al.size() ]);
+		}
+		throw new SQLException("Failed to parse current pljava.implementors");
+	}
+
+	static class Noop extends DDRExecutor
+	{
+		public void execute( String sql, Connection conn)
+		throws SQLException
+		{
+		}
+	}
+
+	static class Plain extends DDRExecutor
+	{
+		public void execute( String sql, Connection conn)
+		throws SQLException
+		{
+			Session session = SessionManager.current();
+			session.executeAsSessionUser( conn, sql);
+		}
+	}
+}


### PR DESCRIPTION
This is the "installment 1" portion of conditional code execution within the deployment descriptor, as [proposed on pljava-dev][prop1]. It uses the deployment-descriptor feature of "implementor blocks" (code snippets wrapped in `BEGIN `_identifier_ and `END `_identifier_ and intended to execute only in contexts that recognize that _identifier_ for that purpose) and creates a new GUC variable `pljava.implementors` that can be adjusted (at query time by ordinary SQL code) listing the identifiers that will be recognized. So, SQL code in an always-executed block of the deployment descriptor can test arbitrary things, then set up which _other_ "implementor blocks" will be executed.

See `org.postgresql.pljava.example.annotation.ConditionalDDR` for an example/test.

If this seems mostly like an ungainly way of getting conditional execution at deployment time (without having to ask what PG version is being deployed on, whether it has `DO`, whether `plpgsql` is enabled, etc.), well, yes, that is essentially what it is. But it is also the first step to the "installment 2" integration-testing support [also proposed on pljava-dev][prop2], and I think that will be worth the price of admission.

[prop1]: http://lists.pgfoundry.org/pipermail/pljava-dev/2015/002368.html
[prop2]: http://lists.pgfoundry.org/pipermail/pljava-dev/2015/002369.html