### PR TITLE
Track upstream maven-site-plugin.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-site-plugin</artifactId>
-				<version>3.0</version>
+				<version>3.4</version>
 				<dependencies>
 					<dependency>
 						<groupId>org.apache.maven.doxia</groupId>


### PR DESCRIPTION
Reported by dblanch: mvn site site:stage  can fail in newer Maven versions, with `java.lang.NoClassDefFoundError: org/sonatype/aether/graph/DependencyFilter`

The explanation is here:
https://cwiki.apache.org/confluence/display/MAVEN/AetherClassNotFound

Solution requires updating to `maven-site-plugin` >= 3.3.  3.4 is current
and works for me, so it is now specified.