### PR TITLE
Pass all Unicode codepoints transparently (issue #21).

### DIFF
--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/UnicodeRoundTripTest.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/UnicodeRoundTripTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2015 Tada AB and other contributors, as listed below.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Chapman Flack
+ */
+package org.postgresql.pljava.example.annotation;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import org.postgresql.pljava.annotation.SQLAction;
+import org.postgresql.pljava.annotation.SQLActions;
+import org.postgresql.pljava.annotation.Function;
+
+/**
+ * Test that strings containing characters from all Unicode planes
+ * are passed between PG and Java without alteration (issue 21).
+ * <p>
+ * This function takes a string and an array of ints constructed in PG, such
+ * that PG believes the codepoints in the string to correspond exactly with the
+ * ints in the array. The function compares the two, generates a new array from
+ * the codepoints Java sees in the string and a new Java string from the
+ * original array, and returns a tuple (matched, cparray, s) where
+ * {@code matched} indicates whether the original array and string matched
+ * as seen by Java, and {@code cparray} and {@code s} are the new array and
+ * string generated in Java.
+ * <p>
+ * The supplied test query generates all Unicode code points 1k at a time,
+ * calls this function on each (1k array, 1k string) pair, and counts a failure
+ * if {@code matched} is false or the original and returned arrays or strings
+ * do not match as seen in SQL.
+ *
+ * @param s A string, whose codepoints should match the entries of {@code ints}.
+ * @param ints Array of ints that should match the codepoints in {@code s}.
+ * @param rs OUT (matched, cparray, s) as described above.
+ * @return true to indicate the OUT tuple is not null
+ */
+@SQLActions({
+	@SQLAction(requires="unicodetest fn", install=
+"   with " +
+"    usable_codepoints ( cp ) as ( " +
+"     select generate_series(1,x'd7ff'::int) " +
+"     union all " +
+"     select generate_series(x'e000'::int,x'10ffff'::int) " +
+"    ), " +
+"    test_inputs ( groupnum, cparray, s ) as ( " +
+"     select " +
+"       cp / 1024 as groupnum, " +
+"       array_agg(cp order by cp), string_agg(chr(cp), '' order by cp) " +
+"     from usable_codepoints " +
+"     group by groupnum " +
+"    ), " +
+"    test_outputs as ( " +
+"     select groupnum, cparray, s, unicodetest(s, cparray) as roundtrip " +
+"     from test_inputs " +
+"    ), " +
+"    test_failures as ( " +
+"     select * " +
+"     from test_outputs " +
+"     where " +
+"      cparray != (roundtrip).cparray or s != (roundtrip).s " +
+"      or not (roundtrip).matched " +
+"    ), " +
+"    test_summary ( n_failing_groups, first_failing_group ) as ( " +
+"     select count(*), min(groupnum) from test_failures " +
+"    ) " +
+"   select " +
+"    case when n_failing_groups > 0 then " +
+"     javatest.logmessage('WARNING', format( " +
+"      '%s 1k codepoint ranges had mismatches, first is block starting 0x%s', " +
+"      n_failing_groups, to_hex(1024 * first_failing_group))) " +
+"    else " +
+"     javatest.logmessage('INFO', " +
+"        'all Unicode codepoint ranges roundtripped successfully.') " +
+"    end " +
+"    from test_summary"
+	),
+	@SQLAction(
+    	install=
+    		"CREATE TYPE unicodetestrow AS " +
+    		"(matched boolean, cparray integer[], s text)",
+    	remove="DROP TYPE unicodetestrow",
+    	provides="unicodetestrow type"
+	)
+})
+public class UnicodeRoundTripTest {
+	/** 
+	 * This function takes a string and an array of ints constructed in PG,
+	 * such that PG believes the codepoints in the string to correspond exactly
+	 * with the ints in the array. The function compares the two, generates a
+	 * new array from the codepoints Java sees in the string and a new Java
+	 * string from the original array, and returns a tuple (matched, cparray,
+	 * s) where {@code matched} indicates whether the original array and string
+	 * matched as seen by Java, and {@code cparray} and {@code s} are the new
+	 * array and string generated in Java.
+	 *
+	 * @param s A string, whose codepoints should match the entries of
+	 *        {@code ints}
+	 * @param ints Array of ints that should match the codepoints in {@code s}
+	 * @param rs OUT (matched, cparray, s) as described above
+	 * @return true to indicate the OUT tuple is not null
+	 */
+	@Function(complexType="unicodetestrow",
+		requires="unicodetestrow type", provides="unicodetest fn")
+	public static boolean unicodetest(String s, int[] ints, ResultSet rs)
+	throws SQLException {
+		boolean ok = true;
+
+		int cpc = s.codePointCount(0, s.length());
+		Integer[] myInts = new Integer[cpc];
+		int ci = 0;
+		for ( int cpi = 0; cpi < cpc; cpi++ ) {
+			myInts[cpi] = s.codePointAt(ci);
+			ci = s.offsetByCodePoints(ci, 1);
+		}
+
+		String myS = new String(ints, 0, ints.length);
+
+		if ( ints.length != myInts.length )
+			ok = false;
+		else
+			for ( int i = 0; i < ints.length; ++ i )
+	if ( ints[i] != myInts[i] )
+		ok = false;
+
+		rs.updateBoolean("matched", true);
+		rs.updateObject("cparray", myInts);
+		rs.updateString("s", myS);
+		return true;
+	}
+}

--- a/pljava-examples/src/main/resources/deployment/examples.ddr
+++ b/pljava-examples/src/main/resources/deployment/examples.ddr
@@ -299,7 +299,7 @@ SQLActions[ ] = {
 		CREATE FUNCTION javatest.logMessage(varchar, varchar)
 			RETURNS void
 			AS 'org.postgresql.pljava.example.LoggerTest.logMessage'
-			IMMUTABLE LANGUAGE java;
+			LANGUAGE java;
 
 		CREATE TYPE javatest.BinaryColumnPair
 			AS (col1 bytea, col2 bytea);

--- a/pljava-so/src/main/c/JNICalls.c
+++ b/pljava-so/src/main/c/JNICalls.c
@@ -42,6 +42,11 @@ static jobject s_threadLock;
 
 #define END_CALL endCall(env); }
 
+#define BEGIN_CALL_MONITOR_HELD \
+	BEGIN_JAVA
+
+#define END_CALL_MONITOR_HELD endCallMonitorHeld(env); }
+
 static void elogExceptionMessage(JNIEnv* env, jthrowable exh, int logLevel)
 {
 	StringInfoData buf;
@@ -100,6 +105,30 @@ static void endCall(JNIEnv* env)
 
 	if((*env)->MonitorEnter(env, s_threadLock) < 0)
 		elog(ERROR, "Java enter monitor failure");
+
+	jniEnv = env;
+	if(exh != 0)
+	{
+		printStacktrace(env, exh);
+		if((*env)->IsInstanceOf(env, exh, ServerException_class))
+		{
+			/* Rethrow the server error.
+			 */
+			jobject jed = (*env)->CallObjectMethod(env, exh, ServerException_getErrorData);
+			if(jed != 0)
+				ReThrowError(ErrorData_getErrorData(jed));
+		}
+		/* There's no return from this call.
+		 */
+		elogExceptionMessage(env, exh, ERROR);
+	}
+}
+
+static void endCallMonitorHeld(JNIEnv* env)
+{
+	jobject exh = (*env)->ExceptionOccurred(env);
+	if(exh != 0)
+		(*env)->ExceptionClear(env);
 
 	jniEnv = env;
 	if(exh != 0)
@@ -255,6 +284,25 @@ jint JNI_callIntMethodV(jobject object, jmethodID methodID, va_list args)
 	return result;
 }
 
+jint JNI_callIntMethodLocked(jobject object, jmethodID methodID, ...)
+{
+	jint result;
+	va_list args;
+	va_start(args, methodID);
+	result = JNI_callIntMethodLockedV(object, methodID, args);
+	va_end(args);
+	return result;
+}
+
+jint JNI_callIntMethodLockedV(jobject object, jmethodID methodID, va_list args)
+{
+	jint result;
+	BEGIN_CALL_MONITOR_HELD
+	result = (*env)->CallIntMethodV(env, object, methodID, args);
+	END_CALL_MONITOR_HELD
+	return result;
+}
+
 jlong JNI_callLongMethod(jobject object, jmethodID methodID, ...)
 {
 	jlong result;
@@ -309,6 +357,25 @@ jobject JNI_callObjectMethodV(jobject object, jmethodID methodID, va_list args)
 	BEGIN_CALL
 	result = (*env)->CallObjectMethodV(env, object, methodID, args);
 	END_CALL
+	return result;
+}
+
+jobject JNI_callObjectMethodLocked(jobject object, jmethodID methodID, ...)
+{
+	jobject result;
+	va_list args;
+	va_start(args, methodID);
+	result = JNI_callObjectMethodLockedV(object, methodID, args);
+	va_end(args);
+	return result;
+}
+
+jobject JNI_callObjectMethodLockedV(jobject object, jmethodID methodID, va_list args)
+{
+	jobject result;
+	BEGIN_CALL_MONITOR_HELD
+	result = (*env)->CallObjectMethodV(env, object, methodID, args);
+	END_CALL_MONITOR_HELD
 	return result;
 }
 
@@ -413,6 +480,25 @@ jobject JNI_callStaticObjectMethodV(jclass clazz, jmethodID methodID, va_list ar
 	return result;
 }
 
+jobject JNI_callStaticObjectMethodLocked(jclass clazz, jmethodID methodID, ...)
+{
+	jobject result;
+	va_list args;
+	va_start(args, methodID);
+	result = JNI_callStaticObjectMethodLockedV(clazz, methodID, args);
+	va_end(args);
+	return result;
+}
+
+jobject JNI_callStaticObjectMethodLockedV(jclass clazz, jmethodID methodID, va_list args)
+{
+	jobject result;
+	BEGIN_CALL_MONITOR_HELD
+	result = (*env)->CallStaticObjectMethodV(env, clazz, methodID, args);
+	END_CALL_MONITOR_HELD
+	return result;
+}
+
 jshort JNI_callStaticShortMethodA(jclass clazz, jmethodID methodID, jvalue* args)
 {
 	jshort result;
@@ -457,6 +543,21 @@ void JNI_callVoidMethodV(jobject object, jmethodID methodID, va_list args)
 	BEGIN_CALL
 	(*env)->CallVoidMethodV(env, object, methodID, args);
 	END_CALL
+}
+
+void JNI_callVoidMethodLocked(jobject object, jmethodID methodID, ...)
+{
+	va_list args;
+	va_start(args, methodID);
+	JNI_callVoidMethodLockedV(object, methodID, args);
+	va_end(args);
+}
+
+void JNI_callVoidMethodLockedV(jobject object, jmethodID methodID, va_list args)
+{
+	BEGIN_CALL_MONITOR_HELD
+	(*env)->CallVoidMethodV(env, object, methodID, args);
+	END_CALL_MONITOR_HELD
 }
 
 jint JNI_createVM(JavaVM** javaVM, JavaVMInitArgs* vmArgs)

--- a/pljava-so/src/main/c/JNICalls.c
+++ b/pljava-so/src/main/c/JNICalls.c
@@ -813,6 +813,15 @@ jboolean JNI_isInstanceOf(jobject obj, jclass clazz)
 	return result;
 }
 
+jboolean JNI_isSameObject(jobject obj1, jobject obj2)
+{
+	jboolean result;
+	BEGIN_JAVA
+	result = (*env)->IsSameObject(env, obj1, obj2);
+	END_JAVA
+	return result;
+}
+
 jbyteArray JNI_newByteArray(jsize length)
 {
 	jbyteArray result;

--- a/pljava-so/src/main/include/pljava/JNICalls.h
+++ b/pljava-so/src/main/include/pljava/JNICalls.h
@@ -132,6 +132,7 @@ extern const char*  JNI_getStringUTFChars(jstring string, jboolean* isCopy);
 extern jboolean     JNI_hasNullArrayElement(jobjectArray array);
 extern jboolean     JNI_isCallingJava(void);
 extern jboolean     JNI_isInstanceOf(jobject obj, jclass clazz);
+extern jboolean     JNI_isSameObject(jobject obj1, jobject obj2);
 extern jbyteArray   JNI_newByteArray(jsize length);
 extern jbooleanArray JNI_newBooleanArray(jsize length);
 extern jobject      JNI_newDirectByteBuffer(void* address, jlong capacity);

--- a/pljava-so/src/main/include/pljava/JNICalls.h
+++ b/pljava-so/src/main/include/pljava/JNICalls.h
@@ -58,6 +58,24 @@ extern jmethodID UnsupportedOperationException_init;
 extern jclass    NoSuchMethodError_class;
 
 /*
+ * A few very specialized JNI method-invocation wrappers, that do NOT do
+ * one thing all the rest of the method wrappers do. These do NOT release the
+ * threadlock before calling the method and reacquire it after the method
+ * returns. These versions just call the method with the threadlock held the
+ * whole time. They are used in String.c for character set coding conversions,
+ * which may frequently call Java methods that are never expected to have any
+ * reason to block or reenter the backend.
+ */
+extern jobject      JNI_callObjectMethodLocked(jobject object, jmethodID methodID, ...);
+extern jobject      JNI_callObjectMethodLockedV(jobject object, jmethodID methodID, va_list args);
+extern jobject      JNI_callStaticObjectMethodLocked(jclass clazz, jmethodID methodID, ...);
+extern jobject      JNI_callStaticObjectMethodLockedV(jclass clazz, jmethodID methodID, va_list args);
+extern jint         JNI_callIntMethodLocked(jobject object, jmethodID methodID, ...);
+extern jint         JNI_callIntMethodLockedV(jobject object, jmethodID methodID, va_list args);
+extern void         JNI_callVoidMethodLocked(jobject object, jmethodID methodID, ...);
+extern void         JNI_callVoidMethodLockedV(jobject object, jmethodID methodID, va_list args);
+
+/*
  * Misc JNIEnv mappings. See <jni.h> for more info.
  */
 extern jboolean     JNI_callBooleanMethod(jobject object, jmethodID methodID, ...);


### PR DESCRIPTION
With this pull request I am hoping to start a tradition where a pull request for a bug will have a _first_ commit that only adds a testcase ... so the testcase should then fail, and the remaining commit(s) should make it pass.

I'd be happy to rebase this PR on top of #56 deployment descriptor conditionals if that gets merged first. The testcase added here uses `ORDER BY` inside `array_agg` and `string_agg` which will be a syntax error before PG 9.0 ... a perfect occasion to use DDR conditionals ....

Closes #21.