### PR TITLE
Remove nexus.tada.se references from POM.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,52 +76,6 @@
 		</site>
 	</distributionManagement>
 
-	<repositories>
-		<repository>
-			<id>releases.tada.se</id>
-			<url>http://nexus.tada.se/content/repositories/releases/</url>
-			<releases>
-				<enabled>true</enabled>
-			</releases>
-			<snapshots>
-				<enabled>false</enabled>
-			</snapshots>
-		</repository>
-		<repository>
-			<id>snapshots.tada.se</id>
-			<url>http://nexus.tada.se/content/repositories/snapshots/</url>
-			<releases>
-				<enabled>false</enabled>
-			</releases>
-			<snapshots>
-				<enabled>true</enabled>
-			</snapshots>
-		</repository>
-	</repositories>
-
-	<pluginRepositories>
-		<pluginRepository>
-			<id>releases.tada.se</id>
-			<url>http://nexus.tada.se/content/repositories/releases/</url>
-			<releases>
-				<enabled>true</enabled>
-			</releases>
-			<snapshots>
-				<enabled>false</enabled>
-			</snapshots>
-		</pluginRepository>
-		<pluginRepository>
-			<id>snapshots.tada.se</id>
-			<url>http://nexus.tada.se/content/repositories/snapshots/</url>
-			<releases>
-				<enabled>false</enabled>
-			</releases>
-			<snapshots>
-				<enabled>true</enabled>
-			</snapshots>
-		</pluginRepository>
-	</pluginRepositories>
-
 	<build>
 		<plugins>
 			<plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,8 @@
 		<url>http://tada.se/eng/</url>
 	</organization>
 
+	<inceptionYear>2003</inceptionYear>
+
 	<licenses>
 		<license>
 			<name>BSD 3-clause</name>

--- a/pom.xml
+++ b/pom.xml
@@ -57,18 +57,6 @@
 	</modules>
 
 	<distributionManagement>
-		<repository>
-			<uniqueVersion>false</uniqueVersion>
-			<id>tada.se</id>
-			<name>PL/Java Releases</name>
-			<url>http://nexus.tada.se/content/repositories/releases/</url>
-		</repository>
-		<snapshotRepository>
-			<uniqueVersion>false</uniqueVersion>
-			<id>tada.se</id>
-			<name>PL/Java Snapshots</name>
-			<url>http://nexus.tada.se/content/repositories/snapshots/</url>
-		</snapshotRepository>
 		<site>
 			<id>site.pljava.tada.se</id>
 			<name>PL/Java Developer Info</name>


### PR DESCRIPTION
Apparently nothing is needed any more from repositories declared
at nexus.tada.se - my builds complete faultlessly with these repository
declarations removed. On the other hand, when they are present, they
will hang a maven build if the nexus.tada.se server can't be contacted,
which has been a lot of the time lately.