### PR TITLE
Fix oldest outstanding github issue, enum support.

### DIFF
--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/Enumeration.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/Enumeration.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2015- Tada AB and other contributors, as listed below.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Chapman Flack
+ */
+package org.postgresql.pljava.example.annotation;
+
+import java.util.Iterator;
+import java.util.Arrays;
+
+import org.postgresql.pljava.annotation.SQLAction;
+import org.postgresql.pljava.annotation.SQLActions;
+import org.postgresql.pljava.annotation.SQLType;
+import org.postgresql.pljava.annotation.Function;
+
+/**
+ * Confirms the mapping of PG enum and Java String, and arrays of each, as
+ * parameter and return types.
+ */
+@SQLActions({
+	@SQLAction(provides="mood type",
+		install="CREATE TYPE mood AS ENUM ('sad', 'ok', 'happy')",
+		remove="DROP TYPE mood"
+	),
+	@SQLAction(
+		requires={"textToMood", "moodToText", "textsToMoods", "moodsToTexts"},
+		install={
+			"SELECT textToMood('happy')",
+			"SELECT moodToText('happy'::mood)",
+			"SELECT textsToMoods(array['happy','happy','sad','ok'])",
+			"SELECT moodsToTexts(array['happy','happy','sad','ok']::mood[])"
+		}
+	)
+})
+public class Enumeration
+{
+	@Function(requires="mood type", provides="textToMood", complexType="mood")
+	public static String textToMood(String s)
+	{
+		return s;
+	}
+	@Function(requires="mood type", provides="moodToText")
+	public static String moodToText(@SQLType("mood")String s)
+	{
+		return s;
+	}
+	@Function(requires="mood type", provides="textsToMoods", complexType="mood")
+	public static Iterator<String> textsToMoods(String[] ss)
+	{
+		return Arrays.asList(ss).iterator();
+	}
+	@Function(requires="mood type", provides="moodsToTexts")
+	public static Iterator<String> moodsToTexts(@SQLType("mood[]")String[] ss)
+	{
+		return Arrays.asList(ss).iterator();
+	}
+}

--- a/pljava-so/src/main/c/type/String.c
+++ b/pljava-so/src/main/c/type/String.c
@@ -68,7 +68,7 @@ static String String_create(TypeClass cls, Oid typeId)
 	MemoryContext ctx = GetMemoryChunkContext(self);
 	fmgr_info_cxt(pgType->typoutput, &self->textOutput, ctx);
 	fmgr_info_cxt(pgType->typinput,  &self->textInput,  ctx);
-	self->elementType = pgType->typelem;
+	self->elementType = 'e' == pgType->typtype ? typeId : pgType->typelem;
 	ReleaseSysCache(typeTup);
 	return self;
 }


### PR DESCRIPTION
I opted not to always pass `typeId` in place of `elementType` to the input function (r0ml's solution), but instead to assign the `typeId` to `elementType` at creation (instead of zero), in the case that the type being mapped is an enum. Not sure it matters, but seemed a more conservative change.