### PR TITLE
Type_getCoerceOut correct statement order.

### DIFF
--- a/pljava-so/src/main/c/type/Type.c
+++ b/pljava-so/src/main/c/type/Type.c
@@ -145,18 +145,18 @@ Type Type_getCoerceOut(Type self, Type other)
 			return coercer;
 	}
 
-	if(funcId == InvalidOid)
-		/*
-		 * Binary compatible type. No need for a special coercer
-		 */
-		return self;
-
 	if (!find_coercion_pathway(toOid, fromOid, COERCION_EXPLICIT, &funcId))
 	{
 		elog(ERROR, "no conversion function from %s to %s",
 			 format_type_be(fromOid),
 			 format_type_be(toOid));
 	}
+
+	if(funcId == InvalidOid)
+		/*
+		 * Binary compatible type. No need for a special coercer
+		 */
+		return self;
 
 	if(self->outCoercions == 0)
 		self->outCoercions = HashMap_create(7, GetMemoryChunkContext(self));


### PR DESCRIPTION
Ken Olson pointed this out as a case of 'dead code', but in fact it was live use of an unassigned variable just _before_ the function call that was going to assign it. Had to be an editing mixup, has been that way a very long time, and has probably not caused more problems only because it's statistically rare for a random stack location to be exactly equal to `InvalidOid`.

Scratches the surface of #65. A full solution for that issue will have to come later, but this much was an obvious Heisenbug with an obvious fix.