### PR TITLE
Bug/master/issue63

### DIFF
--- a/packaging/build.xml
+++ b/packaging/build.xml
@@ -12,7 +12,7 @@
             <filterchain>
                 <tokenfilter>
                     <!--containsregex pattern=".*SNAPSHOT-(.*)-shared.*$" replace="\1" /-->
-                    <containsregex pattern=".*/lib/(.*)/shared/.*$" replace="\1" />
+                    <containsregex pattern=".*/lib/(.*)/plugin/.*$" replace="\1" />
                 </tokenfilter>
 				<striplinebreaks/>
             </filterchain>

--- a/pljava-so/build.xml
+++ b/pljava-so/build.xml
@@ -38,6 +38,9 @@
 
 	<target name="pg_config" depends="configure_msvc_options">
 		<!-- First gather all values from the pg_config executable. -->
+		<exec executable="pg_config" outputproperty="PGSQL_BINDIR">
+			<arg line="--bindir"/>
+		</exec>
 		<exec executable="pg_config" outputproperty="PGSQL_PKGLIBDIR">
 			<arg line="--pkglibdir"/>
 		</exec>
@@ -96,6 +99,7 @@
 
 		<!-- Finally write all properties to a file which Maven understands. -->
 		<propertyfile file="pgsql.properties" jdkproperties="true">
+			<entry key="PGSQL_BINDIR" value="${PGSQL_BINDIR}" />
 			<entry key="PGSQL_PKGLIBDIR" value="${PGSQL_PKGLIBDIR}" />
 			<entry key="PGSQL_LIBDIR" value="${PGSQL_LIBDIR}" />
 			<entry key="PGSQL_INCLUDEDIR" value="${PGSQL_INCLUDEDIR}" />

--- a/pljava-so/pom.xml
+++ b/pljava-so/pom.xml
@@ -172,7 +172,7 @@
 			<plugin>
 				<groupId>com.github.maven-nar</groupId>
 				<artifactId>nar-maven-plugin</artifactId>
-				<version>3.1.0</version>
+				<version>3.2.3</version>
 				<extensions>true</extensions>
 
 				<configuration>
@@ -306,7 +306,7 @@
 									<pluginExecutionFilter>
 										<groupId>com.github.maven-nar</groupId>
 										<artifactId>nar-maven-plugin</artifactId>
-										<versionRange>[3.1.0]</versionRange>
+										<versionRange>[3.2.3]</versionRange>
 										<goals>
 											<goal>nar-compile</goal>
 											<goal>nar-download</goal>

--- a/pljava-so/pom.xml
+++ b/pljava-so/pom.xml
@@ -218,7 +218,7 @@
 					<!-- Builds a *.so library. -->
 					<libraries>
 						<library>
-							<type>shared</type>
+							<type>plugin</type>
 							<!-- Do not add "-lstdc++". Adds "-shared-libgcc" though. -->
 							<linkCPP>false</linkCPP>
 						</library>

--- a/pljava-so/pom.xml
+++ b/pljava-so/pom.xml
@@ -20,6 +20,31 @@
 
 	<profiles>
 		<profile>
+			<id>osx</id>
+			<activation>
+				<os>
+					<name>mac os x</name>
+				</os>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>com.github.maven-nar</groupId>
+						<artifactId>nar-maven-plugin</artifactId>
+						<configuration>
+							<linker>
+								<options>
+									<option>-bundle_loader</option>
+									<option>${PGSQL_BINDIR}/postgres</option>
+								</options>
+							</linker>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+
+		<profile>
 			<id>compiler-msvc</id>
 			<activation>
 				<property>


### PR DESCRIPTION
Fixes #63 by declaring the `nar` artifact to be of `plugin` type rather than `shared`, so on OS X it is allowed to have unresolved references that will be found in the thing that loads it.

On non-OS X platforms, the choice of `plugin` or `shared` makes no difference in the link. It does, however, show up in the pathname of the built object, so the wiki install instructions will have to be updated.

Tested by me, dblanch, Darsstar.