### PR TITLE
Track PostgreSQL's changes to stack base access.

### DIFF
--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/ThreadTest.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/ThreadTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2015 Tada AB and other contributors, as listed below.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Chapman Flack
+ */
+package org.postgresql.pljava.example.annotation;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import java.lang.reflect.UndeclaredThrowableException;
+
+import org.postgresql.pljava.annotation.SQLAction;
+import org.postgresql.pljava.annotation.Function;
+
+/**
+ * Test control of access to 1-thread backend by n-thread JVM.
+ *
+ * The "select strictlyNestedTest()" is marked "notFromDDR" because it actually
+ * <em>does</em> deadlock when invoked from within install_jar, though it
+ * succeeds when invoked directly. The explanation may lie in the JNI spec's
+ * caveat that JNI MonitorEnter/MonitorExit functions must be paired with each
+ * other and not arbitrarily mixed with JVM monitorenter/monitorexit bytecodes.
+ * In the present design, that can happen (install_jar uses a synchronized
+ * block to call into the backend when executing DDR commands; DDR command
+ * calling strictlyNestedTest leads to JNI MonitorExit in BEGIN_CALL; perhaps
+ * that does not effectively release the lock taken by the synchronized block).
+ */
+@SQLAction(implementor="notFromDDR",
+	requires="strictlyNestedTest fn",
+	install="select strictlyNestedTest()"
+)
+public class ThreadTest implements Runnable {
+	/**
+	 * Test that another thread can enter SPI while the calling thread is out.
+	 *
+	 * Create a thread that uses SPI to perform a query and set the value of
+	 * {@link #result}. Start and wait for that thread (so this one is clearly
+	 * out of the backend the whole time), then return the result.
+	 */
+	@Function(provides="strictlyNestedTest fn")
+	public static String strictlyNestedTest()
+	throws SQLException {
+		ThreadTest tt = new ThreadTest();
+		Thread t = new Thread( tt);
+		t.start();
+		while ( true )
+		{
+			try
+			{
+				t.join();
+			}
+			catch ( InterruptedException ie )
+			{
+				continue;
+			}
+			break;
+		}
+		return tt.result;
+	}
+
+	String result;
+
+	public void run()
+	{
+		try
+		{
+			Connection c = DriverManager.getConnection(
+				"jdbc:default:connection");
+			Statement s = c.createStatement();
+			ResultSet rs = s.executeQuery( "select version() as version");
+			rs.next();
+			result = rs.getString( "version");
+		}
+		catch ( Exception e )
+		{
+			if ( e instanceof RuntimeException )
+				throw (RuntimeException)e;
+			throw new UndeclaredThrowableException( e);
+		}
+	}
+}

--- a/pljava-so/src/main/c/ExecutionPlan.c
+++ b/pljava-so/src/main/c/ExecutionPlan.c
@@ -19,6 +19,10 @@
 #include "pljava/type/Portal.h"
 #include "pljava/type/String.h"
 
+#if defined(NEED_MISCADMIN_FOR_STACK_BASE)
+#include <miscadmin.h>
+#endif
+
 /* Class 07 - Dynamic SQL Error */
 #define ERRCODE_PARAMETER_COUNT_MISMATCH	MAKE_SQLSTATE('0','7', '0','0','1')
 

--- a/pljava-so/src/main/c/SPI.c
+++ b/pljava-so/src/main/c/SPI.c
@@ -15,6 +15,9 @@
 #include "pljava/type/TupleTable.h"
 
 #include <access/xact.h>
+#if defined(NEED_MISCADMIN_FOR_STACK_BASE)
+#include <miscadmin.h>
+#endif
 
 Savepoint* infant = 0;
 

--- a/pljava-so/src/main/c/type/Portal.c
+++ b/pljava-so/src/main/c/type/Portal.c
@@ -23,6 +23,10 @@
 #include "pljava/type/Portal.h"
 #include "pljava/type/String.h"
 
+#if defined(NEED_MISCADMIN_FOR_STACK_BASE)
+#include <miscadmin.h>
+#endif
+
 static jclass    s_Portal_class;
 static jmethodID s_Portal_init;
 static jfieldID  s_Portal_pointer;


### PR DESCRIPTION
set_stack_base() and restore_stack_base() were added in preference to
direct access to stack_base_ptr (for 9.2, backpatched into 9.1.4,
9.0.8, 8.4.12, and 8.3.19). This adapts PL/Java to that new API so PostgreSQL
doesn't have to keep the old one around forever.

The new style requires miscadmin.h to be included
in those source files that use the STACK_BASE_PUSH / STACK_BASE_POP
macros (there is so much in miscadmin.h, I did not want to add it in
pljava.h and have it processed everywhere).

Also added example ThreadTest.java just to exercise the new logic.
However, if enabled to run from the deployment descriptor, it does
deadlock; apparently PG -> J -> (otherthread PG) works, but the deeper
PG -> J -> PG -> J -> (otherthread PG) does not, and I *suspect* it's
because of the JNI warning against mispairing bytecode monitorenters with
JNI monitorexits. But that is what the code has done for years now, so
if nothing has been reported, there must not be high demand for that use
pattern.