### PR TITLE
Resolve OS X build problems (issue 63).

### DIFF
--- a/packaging/build.xml
+++ b/packaging/build.xml
@@ -12,7 +12,7 @@
             <filterchain>
                 <tokenfilter>
                     <!--containsregex pattern=".*SNAPSHOT-(.*)-shared.*$" replace="\1" /-->
-                    <containsregex pattern=".*/lib/(.*)/shared/.*$" replace="\1" />
+                    <containsregex pattern=".*/lib/(.*)/plugin/.*$" replace="\1" />
                 </tokenfilter>
 				<striplinebreaks/>
             </filterchain>

--- a/pljava-so/build.xml
+++ b/pljava-so/build.xml
@@ -38,6 +38,9 @@
 
 	<target name="pg_config" depends="configure_msvc_options">
 		<!-- First gather all values from the pg_config executable. -->
+		<exec executable="pg_config" outputproperty="PGSQL_BINDIR">
+			<arg line="--bindir"/>
+		</exec>
 		<exec executable="pg_config" outputproperty="PGSQL_PKGLIBDIR">
 			<arg line="--pkglibdir"/>
 		</exec>
@@ -86,6 +89,7 @@
 		<!-- Finally write all properties to a file which Maven understands. -->
 		<propertyfile file="target/pgsql.properties" jdkproperties="true">
 			<entry key="PGSQL_VER_CLASSIFIER" value="${PGSQL_VER_CLASSIFIER}" />
+			<entry key="PGSQL_BINDIR" value="${PGSQL_BINDIR}" />
 			<entry key="PGSQL_PKGLIBDIR" value="${PGSQL_PKGLIBDIR}" />
 			<entry key="PGSQL_LIBDIR" value="${PGSQL_LIBDIR}" />
 			<entry key="PGSQL_INCLUDEDIR" value="${PGSQL_INCLUDEDIR}" />

--- a/pljava-so/pom.xml
+++ b/pljava-so/pom.xml
@@ -20,6 +20,31 @@
 
 	<profiles>
 		<profile>
+			<id>osx</id>
+			<activation>
+				<os>
+					<name>mac os x</name>
+				</os>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>com.github.maven-nar</groupId>
+						<artifactId>nar-maven-plugin</artifactId>
+						<configuration>
+							<linker>
+								<options>
+									<option>-bundle_loader</option>
+									<option>${PGSQL_BINDIR}/postgres</option>
+								</options>
+							</linker>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+
+		<profile>
 			<id>compiler-msvc</id>
 			<activation>
 				<property>
@@ -209,7 +234,7 @@
 					<!-- Builds a *.so library. -->
 					<libraries>
 						<library>
-							<type>shared</type>
+							<type>plugin</type>
 							<!-- Do not add "-lstdc++". Adds "-shared-libgcc" though. -->
 							<linkCPP>false</linkCPP>
 						</library>


### PR DESCRIPTION
In the nar-maven-plugin, `shared` and `plugin` are interchangeable on
platforms other than Darwin, but on Darwin they produce two different
link commands (a `plugin` gets the `-bundle` option).

The distinction (on Darwin) is a shared object is something exporting
some API that the process loading it will call into, but a plugin/bundle
also expects to be able to call *back* into API provided by the thing that
loaded it. PL/Java fits in the second category, so may as well call it a
plugin; won't change much on other platforms, but makes a difference on
Darwin.

When linking a plugin, the Darwin linker wants the `-bundle_loader` option
to identify the program that will be loading the plugin (postgres, in
this case). It verifies that the symbols unresolved in the plugin itself
really will be found in the program that loads it.

Update the packaging script to reflect the change from `shared` to `plugin`
in the object path.