### PR TITLE
Simplify/master/libdirmacro

### DIFF
--- a/packaging/build.xml
+++ b/packaging/build.xml
@@ -18,9 +18,9 @@
             </filterchain>
         </loadresource>
 		
-		<loadproperties srcFile="../pljava-so/pgsql.properties"/>
+		<loadproperties srcFile="../pljava-so/target/pgsql.properties"/>
 		
-		<property name="suffix" value="pg${PGSQL_MAJOR_VER}.${PGSQL_MINOR_VER}-${naraol}"/>
+		<property name="suffix" value="${PGSQL_VER_CLASSIFIER}-${naraol}"/>
 	</target>
 
 	<target name="package-zip" depends="init">

--- a/pljava-so/build.xml
+++ b/pljava-so/build.xml
@@ -50,44 +50,21 @@
 		<exec executable="pg_config" outputproperty="PGSQL_INCLUDEDIR-SERVER">
 			<arg line="--includedir-server"/>
 		</exec>
-		<exec executable="pg_config" outputproperty="PGSQL_VER">
-			<arg line="--version"/>
-		</exec>
-
-		<!-- Then split the version number into its components. -->
-		<loadresource property="PGSQL_MAJOR_VER">
-			<string value="${PGSQL_VER}" />
+		<loadresource property="KNOWS_MSVC_RINT">
+			<filelist files="pg_config.h" dir="${PGSQL_INCLUDEDIR}"/>
 			<filterchain>
 				<tokenfilter>
-					<replaceregex pattern="devel.*|alpha.*|beta.*|rc.*$" replace="\.99" flags="si" />
-					<containsregex pattern="[^\d]*(\d+)\.(\d+)\.(\d+)$" replace="\1" />
-				</tokenfilter>
-			</filterchain>
-		</loadresource>
-		<loadresource property="PGSQL_MINOR_VER">
-			<string value="${PGSQL_VER}" />
-			<filterchain>
-				<tokenfilter>
-					<replaceregex pattern="devel.*|alpha.*|beta.*|rc.*$" replace="\.99" flags="si" />
-					<containsregex pattern="[^\d]*(\d+)\.(\d+)\.(\d+)$" replace="\2" />
-				</tokenfilter>
-			</filterchain>
-		</loadresource>
-		<loadresource property="PGSQL_PATCH_VER">
-			<string value="${PGSQL_VER}" />
-			<filterchain>
-				<tokenfilter>
-					<replaceregex pattern="devel.*|alpha.*|beta.*|rc.*$" replace="\.99" flags="si" />
-					<containsregex pattern="[^\d]*(\d+)\.(\d+)\.(\d+)$" replace="\3" />
+					<filetokenizer/>
+					<containsregex
+						pattern="#if \(_MSC_VER >= 1800\)\s+#define HAVE_RINT"/>
 				</tokenfilter>
 			</filterchain>
 		</loadresource>
 
 		<script language="javascript"><![CDATA[
 			var msvc_version = parseInt(project.getProperty('MSVC_VER'));
-			var pg_major_version = parseInt(project.getProperty('PGSQL_MAJOR_VER'));
-			var pg_minor_version = parseInt(project.getProperty('PGSQL_MINOR_VER'));
-			if (msvc_version >= 1800  && (pg_major_version < 9 || (pg_major_version == 9 && pg_minor_version  < 4))) {
+			var knows_rint = project.getProperty('KNOWS_MSVC_RINT');
+			if (msvc_version >= 1800  && knows_rint === null) {
 				project.setProperty('MSVC_RINT', 'HAVE_RINT=1' );
 			} else {
 				project.setProperty('MSVC_RINT', 'msvc.rint' );
@@ -100,9 +77,6 @@
 			<entry key="PGSQL_LIBDIR" value="${PGSQL_LIBDIR}" />
 			<entry key="PGSQL_INCLUDEDIR" value="${PGSQL_INCLUDEDIR}" />
 			<entry key="PGSQL_INCLUDEDIR-SERVER" value="${PGSQL_INCLUDEDIR-SERVER}" />
-			<entry key="PGSQL_MAJOR_VER" value="${PGSQL_MAJOR_VER}" />
-			<entry key="PGSQL_MINOR_VER" value="${PGSQL_MINOR_VER}" />
-			<entry key="PGSQL_PATCH_VER" value="${PGSQL_PATCH_VER}" />
 			<entry key="MSVC_RINT" value="${MSVC_RINT}" />
 		</propertyfile>
 	</target>

--- a/pljava-so/build.xml
+++ b/pljava-so/build.xml
@@ -50,6 +50,18 @@
 		<exec executable="pg_config" outputproperty="PGSQL_INCLUDEDIR-SERVER">
 			<arg line="--includedir-server"/>
 		</exec>
+		<exec executable="pg_config" outputproperty="PGSQL_VER">
+			<arg line="--version"/>
+		</exec>
+		<loadresource property="PGSQL_VER_CLASSIFIER">
+			<string value="${PGSQL_VER}" />
+			<filterchain>
+				<tokenfilter>
+					<replaceregex pattern="devel.*|alpha.*|beta.*|rc.*$" replace="\.99" flags="si" />
+					<containsregex pattern="[^\d]*(\d+)\.(\d+)\.(\d+)$" replace="pg\1.\2" />
+				</tokenfilter>
+			</filterchain>
+		</loadresource>
 		<loadresource property="KNOWS_MSVC_RINT">
 			<filelist files="pg_config.h" dir="${PGSQL_INCLUDEDIR}"/>
 			<filterchain>
@@ -73,6 +85,7 @@
 
 		<!-- Finally write all properties to a file which Maven understands. -->
 		<propertyfile file="target/pgsql.properties" jdkproperties="true">
+			<entry key="PGSQL_VER_CLASSIFIER" value="${PGSQL_VER_CLASSIFIER}" />
 			<entry key="PGSQL_PKGLIBDIR" value="${PGSQL_PKGLIBDIR}" />
 			<entry key="PGSQL_LIBDIR" value="${PGSQL_LIBDIR}" />
 			<entry key="PGSQL_INCLUDEDIR" value="${PGSQL_INCLUDEDIR}" />

--- a/pljava-so/build.xml
+++ b/pljava-so/build.xml
@@ -72,7 +72,7 @@
 			]]></script>
 
 		<!-- Finally write all properties to a file which Maven understands. -->
-		<propertyfile file="pgsql.properties" jdkproperties="true">
+		<propertyfile file="target/pgsql.properties" jdkproperties="true">
 			<entry key="PGSQL_PKGLIBDIR" value="${PGSQL_PKGLIBDIR}" />
 			<entry key="PGSQL_LIBDIR" value="${PGSQL_LIBDIR}" />
 			<entry key="PGSQL_INCLUDEDIR" value="${PGSQL_INCLUDEDIR}" />

--- a/pljava-so/pom.xml
+++ b/pljava-so/pom.xml
@@ -147,7 +147,7 @@
 			<plugin>
 				<groupId>com.github.maven-nar</groupId>
 				<artifactId>nar-maven-plugin</artifactId>
-				<version>3.1.0</version>
+				<version>3.2.3</version>
 				<extensions>true</extensions>
 
 				<configuration>
@@ -272,7 +272,7 @@
 									<pluginExecutionFilter>
 										<groupId>com.github.maven-nar</groupId>
 										<artifactId>nar-maven-plugin</artifactId>
-										<versionRange>[3.1.0]</versionRange>
+										<versionRange>[3.2.3]</versionRange>
 										<goals>
 											<goal>nar-compile</goal>
 											<goal>nar-download</goal>

--- a/pljava-so/pom.xml
+++ b/pljava-so/pom.xml
@@ -170,10 +170,6 @@
 						<name>${CPP_COMPILER}</name>
 				-->
 						<defines>
-							<!-- What PKGLIBDIR controls is the expansion of
-							     $libdir if used in pljava.classpath
-							-->
-							<define>PKGLIBDIR=${PGSQL_PKGLIBDIR}</define>
 							<define>PGSQL_MAJOR_VER=${PGSQL_MAJOR_VER}</define>
 							<define>PGSQL_MINOR_VER=${PGSQL_MINOR_VER}</define>
 							<define>PGSQL_PATCH_VER=${PGSQL_PATCH_VER}</define>

--- a/pljava-so/pom.xml
+++ b/pljava-so/pom.xml
@@ -136,7 +136,7 @@
 						</goals>
 						<configuration>
 							<files>
-								<file>${basedir}/pgsql.properties</file>
+								<file>${basedir}/target/pgsql.properties</file>
 							</files>
 						</configuration>
 					</execution>

--- a/pljava-so/pom.xml
+++ b/pljava-so/pom.xml
@@ -169,11 +169,6 @@
 				<!-- uncomment the next line if you need to configure your compiler (e.g. clang)
 						<name>${CPP_COMPILER}</name>
 				-->
-						<defines>
-							<define>PGSQL_MAJOR_VER=${PGSQL_MAJOR_VER}</define>
-							<define>PGSQL_MINOR_VER=${PGSQL_MINOR_VER}</define>
-							<define>PGSQL_PATCH_VER=${PGSQL_PATCH_VER}</define>
-						</defines>
 						<includePaths>
 							<!-- TODO: hardcoded paths -->
 							<includePath>${PGSQL_INCLUDEDIR}</includePath>

--- a/pljava-so/src/main/c/Backend.c
+++ b/pljava-so/src/main/c/Backend.c
@@ -43,21 +43,6 @@
 #include "utils/timeout.h"
 #endif
 
-/* Example format: /usr/local/pgsql/lib */
-#ifndef PKGLIBDIR
-#error "PKGLIBDIR needs to be defined to compile this file."
-/*
- * Though really, the only bad thing that would happen without it is $libdir
- * wouldn't be expandable in pljava.classpath.
- */
-#else
-/*
- * CppAsString2 first appears in PG8.4.  IF that's a problem, the definition
- * is really simple.
- */
-#define PKGLIBDIRSTRING CppAsString2(PKGLIBDIR)
-#endif
-
 /* Include the 'magic block' that PostgreSQL 8.2 and up will use to ensure
  * that a module is not loaded into an incompatible server.
  */ 
@@ -270,15 +255,13 @@ static void appendPathParts(const char* path, StringInfoData* bld, HashMap uniqu
 		initStringInfo(&buf);
 		if(*path == '$')
 		{
-#if defined(PKGLIBDIRSTRING)
 			if(len == 7 || (strcspn(path, "/\\") == 7 && strncmp(path, "$libdir", 7) == 0))
 			{
 				len -= 7;
 				path += 7;
-				appendStringInfo(&buf, PKGLIBDIRSTRING);
+				appendStringInfoString(&buf, pkglib_path);
 			}
 			else
-#endif
 				ereport(ERROR, (
 					errcode(ERRCODE_INVALID_NAME),
 					errmsg("invalid macro name '%*s' in PL/Java classpath", (int)len, path)));

--- a/pljava-so/src/main/c/Backend.c
+++ b/pljava-so/src/main/c/Backend.c
@@ -259,7 +259,9 @@ static void appendPathParts(const char* path, StringInfoData* bld, HashMap uniqu
 			{
 				len -= 7;
 				path += 7;
-				appendStringInfoString(&buf, pkglib_path);
+				enlargeStringInfo(&buf, MAXPGPATH);
+				get_pkglib_path(my_exec_path, buf.data);
+				buf.len += strlen(buf.data);
 			}
 			else
 				ereport(ERROR, (

--- a/pljava-so/src/main/include/pljava/pljava.h
+++ b/pljava-so/src/main/include/pljava/pljava.h
@@ -34,6 +34,10 @@ extern int vsnprintf(char* buf, size_t count, const char* format, va_list arg);
 #include <utils/memutils.h>
 #include <tcop/tcopprot.h>
 
+#define PGSQL_MAJOR_VER (PG_VERSION_NUM / 10000)
+#define PGSQL_MINOR_VER ((PG_VERSION_NUM / 100) % 100)
+#define PGSQL_PATCH_VER (PG_VERSION_NUM % 100)
+
 /*
  * AssertVariableIsOfType appeared in PG9.3. Can test for the macro directly.
  */


### PR DESCRIPTION
Expand `$libdir` in `pljava.classpath` according to the actual run-time result of `get_pkglib_path` instead of a compile-time string passed to the compiler. This is more correct (handles the case where someone relocates the PG tree), and simplifies the C code and the build scripting. While touching the build scripts, simplify the handling of version numbers and the MSVC `rint` hack also.

Tested by me, dblanch on OS X, kenolson on Windows.