### PR TITLE
The long-in-coming install-procedure update.

### DIFF
--- a/pljava-api/pom.xml
+++ b/pljava-api/pom.xml
@@ -12,6 +12,30 @@
 	<build>
 		<plugins>
 			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<configuration>
+					<archive>
+						<manifestSections>
+							<manifestSection>
+								<name>org/postgresql/pljava/</name>
+								<manifestEntries>
+									<Implementation-Title>
+										${project.name}
+									</Implementation-Title>
+									<Implementation-Version>
+										${project.version}
+									</Implementation-Version>
+									<Implementation-Vendor>
+										${project.organization.name}
+									</Implementation-Vendor>
+								</manifestEntries>
+							</manifestSection>
+						</manifestSections>
+					</archive>
+				</configuration>
+			</plugin>
+			<plugin>
 				<artifactId>maven-resources-plugin</artifactId>
 				<version>2.5</version>
 				<executions>

--- a/pljava-api/src/main/java/org/postgresql/pljava/sqlgen/DDRWriter.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/sqlgen/DDRWriter.java
@@ -32,7 +32,7 @@ import static org.postgresql.pljava.sqlgen.Lexicals.ISO_PG_JAVA_IDENTIFIER;
  * @author Chapman Flack (Purdue Mathematics) - update to Java6, reorganize,
  * add lexable check
  */
-class DDRWriter
+public class DDRWriter
 {
 	/**
 	 * Generate the deployment descriptor file.

--- a/pljava-so/pom.xml
+++ b/pljava-so/pom.xml
@@ -194,6 +194,9 @@
 				<!-- uncomment the next line if you need to configure your compiler (e.g. clang)
 						<name>${CPP_COMPILER}</name>
 				-->
+						<defines>
+							<define>PLJAVA_SO_VERSION=${project.version}</define>
+						</defines>
 						<includePaths>
 							<!-- TODO: hardcoded paths -->
 							<includePath>${PGSQL_INCLUDEDIR}</includePath>

--- a/pljava-so/pom.xml
+++ b/pljava-so/pom.xml
@@ -203,13 +203,6 @@
 						</includePaths>
 					</c>
 
-					<java>
-						<!-- This is supposed to be the same as adding the
-						     exact right <lib> specification under <linker>
-							 to refer to libjvm.
-						-->
-						<link>true</link>
-					</java>
 					<!-- Defines linker flags "-ljvm -L.../server" -->
 					<linker>
 						<libs>

--- a/pljava-so/pom.xml
+++ b/pljava-so/pom.xml
@@ -65,6 +65,7 @@
 								<includePaths combine.children='append'>
 									<includePath>${PGSQL_INCLUDEDIR-SERVER}/port/win32</includePath>
 									<includePath>${PGSQL_INCLUDEDIR-SERVER}/port/win32_msvc</includePath>
+									<includePath>${basedir}/src/main/include/fallback/win32</includePath>
 								</includePaths>
 							</c>
 							<linker>

--- a/pljava-so/src/main/c/Backend.c
+++ b/pljava-so/src/main/c/Backend.c
@@ -168,6 +168,8 @@ static void initsequencer(enum initstage is, bool tolerant);
 		char **newval, void **extra, GucSource source);
 	static bool check_classpath(
 		char **newval, void **extra, GucSource source);
+	static bool check_enabled(
+		bool *newval, void **extra, GucSource source);
 
 	/* Check hooks will always allow "setting" a value that is the same as
 	 * current; otherwise, it would be frustrating to have just found settings

--- a/pljava-so/src/main/c/Backend.c
+++ b/pljava-so/src/main/c/Backend.c
@@ -180,7 +180,7 @@ static void initsequencer(enum initstage is, bool tolerant);
 	{
 		if ( initstage < IS_CAND_JVMOPENED )
 			return true;
-		if ( vmoptions == *newval )
+		if ( libjvmlocation == *newval )
 			return true;
 		if ( libjvmlocation && *newval && 0 == strcmp(libjvmlocation, *newval) )
 			return true;

--- a/pljava-so/src/main/c/Backend.c
+++ b/pljava-so/src/main/c/Backend.c
@@ -1216,6 +1216,8 @@ static jint initializeJavaVM(JVMOptList *optList)
 
 static void registerGUCOptions(void)
 {
+	char pathbuf[MAXPGPATH];
+
 	DefineCustomStringVariable(
 		"pljava.libjvm_location",
 		"Path to the libjvm (.so, .dll, etc.) file in Java's jre/lib area",
@@ -1258,7 +1260,7 @@ static void registerGUCOptions(void)
 		NULL, /* extended description */
 		&classpath,
 		#if (PGSQL_MAJOR_VER > 8 || (PGSQL_MAJOR_VER == 8 && PGSQL_MINOR_VER > 3))
-			NULL, /* boot value */
+			InstallHelper_defaultClassPath(pathbuf), /* boot value */
 		#endif
 		PGC_SUSET,
 		#if (PGSQL_MAJOR_VER > 8 || (PGSQL_MAJOR_VER == 8 && PGSQL_MINOR_VER > 3))

--- a/pljava-so/src/main/c/Backend.c
+++ b/pljava-so/src/main/c/Backend.c
@@ -237,7 +237,7 @@ static void initsequencer(enum initstage is, bool tolerant);
 		if ( *newval )
 			return true;
 		GUC_check_errmsg(
-			"too late to change \"pljava.enabled\" setting");
+			"too late to change \"pljava.enable\" setting");
 		GUC_check_errdetail(
 			"Start-up has progressed past the point where it is checked.");
 		GUC_check_errhint(
@@ -382,10 +382,10 @@ static void initsequencer(enum initstage is, bool tolerant)
 			ereport(WARNING, (
 				errmsg("Java virtual machine not yet loaded"),
 				errdetail(
-					"Pausing because \"pljava.enable\" is set \"false\". "),
+					"Pausing because \"pljava.enable\" is set \"off\". "),
 				errhint(
 					"After changing any other settings as necessary, set it "
-					"\"true\" to proceed.")));
+					"\"on\" to proceed.")));
 			goto check_tolerant;
 		}
 		initstage = IS_PLJAVA_ENABLED;
@@ -1307,7 +1307,7 @@ static void registerGUCOptions(void)
 
 	DefineCustomBoolVariable(
 		"pljava.enable",
-		"If false, the Java virtual machine will not be started until set true.",
+		"If off, the Java virtual machine will not be started until set on.",
 		"This is mostly of use on PostgreSQL versions < 9.2, where option "
 		"settings changed before LOADing PL/Java may be rejected, so they must "
 		"be made after LOAD, but before the virtual machine is started.",

--- a/pljava-so/src/main/c/Backend.c
+++ b/pljava-so/src/main/c/Backend.c
@@ -123,49 +123,204 @@ extern void SQLOutputToChunk_initialize(void);
 extern void SQLInputFromTuple_initialize(void);
 extern void SQLOutputToTuple_initialize(void);
 
+
+typedef struct {
+	JavaVMOption* options;
+	unsigned int  size;
+	unsigned int  capacity;
+} JVMOptList;
+
 static void registerGUCOptions(void);
+static jint initializeJavaVM(JVMOptList*);
+static void JVMOptList_init(JVMOptList*);
+static void JVMOptList_delete(JVMOptList*);
+static void JVMOptList_add(JVMOptList*, const char*, void*, bool);
+static void addUserJVMOptions(JVMOptList*);
+static void checkIntTimeType(void);
+static char* getClassPath(const char*);
+static void pljavaStatementCancelHandler(int);
+static void pljavaDieHandler(int);
+static void pljavaQuickDieHandler(int);
+static jint JNICALL my_vfprintf(FILE*, const char*, va_list);
+static void _destroyJavaVM(int, Datum);
+static void initPLJavaClasses(void);
+static void initJavaSession(void);
+
+enum initstage
+{
+	IS_FORMLESS_VOID,
+	IS_GUCS_REGISTERED,
+	IS_CAND_JVMLOCATION,
+	IS_CAND_JVMOPENED,
+	IS_CREATEVM_SYM_FOUND,
+	IS_MISC_ONCE_DONE,
+	IS_JAVAVM_OPTLIST,
+	IS_JAVAVM_STARTED,
+	IS_SIGHANDLERS,
+	IS_COMPLETE
+};
+
+static enum initstage initstage = IS_FORMLESS_VOID;
+static void *libjvm_handle;
+
+static void initsequencer(enum initstage is, bool tolerant);
+static void initsequencer(enum initstage is, bool tolerant)
+{
+	JVMOptList optList;
+	Invocation ctx;
+
+	switch (is)
+	{
+	case IS_FORMLESS_VOID:
+		registerGUCOptions();
+		initstage = IS_GUCS_REGISTERED;
+
+	case IS_GUCS_REGISTERED:
+		if ( NULL == libjvmlocation )
+		{
+			ereport(WARNING, (
+				errmsg("Java virtual machine not yet loaded"),
+				errdetail("location of libjvm is not configured"),
+				errhint("SET pljava.libjvm_location TO the correct "
+						"path to the libjvm (.so or .dll, etc.)")));
+			goto check_tolerant;
+		}
+		initstage = IS_CAND_JVMLOCATION;
+
+	case IS_CAND_JVMLOCATION:
+		libjvm_handle = pg_dlopen(libjvmlocation);
+		if ( NULL == libjvm_handle )
+		{
+			ereport(WARNING, (
+				errmsg("Java virtual machine not yet loaded"),
+				errdetail("%s", (char *)pg_dlerror()),
+				errhint("SET pljava.libjvm_location TO the correct "
+						"path to the libjvm (.so or .dll, etc.)")));
+			goto check_tolerant;
+		}
+		initstage = IS_CAND_JVMOPENED;
+
+	case IS_CAND_JVMOPENED:
+		pljava_createvm =
+			(jint JNICALL (*)(JavaVM **, void **, void *))
+			pg_dlsym(libjvm_handle, "JNI_CreateJavaVM");
+		if ( NULL == pljava_createvm )
+		{
+			/*
+			 * If it hasn't got the symbol, it can't be the right
+			 * library, so close/unload it so another can be tried.
+			 * Format the dlerror string first: dlclose may clobber it.
+			 */
+			char *dle = (pre_format_elog_string(errno, TEXTDOMAIN),
+				format_elog_string("%s", (char *)pg_dlerror()));
+			pg_dlclose(libjvm_handle);
+			initstage = IS_CAND_JVMLOCATION;
+			ereport(WARNING, (
+				errmsg("Java virtual machine not yet started"),
+				errdetail("%s", dle),
+				errhint("Is the file named in pljava.libjvm_location "
+						"the right one?")));
+			goto check_tolerant;
+		}
+		initstage = IS_CREATEVM_SYM_FOUND;
+
+	case IS_CREATEVM_SYM_FOUND:
+		s_javaLogLevel = INFO;
+		checkIntTimeType();
+		HashMap_initialize(); /* creates things in TopMemoryContext */
+#ifdef PLJAVA_DEBUG
+		/* Hard setting for debug. Don't forget to recompile...
+		 */
+		pljavaDebug = 1;
+#endif
+		initstage = IS_MISC_ONCE_DONE;
+
+	case IS_MISC_ONCE_DONE:
+		JVMOptList_init(&optList);
+		addUserJVMOptions(&optList);
+		/**
+		 * As stipulated by JRT-2003
+		 */
+		JVMOptList_add(&optList,
+			"-Dsqlj.defaultconnection=jdbc:default:connection",
+			0, true);
+		JVMOptList_add(&optList, "vfprintf", (void*)my_vfprintf, true);
+#ifndef GCJ
+		JVMOptList_add(&optList, "-Xrs", 0, true);
+#endif
+		effectiveClassPath = getClassPath("-Djava.class.path=");
+		if(effectiveClassPath != 0)
+		{
+			JVMOptList_add(&optList, effectiveClassPath, 0, true);
+		}
+		initstage = IS_JAVAVM_OPTLIST;
+
+	case IS_JAVAVM_OPTLIST:
+		if( JNI_OK != initializeJavaVM(&optList) )
+		{
+			ereport(WARNING, (errmsg("Failed to create Java VM")));
+			goto check_tolerant;
+		}
+		elog(DEBUG1, "JavaVM created");
+		initstage = IS_JAVAVM_STARTED;
+
+	case IS_JAVAVM_STARTED:
+#if !defined(WIN32)
+		pqsignal(SIGINT,  pljavaStatementCancelHandler);
+		pqsignal(SIGTERM, pljavaDieHandler);
+		pqsignal(SIGQUIT, pljavaQuickDieHandler);
+#endif
+		/* Register an on_proc_exit handler that destroys the VM
+		 */
+		on_proc_exit(_destroyJavaVM, 0);
+		initstage = IS_SIGHANDLERS;
+
+	case IS_SIGHANDLERS:
+		Invocation_pushBootContext(&ctx);
+		PG_TRY();
+		{
+			initPLJavaClasses();
+			initJavaSession();
+			Invocation_popBootContext();
+		}
+		PG_CATCH();
+		{
+			Invocation_popBootContext();
+			/* JVM initialization failed for some reason. Destroy
+			 * the VM if it exists. Perhaps the user will try
+			 * fixing the pljava.classpath and make a new attempt.
+			 */
+			_destroyJavaVM(0, 0);
+			initstage = IS_MISC_ONCE_DONE;
+			/* We can't stay here...
+			 */
+			if ( tolerant )
+				PG_TRY_RETURN_VOID;
+			PG_RE_THROW();
+		}
+		PG_END_TRY();
+		initstage = IS_COMPLETE;
+
+	case IS_COMPLETE:
+		return;
+
+	default:
+		ereport(ERROR, (
+			errmsg("PL/Java startup failed"),
+			errdetail("unexpected stage in startup sequence")));
+	}
+
+check_tolerant:
+	if ( !tolerant ) {
+		ereport(ERROR, (
+			errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
+			errmsg("PL/Java used before its startup complete")));
+	}
+}
 
 void _PG_init()
 {
-	void *libjvm_handle;
-
-	registerGUCOptions();
-	
-	if ( NULL == libjvmlocation )
-	{
-		ereport(ERROR, (errcode(ERRCODE_CONFIG_FILE_ERROR),
-			errmsg("could not load Java virtual machine"),
-			errdetail("location of libjvm is not configured"),
-			errhint("SET pljava.libjvm_location TO the correct path "
-					"to the libjvm (.so or .dll, etc.)")));
-	}
-
-	libjvm_handle = pg_dlopen(libjvmlocation);
-
-	if ( NULL == libjvm_handle )
-	{
-		ereport(ERROR, (errcode_for_file_access(),
-			errmsg("could not load Java virtual machine"),
-			errdetail("%s", (char *)pg_dlerror()),
-			errhint("SET pljava.libjvm_location TO the correct path "
-					"to the libjvm (.so or .dll, etc.)")));
-	}
-
-	pljava_createvm =
-		(jint JNICALL (*)(JavaVM **, void **, void *))
-		pg_dlsym(libjvm_handle, "JNI_CreateJavaVM");
-
-	if ( NULL == pljava_createvm )
-	{
-		char *dle = (pre_format_elog_string(errno, TEXTDOMAIN),
-			format_elog_string("%s", (char *)pg_dlerror()));
-		pg_dlclose(libjvm_handle);
-		ereport(ERROR, (errcode(ERRCODE_SYSTEM_ERROR),
-			errmsg("could not link Java virtual machine"),
-			errdetail("%s", dle),
-			errhint("Is the file named in pljava.libjvm_location "
-					"the right one?")));
-	}
+	initsequencer( initstage, true);
 }
 
 static void initPLJavaClasses(void)
@@ -491,12 +646,6 @@ static void _destroyJavaVM(int status, Datum dummy)
 	}
 }
 
-typedef struct {
-	JavaVMOption* options;
-	unsigned int  size;
-	unsigned int  capacity;
-} JVMOptList;
-
 static void JVMOptList_init(JVMOptList* jol)
 {
 	jol->options  = (JavaVMOption*)palloc(10 * sizeof(JavaVMOption));
@@ -644,49 +793,11 @@ static void checkIntTimeType(void)
 	elog(DEBUG1, integerDateTimes ? "Using integer_datetimes" : "Not using integer_datetimes");
 }
 
-static bool s_firstTimeInit = true;
-
-static void initializeJavaVM(void)
+static jint initializeJavaVM(JVMOptList *optList)
 {
-	jboolean jstat;
+	jint jstat;
 	JavaVMInitArgs vm_args;
-	JVMOptList optList;
 
-	JVMOptList_init(&optList);
-
-	if(s_firstTimeInit)
-	{
-		s_firstTimeInit = false;
-		s_javaLogLevel = INFO;
-
-		checkIntTimeType();
-		HashMap_initialize();	
-	}
-
-#ifdef PLJAVA_DEBUG
-	/* Hard setting for debug. Don't forget to recompile...
-	 */
-	pljavaDebug = 1;
-#endif
-
-	addUserJVMOptions(&optList);
-	effectiveClassPath = getClassPath("-Djava.class.path=");
-	if(effectiveClassPath != 0)
-	{
-		JVMOptList_add(&optList, effectiveClassPath, 0, true);
-	}
-
-	/**
-	 * As stipulated by JRT-2003
-	 */
-	JVMOptList_add(&optList, 
-		"-Dsqlj.defaultconnection=jdbc:default:connection",
-		0, true);
-
-	JVMOptList_add(&optList, "vfprintf", (void*)my_vfprintf, true);
-#ifndef GCJ
-	JVMOptList_add(&optList, "-Xrs", 0, true);
-#endif
 	if(pljavaDebug)
 	{
 		elog(INFO, "Backend pid = %d. Attach the debugger and set pljavaDebug to false to continue", getpid());
@@ -694,8 +805,8 @@ static void initializeJavaVM(void)
 			pg_usleep(1000000L);
 	}
 
-	vm_args.nOptions = optList.size;
-	vm_args.options  = optList.options;
+	vm_args.nOptions = optList->size;
+	vm_args.options  = optList->options;
 	vm_args.version  = JNI_VERSION_1_4;
 	vm_args.ignoreUnrecognized = JNI_FALSE;
 
@@ -709,23 +820,9 @@ static void initializeJavaVM(void)
 		JNI_exceptionClear();
 		jstat = JNI_ERR;
 	}
-	JVMOptList_delete(&optList);
+	JVMOptList_delete(optList);
 
-	if(jstat != JNI_OK)
-		ereport(ERROR, (errmsg("Failed to create Java VM")));
-
-#if !defined(WIN32)
-	pqsignal(SIGINT,  pljavaStatementCancelHandler);
-	pqsignal(SIGTERM, pljavaDieHandler);
-	pqsignal(SIGQUIT, pljavaQuickDieHandler);
-#endif
-	elog(DEBUG1, "JavaVM created");
-
-	/* Register an on_proc_exit handler that destroys the VM
-	 */
-	on_proc_exit(_destroyJavaVM, 0);
-	initPLJavaClasses();
-	initJavaSession();
+	return jstat;
 }
 
 static void registerGUCOptions(void)
@@ -882,29 +979,9 @@ static Datum internalCallHandler(bool trusted, PG_FUNCTION_ARGS)
 	Invocation ctx;
 	Datum retval = 0;
 
-	if(s_javaVM == 0)
+	if ( IS_COMPLETE != initstage )
 	{
-		Invocation_pushBootContext(&ctx);
-		PG_TRY();
-		{
-			initializeJavaVM();
-			Invocation_popBootContext();
-		}
-		PG_CATCH();
-		{
-			Invocation_popBootContext();
-
-			/* JVM initialization failed for some reason. Destroy
-			 * the VM if it exists. Perhaps the user will try
-			 * fixing the pljava.classpath and make a new attempt.
-			 */
-			_destroyJavaVM(0, 0);			
-
-			/* We can't stay here...
-			 */
-			PG_RE_THROW();
-		}
-		PG_END_TRY();
+		initsequencer( initstage, false);
 
 		/* Force initial setting
  		 */

--- a/pljava-so/src/main/c/Backend.c
+++ b/pljava-so/src/main/c/Backend.c
@@ -370,7 +370,7 @@ static void initsequencer(enum initstage is, bool tolerant)
 
 	case IS_CAND_JVMOPENED:
 		pljava_createvm =
-			(jint JNICALL (*)(JavaVM **, void **, void *))
+			(jint (JNICALL *)(JavaVM **, void **, void *))
 			pg_dlsym(libjvm_handle, "JNI_CreateJavaVM");
 		if ( NULL == pljava_createvm )
 		{

--- a/pljava-so/src/main/c/Backend.c
+++ b/pljava-so/src/main/c/Backend.c
@@ -75,20 +75,6 @@ PG_MODULE_MAGIC;
 
 extern PLJAVADLLEXPORT void _PG_init(void);
 
-#ifdef PG_GETCONFIGOPTION
-#error The macro PG_GETCONFIGOPTION needs to be renamed.
-#endif
-
-#if ( PGSQL_MAJOR_VER > 8 )
-#if ( PGSQL_MINOR_VER > 0 )
-#define PG_GETCONFIGOPTION(key) GetConfigOption(key, false, true)
-#else
-#define PG_GETCONFIGOPTION(key) GetConfigOption(key, true)
-#endif
-#else
-#define PG_GETCONFIGOPTION(key) GetConfigOption(key)
-#endif
-
 #define LOCAL_REFERENCE_COUNT 128
 
 jlong mainThreadId;

--- a/pljava-so/src/main/c/Function.c
+++ b/pljava-so/src/main/c/Function.c
@@ -118,6 +118,14 @@ struct Function_
 	} func;
 };
 
+/*
+ * Not fussing with initializer, relying on readOnly being false by C static
+ * initial default.
+ */
+static struct Function_ s_initWriter;
+
+Function Function_INIT_WRITER = &s_initWriter;
+
 typedef struct ParseResultData
 {
 	char* buffer;	/* The buffer to pfree once we are done */

--- a/pljava-so/src/main/c/InstallHelper.c
+++ b/pljava-so/src/main/c/InstallHelper.c
@@ -36,13 +36,17 @@
 #include "pljava/PgObject.h"
 #include "pljava/type/String.h"
 
+/*
+ * CppAsString2 first appears in PG8.4.  Once the compatibility target reaches
+ * 8.4, this fallback will not be needed.
+ */
+#ifndef CppAsString2
+#define CppAsString2(x) CppAsString(x)
+#endif
+
 #ifndef PLJAVA_SO_VERSION
 #error "PLJAVA_SO_VERSION needs to be defined to compile this file."
 #else
-/*
- * CppAsString2 first appears in PG8.4.  IF that's a problem, the definition
- * is really simple.
- */
 #define SO_VERSION_STRING CppAsString2(PLJAVA_SO_VERSION)
 #endif
 

--- a/pljava-so/src/main/c/InstallHelper.c
+++ b/pljava-so/src/main/c/InstallHelper.c
@@ -30,6 +30,7 @@
 #endif
 
 #include "pljava/InstallHelper.h"
+#include "pljava/Function.h"
 #include "pljava/Invocation.h"
 #include "pljava/JNICalls.h"
 #include "pljava/PgObject.h"
@@ -47,6 +48,7 @@
 
 static jclass s_InstallHelper_class;
 static jmethodID s_InstallHelper_hello;
+static jmethodID s_InstallHelper_groundwork;
 
 char const *pljavaLoadPath = NULL;
 
@@ -151,6 +153,26 @@ char *InstallHelper_hello()
 	return hiC;
 }
 
+void InstallHelper_groundwork()
+{
+	Invocation ctx;
+	Invocation_pushInvocation(&ctx, false);
+	ctx.function = Function_INIT_WRITER;
+	PG_TRY();
+	{
+		jstring pljlp = String_createJavaStringFromNTS(pljavaLoadPath);
+		JNI_callStaticObjectMethod(
+			s_InstallHelper_class, s_InstallHelper_groundwork, pljlp);
+		Invocation_popInvocation(false);
+	}
+	PG_CATCH();
+	{
+		Invocation_popInvocation(true);
+		PG_RE_THROW();
+	}
+	PG_END_TRY();
+}
+
 void InstallHelper_initialize()
 {
 	s_InstallHelper_class = (jclass)JNI_newGlobalRef(PgObject_getJavaClass(
@@ -160,4 +182,6 @@ void InstallHelper_initialize()
 		"(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;"
 		"Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;"
 		"Ljava/lang/String;)Ljava/lang/String;");
+	s_InstallHelper_groundwork = PgObject_getStaticJavaMethod(
+		s_InstallHelper_class, "groundwork", "(Ljava/lang/String;)V");
 }

--- a/pljava-so/src/main/c/InstallHelper.c
+++ b/pljava-so/src/main/c/InstallHelper.c
@@ -132,6 +132,30 @@ char *pljavaFnOidToLibPath(Oid myOid)
 	return result;
 }
 
+char const *InstallHelper_defaultClassPath(char *pathbuf)
+{
+	char * const pbend = pathbuf + MAXPGPATH;
+	char *pbp = pathbuf;
+	size_t remaining;
+	size_t verlen = strlen(SO_VERSION_STRING);
+
+	get_share_path(my_exec_path, pathbuf);
+	join_path_components(pathbuf, pathbuf, "pljava");
+	join_path_components(pathbuf, pathbuf, "pljava-");
+
+	for ( ; pbp < pbend && '\0' != *pbp ; ++ pbp )
+		;
+	if ( pbend == pbp )
+		return NULL;
+
+	remaining = pbend - pbp;
+	if ( remaining < verlen + 5 )
+		return NULL;
+
+	snprintf(pbp, remaining, "%s.jar", SO_VERSION_STRING);
+	return pathbuf;
+}
+
 char *InstallHelper_hello()
 {
 	char pathbuf[MAXPGPATH];

--- a/pljava-so/src/main/c/InstallHelper.c
+++ b/pljava-so/src/main/c/InstallHelper.c
@@ -128,7 +128,9 @@ char *InstallHelper_hello()
 	jstring user = String_createJavaStringFromNTS(MyProcPort->user_name);
 	jstring dbname = String_createJavaStringFromNTS(MyProcPort->database_name);
 	jstring ddir = String_createJavaStringFromNTS(DataDir);
-	jstring ldir = String_createJavaStringFromNTS(pkglib_path);
+
+	get_pkglib_path(my_exec_path, pathbuf);
+	jstring ldir = String_createJavaStringFromNTS(pathbuf);
 
 	get_share_path(my_exec_path, pathbuf);
 	jstring sdir = String_createJavaStringFromNTS(pathbuf);

--- a/pljava-so/src/main/c/InstallHelper.c
+++ b/pljava-so/src/main/c/InstallHelper.c
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2015 Tada AB and other contributors, as listed below.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Chapman Flack
+ */
+#include <postgres.h>
+#if PGSQL_MAJOR_VER > 9 || PGSQL_MAJOR_VER == 9 && PGSQL_MINOR_VER >= 3
+#include <access/htup_details.h>
+#else
+#include <access/htup.h>
+#endif
+#include <catalog/pg_language.h>
+#include <catalog/pg_proc.h>
+#include <commands/portalcmds.h>
+#include <miscadmin.h>
+#include <libpq/libpq-be.h>
+#include <tcop/pquery.h>
+#include <utils/builtins.h>
+#include <utils/memutils.h>
+#include <utils/syscache.h>
+
+#ifndef SearchSysCache1
+#define SearchSysCache1(cid, k1) SearchSysCache(cid, k1, 0, 0, 0)
+#endif
+
+#include "pljava/InstallHelper.h"
+
+char const *pljavaLoadPath = NULL;
+
+Oid pljavaTrustedOid = InvalidOid;
+
+Oid pljavaUntrustedOid = InvalidOid;
+
+char *pljavaDbName()
+{
+	return MyProcPort->database_name;
+}
+
+void pljavaCheckLoadPath()
+{
+	if ( NULL == ActivePortal )
+		return;
+	List *l = ActivePortal->stmts;
+	if ( NULL == l )
+		return;
+	if ( 1 < list_length( l) )
+		elog(DEBUG1, "ActivePortal lists %d statements", list_length( l));
+	Node *ut = (Node *)linitial(l);
+	if ( NULL == ut )
+	{
+		elog(DEBUG1, "got null for first statement from ActivePortal");
+		return;
+	}
+	if ( T_LoadStmt != nodeTag(ut) )
+		return;
+	LoadStmt *ls = (LoadStmt *)ut;
+	if ( NULL == ls->filename )
+	{
+		elog(DEBUG1, "got null for a LOAD statement's filename");
+		return;
+	}
+	pljavaLoadPath =
+		(char const *)MemoryContextStrdup( TopMemoryContext, ls->filename);
+}
+
+char *pljavaFnOidToLibPath(Oid myOid)
+{
+	bool isnull;
+	char *result;
+	HeapTuple myPT = SearchSysCache1(PROCOID, ObjectIdGetDatum(myOid));
+	if (!HeapTupleIsValid(myPT))
+		elog(ERROR, "cache lookup failed for function %u", myOid);
+	Form_pg_proc myPS = (Form_pg_proc) GETSTRUCT(myPT);
+	Oid langId = myPS->prolang;
+	ReleaseSysCache(myPT);
+	HeapTuple langTup = SearchSysCache1(LANGOID, ObjectIdGetDatum(langId));
+	if (!HeapTupleIsValid(langTup))
+		elog(ERROR, "cache lookup failed for language %u", langId);
+	Form_pg_language langSt = (Form_pg_language) GETSTRUCT(langTup);
+	Oid handlerOid = langSt->lanplcallfoid;
+	ReleaseSysCache(langTup);
+	HeapTuple handlerPT =
+		SearchSysCache1(PROCOID, ObjectIdGetDatum(handlerOid));
+	if (!HeapTupleIsValid(handlerPT))
+		elog(ERROR, "cache lookup failed for function %u", handlerOid);
+	Datum probinattr =
+		SysCacheGetAttr(PROCOID, handlerPT, Anum_pg_proc_probin, &isnull);
+	if ( isnull )
+		elog(ERROR, "null probin for C function %u", handlerOid);
+	char *probinstring = TextDatumGetCString(probinattr);
+	result = pstrdup( probinstring);
+	pfree(probinstring);
+	ReleaseSysCache(handlerPT);
+	return result;
+}

--- a/pljava-so/src/main/c/JNICalls.c
+++ b/pljava-so/src/main/c/JNICalls.c
@@ -14,7 +14,7 @@
 #include "pljava/type/String.h"
 
 JNIEnv* jniEnv;
-jint JNICALL (*pljava_createvm)(JavaVM **, void **, void *);
+jint (JNICALL *pljava_createvm)(JavaVM **, void **, void *);
 
 /* MSVC will not allow redefinition WITH dllimport after seeing
  * the definition in guc.h that does not include dllimport.

--- a/pljava-so/src/main/c/JNICalls.c
+++ b/pljava-so/src/main/c/JNICalls.c
@@ -14,6 +14,7 @@
 #include "pljava/type/String.h"
 
 JNIEnv* jniEnv;
+jint JNICALL (*pljava_createvm)(JavaVM **, void **, void *);
 
 /* MSVC will not allow redefinition WITH dllimport after seeing
  * the definition in guc.h that does not include dllimport.
@@ -563,7 +564,7 @@ void JNI_callVoidMethodLockedV(jobject object, jmethodID methodID, va_list args)
 jint JNI_createVM(JavaVM** javaVM, JavaVMInitArgs* vmArgs)
 {
 	JNIEnv* env = 0;
-	jint jstat = JNI_CreateJavaVM(javaVM, (void **)&env, vmArgs);
+	jint jstat = pljava_createvm(javaVM, (void **)&env, vmArgs);
 	if(jstat == JNI_OK)
 		jniEnv = env;
 	return jstat;

--- a/pljava-so/src/main/c/type/AclId.c
+++ b/pljava-so/src/main/c/type/AclId.c
@@ -44,9 +44,9 @@ void AclId_initialize(void)
 	  	Java_org_postgresql_pljava_internal_AclId__1getUser
 		},
 		{
-		"_getSessionUser",
+		"_getOuterUser",
 		"()Lorg/postgresql/pljava/internal/AclId;",
-		Java_org_postgresql_pljava_internal_AclId__1getSessionUser
+		Java_org_postgresql_pljava_internal_AclId__1getOuterUser
 		},
 		{
 		"_fromName",
@@ -104,21 +104,21 @@ Java_org_postgresql_pljava_internal_AclId__1getUser(JNIEnv* env, jclass clazz)
 
 /*
  * Class:     org_postgresql_pljava_internal_AclId
- * Method:    _getSessionUser
+ * Method:    _getOuterUser
  * Signature: ()Lorg/postgresql/pljava/internal/AclId;
  */
 JNIEXPORT jobject JNICALL
-Java_org_postgresql_pljava_internal_AclId__1getSessionUser(JNIEnv* env, jclass clazz)
+Java_org_postgresql_pljava_internal_AclId__1getOuterUser(JNIEnv* env, jclass clazz)
 {
 	jobject result = 0;
 	BEGIN_NATIVE
 	PG_TRY();
 	{
-		result = AclId_create(GetSessionUserId());
+		result = AclId_create(GetOuterUserId());
 	}
 	PG_CATCH();
 	{
-		Exception_throw_ERROR("GetSessionUserId");
+		Exception_throw_ERROR("GetOuterUserId");
 	}
 	PG_END_TRY();
 	END_NATIVE

--- a/pljava-so/src/main/include/fallback/win32/dynloader.h
+++ b/pljava-so/src/main/include/fallback/win32/dynloader.h
@@ -1,0 +1,20 @@
+/*
+ * Copied from postgresql.git at 927d61eeff78363ea3938c818d07e511ebaf75cf
+ * src/backend/port/dynloader/win32.h
+ */
+#ifndef PORT_PROTOS_H
+#define PORT_PROTOS_H
+
+#include "utils/dynamic_loader.h"	/* pgrminclude ignore */
+
+#define pg_dlopen(f)	dlopen((f), 1)
+#define pg_dlsym	dlsym
+#define pg_dlclose	dlclose
+#define pg_dlerror	dlerror
+
+char	   *dlerror(void);
+int	    dlclose(void *handle);
+void	   *dlsym(void *handle, const char *symbol);
+void	   *dlopen(const char *path, int mode);
+
+#endif   /* PORT_PROTOS_H */

--- a/pljava-so/src/main/include/pljava/Backend.h
+++ b/pljava-so/src/main/include/pljava/Backend.h
@@ -27,6 +27,18 @@ void Backend_setJavaSecurity(bool trusted);
 
 int Backend_setJavaLogLevel(int logLevel);
 
+#ifdef PG_GETCONFIGOPTION
+#error The macro PG_GETCONFIGOPTION needs to be renamed.
+#endif
+
+#if PGSQL_MAJOR_VER > 9  ||  PGSQL_MAJOR_VER == 9 && PGSQL_MINOR_VER > 0
+#define PG_GETCONFIGOPTION(key) GetConfigOption(key, false, true)
+#elif PGSQL_MAJOR_VER == 9
+#define PG_GETCONFIGOPTION(key) GetConfigOption(key, true)
+#else
+#define PG_GETCONFIGOPTION(key) GetConfigOption(key)
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/pljava-so/src/main/include/pljava/Function.h
+++ b/pljava-so/src/main/include/pljava/Function.h
@@ -72,6 +72,11 @@ extern jobject Function_getTypeMap(Function self);
  */
 extern bool Function_isCurrentReadOnly(void);
 
+/*
+ * A nameless Function singleton with the property ! isCurrentReadOnly()
+ */
+extern Function Function_INIT_WRITER;
+
 #ifdef __cplusplus
 }
 #endif

--- a/pljava-so/src/main/include/pljava/InstallHelper.h
+++ b/pljava-so/src/main/include/pljava/InstallHelper.h
@@ -42,3 +42,7 @@ extern Oid pljavaTrustedOid, pljavaUntrustedOid;
  * Return the name of the current database, from MyProcPort ... don't free it.
  */
 extern char *pljavaDbName();
+
+extern char *InstallHelper_hello();
+
+extern void InstallHelper_initialize();

--- a/pljava-so/src/main/include/pljava/InstallHelper.h
+++ b/pljava-so/src/main/include/pljava/InstallHelper.h
@@ -45,4 +45,6 @@ extern char *pljavaDbName();
 
 extern char *InstallHelper_hello();
 
+extern void InstallHelper_groundwork();
+
 extern void InstallHelper_initialize();

--- a/pljava-so/src/main/include/pljava/InstallHelper.h
+++ b/pljava-so/src/main/include/pljava/InstallHelper.h
@@ -44,7 +44,7 @@ extern Oid pljavaTrustedOid, pljavaUntrustedOid;
 extern char *pljavaDbName();
 
 /*
- * Construct a default for pljava.classpath ($sharedir/java/pljava-$VER.jar)
+ * Construct a default for pljava.classpath ($sharedir/pljava/pljava-$VER.jar)
  * in pathbuf (which must have length at least MAXPGPATH), and return pathbuf,
  * or NULL if the constructed path would not fit.
  */

--- a/pljava-so/src/main/include/pljava/InstallHelper.h
+++ b/pljava-so/src/main/include/pljava/InstallHelper.h
@@ -43,6 +43,13 @@ extern Oid pljavaTrustedOid, pljavaUntrustedOid;
  */
 extern char *pljavaDbName();
 
+/*
+ * Construct a default for pljava.classpath ($sharedir/java/pljava-$VER.jar)
+ * in pathbuf (which must have length at least MAXPGPATH), and return pathbuf,
+ * or NULL if the constructed path would not fit.
+ */
+extern char const *InstallHelper_defaultClassPath(char *);
+
 extern char *InstallHelper_hello();
 
 extern void InstallHelper_groundwork();

--- a/pljava-so/src/main/include/pljava/InstallHelper.h
+++ b/pljava-so/src/main/include/pljava/InstallHelper.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2015 Tada AB and other contributors, as listed below.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Chapman Flack
+ */
+
+/*
+ * InstallHelper is a place to put functions that are useful for improving the
+ * user experience in first setting up PL/Java, but may also involve diving
+ * deeper into PostgreSQL internals than is common for PL/Java (just to dig out
+ * values that aren't more directly exposed), so those internal .h files can be
+ * included only in InstallHelper.c and will not clutter most other code.
+ */
+
+/*
+ * If a LoadStatement is what the current ActivePortal is executing, then save
+ * a copy of the pathname being loaded (pstrdup'd in TopMemoryContext) in
+ * pljavaLoadPath, otherwise leave that variable unchanged/NULL. Nothing like
+ * this would be necessary if PostgreSQL called _PG_init functions with the
+ * path of the library being loaded.
+ */
+extern void pljavaCheckLoadPath();
+
+extern char const *pljavaLoadPath;
+
+/*
+ * Another way of getting the library path: if invoked by the fmgr before
+ * initialization is complete, save the last function Oid seen (trusted or
+ * untrusted) ... can be used later to get the library path if needed.
+ */
+extern char *pljavaFnOidToLibPath(Oid fn);
+
+extern Oid pljavaTrustedOid, pljavaUntrustedOid;
+
+/*
+ * Return the name of the current database, from MyProcPort ... don't free it.
+ */
+extern char *pljavaDbName();

--- a/pljava-so/src/main/include/pljava/JNICalls.h
+++ b/pljava-so/src/main/include/pljava/JNICalls.h
@@ -16,7 +16,7 @@ extern "C" {
 #endif
 
 /* only here to be filled in by Backend and used here */
-extern jint JNICALL (*pljava_createvm)(JavaVM **, void **, void *);
+extern jint (JNICALL *pljava_createvm)(JavaVM **, void **, void *);
 
 #define BEGIN_NATIVE_NO_ERRCHECK if(beginNativeNoErrCheck(env)) {
 #define BEGIN_NATIVE if(beginNative(env)) {

--- a/pljava-so/src/main/include/pljava/JNICalls.h
+++ b/pljava-so/src/main/include/pljava/JNICalls.h
@@ -15,6 +15,9 @@
 extern "C" {
 #endif
 
+/* only here to be filled in by Backend and used here */
+extern jint JNICALL (*pljava_createvm)(JavaVM **, void **, void *);
+
 #define BEGIN_NATIVE_NO_ERRCHECK if(beginNativeNoErrCheck(env)) {
 #define BEGIN_NATIVE if(beginNative(env)) {
 #define END_NATIVE JNI_setEnv(0); }

--- a/pljava/pom.xml
+++ b/pljava/pom.xml
@@ -44,6 +44,92 @@
 					</execution>
 				</executions>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<configuration>
+					<archive>
+						<manifestSections>
+							<manifestSection>
+								<name>org/postgresql/pljava/</name>
+								<!--
+								  This section totally doesn't belong here - it
+								  is crazy that the shade plugin cannot copy it
+								  from the manifest of the API jar being shaded
+								  in - even the manifest transformer is no help.
+								-->
+								<manifestEntries>
+									<Implementation-Title>
+										PL/Java API
+									</Implementation-Title>
+									<Implementation-Version>
+										${project.dependencies[0].version}
+									</Implementation-Version>
+									<Implementation-Vendor>
+										${project.organization.name}
+									</Implementation-Vendor>
+								</manifestEntries>
+							</manifestSection>
+							<manifestSection>
+								<name>org/postgresql/pljava/internal/</name>
+								<manifestEntries>
+									<Implementation-Title>
+										${project.name}
+									</Implementation-Title>
+									<Implementation-Version>
+										${project.version}
+									</Implementation-Version>
+									<Implementation-Vendor>
+										${project.organization.name}
+									</Implementation-Vendor>
+								</manifestEntries>
+							</manifestSection>
+							<manifestSection>
+								<name>org/postgresql/pljava/jdbc/</name>
+								<manifestEntries>
+									<Implementation-Title>
+										${project.name}
+									</Implementation-Title>
+									<Implementation-Version>
+										${project.version}
+									</Implementation-Version>
+									<Implementation-Vendor>
+										${project.organization.name}
+									</Implementation-Vendor>
+								</manifestEntries>
+							</manifestSection>
+							<manifestSection>
+								<name>org/postgresql/pljava/management/</name>
+								<manifestEntries>
+									<Implementation-Title>
+										${project.name}
+									</Implementation-Title>
+									<Implementation-Version>
+										${project.version}
+									</Implementation-Version>
+									<Implementation-Vendor>
+										${project.organization.name}
+									</Implementation-Vendor>
+								</manifestEntries>
+							</manifestSection>
+							<manifestSection>
+								<name>org/postgresql/pljava/sqlj/</name>
+								<manifestEntries>
+									<Implementation-Title>
+										${project.name}
+									</Implementation-Title>
+									<Implementation-Version>
+										${project.version}
+									</Implementation-Version>
+									<Implementation-Vendor>
+										${project.organization.name}
+									</Implementation-Vendor>
+								</manifestEntries>
+							</manifestSection>
+						</manifestSections>
+					</archive>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/pljava/src/main/java/org/postgresql/pljava/internal/InstallHelper.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/InstallHelper.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2015 Tada AB and other contributors, as listed below.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Chapman Flack
+ */
+package org.postgresql.pljava.internal;
+
+/**
+ * Group of methods intended to streamline the PL/Java installation/startup
+ * experience.
+ *
+ * @author Chapman Flack
+ */
+public class InstallHelper
+{
+	private static void setPropertyIfNull( String property, String value)
+	{
+		if ( null == System.getProperty( property) )
+			System.setProperty( property, value);
+	}
+
+	public static String hello(
+		String nativeVer, String user, String dbname,
+		String datadir, String libdir, String sharedir, String etcdir)
+	{
+		String implVersion =
+			InstallHelper.class.getPackage().getImplementationVersion();
+		System.setProperty( "user.name", user);
+		setPropertyIfNull( "java.awt.headless", "true");
+		setPropertyIfNull( "org.postgresql.database", dbname);
+		setPropertyIfNull( "org.postgresql.datadir", datadir);
+		setPropertyIfNull( "org.postgresql.libdir", libdir);
+		setPropertyIfNull( "org.postgresql.sharedir", sharedir);
+		setPropertyIfNull( "org.postgresql.etcdir", etcdir);
+		setPropertyIfNull( "org.postgresql.pljava.version", implVersion);
+		setPropertyIfNull( "org.postgresql.pljava.native.version", nativeVer);
+		setPropertyIfNull( "org.postgresql.version",
+			Backend.getConfigOption( "server_version"));
+		/*
+		 * As stipulated by JRT-2003
+		 */
+		setPropertyIfNull( "sqlj.defaultconnection", "jdbc:default:connection");
+
+		String jreName = System.getProperty( "java.runtime.name");
+		String jreVer = System.getProperty( "java.runtime.version");
+
+		if ( null == jreName || null == jreVer )
+		{
+			jreName = System.getProperty( "java.vendor");
+			jreVer = System.getProperty( "java.version");
+		}
+
+		String vmName = System.getProperty( "java.vm.name");
+		String vmVer = System.getProperty( "java.vm.version");
+		String vmInfo = System.getProperty( "java.vm.info");
+
+		StringBuilder sb = new StringBuilder();
+		sb.append( "PL/Java native code (").append( nativeVer).append( ")\n");
+		sb.append( "PL/Java common code (").append( implVersion).append( ")\n");
+		sb.append( jreName).append( " (").append( jreVer).append( ")\n");
+		sb.append( vmName).append( " (").append( vmVer);
+		if ( null != vmInfo )
+			sb.append( ", ").append( vmInfo);
+		sb.append( ')');
+		return sb.toString();
+	}
+}

--- a/pljava/src/main/java/org/postgresql/pljava/internal/InstallHelper.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/InstallHelper.java
@@ -49,6 +49,12 @@ public class InstallHelper
 	{
 		String implVersion =
 			InstallHelper.class.getPackage().getImplementationVersion();
+		/*
+		 * visualvm.display.name is not really used as a property. jvisualvm
+		 * picks it up by looking for -Dvisualvm.display.name=something in the
+		 * JVM invocation arguments, not by looking at actual properties.
+		 */
+		System.clearProperty( "visualvm.display.name");
 		System.setProperty( "user.name", user);
 		setPropertyIfNull( "java.awt.headless", "true");
 		setPropertyIfNull( "org.postgresql.database", dbname);

--- a/pljava/src/main/java/org/postgresql/pljava/internal/InstallHelper.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/InstallHelper.java
@@ -13,12 +13,17 @@ package org.postgresql.pljava.internal;
 
 import java.io.InputStream;
 import java.sql.Connection;
+import java.sql.DatabaseMetaData;
 import java.sql.DriverManager;
+import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.SQLNonTransientException;
 import java.sql.Savepoint;
 import java.sql.Statement;
 import java.text.ParseException;
 import java.util.Scanner;
+
+import static java.sql.Types.VARCHAR;
 
 import org.postgresql.pljava.jdbc.SQLUtils;
 import org.postgresql.pljava.management.SQLDeploymentDescriptor;
@@ -177,12 +182,172 @@ public class InstallHelper
 		}
 	}
 
+	/**
+	 * Execute the deployment descriptor for PL/Java itself, creating the
+	 * expected tables, functions, etc. Will be skipped if tables conforming
+	 * to the currently expected schema already seem to be there. If an earlier
+	 * schema variant is detected, attempt to migrate to the current one.
+	 */
 	private static void deployment( Connection c, Statement s)
 	throws SQLException, ParseException
 	{
+		SchemaVariant sv = recognizeSchema( c);
+
+		if ( currentSchema == sv )
+			return; // assume (optimistically) that means there's nothing to do
+
+		if ( null != sv )
+		{
+			currentSchema.migrateFrom( sv, c, s);
+			return;
+		}
+
 		InputStream is = InstallHelper.class.getResourceAsStream("/pljava.ddr");
 		String raw = new Scanner(is, "utf-8").useDelimiter("\\A").next();
 		SQLDeploymentDescriptor sdd = new SQLDeploymentDescriptor(raw);
 		sdd.install(c);
+	}
+
+	/**
+	 * Detect an existing PL/Java sqlj schema. Tests for changes between schema
+	 * variants that have appeared in PL/Java's git history and will return a
+	 * correct result if the schema actually is any of those, but does no
+	 * further verification. So, a known SchemaVariant could be returned for a
+	 * messed up schema that never appeared in the git history, if it happened
+	 * to match on the tested parts; likewise, a null return may not necessarily
+	 * mean nothing is there, only that whatever is there didn't match the
+	 * tests for any known variant.
+	 */
+	private static SchemaVariant recognizeSchema( Connection c)
+	throws SQLException
+	{
+		DatabaseMetaData md = c.getMetaData();
+		ResultSet rs = md.getColumns( null, "sqlj", "jar_descriptor", null);
+		boolean seen = rs.next();
+		rs.close();
+		if ( seen )
+			return SchemaVariant.UNREL20130301b;
+
+		rs = md.getColumns( null, "sqlj", "jar_descriptors", null);
+		seen = rs.next();
+		rs.close();
+		if ( seen )
+			return SchemaVariant.UNREL20130301a;
+
+		rs = md.getColumns( null, "sqlj", "jar_repository", "jarmanifest");
+		seen = rs.next();
+		rs.close();
+		if ( seen )
+			return SchemaVariant.REL_1_3_0;
+
+		rs = md.getColumns( null, "sqlj", "typemap_entry", null);
+		seen = rs.next();
+		rs.close();
+		if ( seen )
+			return SchemaVariant.UNREL20060212;
+
+		rs = md.getColumns( null, "sqlj", "jar_repository", "jarowner");
+		if ( rs.next() )
+		{
+			int t = rs.getInt("DATA_TYPE");
+			rs.close();
+			if ( VARCHAR == t )
+				return SchemaVariant.UNREL20060125;
+			return SchemaVariant.REL_1_1_0;
+		}
+		rs.close();
+
+		rs = md.getColumns( null, "sqlj", "jar_repository", "deploymentdesc");
+		seen = rs.next();
+		rs.close();
+		if ( seen )
+			return SchemaVariant.REL_1_0_0;
+
+		rs = md.getColumns( null, "sqlj", "jar_entry", null);
+		seen = rs.next();
+		rs.close();
+		if ( seen )
+			return SchemaVariant.UNREL20040121;
+
+		rs = md.getColumns( null, "sqlj", "jar_repository", "jarimage");
+		seen = rs.next();
+		rs.close();
+		if ( seen )
+			return SchemaVariant.UNREL20040120;
+
+		return null;
+	}
+
+	/**
+	 * The SchemaVariant that is used and expected by the current code.
+	 * Define additional variants as the schema evolves, and keep this field
+	 * up to date.
+	 */
+	private static final SchemaVariant currentSchema =
+		SchemaVariant.UNREL20130301b;
+
+	private enum SchemaVariant
+	{
+		UNREL20130301b ("c51cffa34acd5a228325143ec29563174891a873")
+		{
+			@Override
+			void migrateFrom( SchemaVariant sv, Connection c, Statement s)
+			throws SQLException
+			{
+				switch ( sv )
+				{
+				case REL_1_3_0:
+					s.execute(
+						"CREATE TABLE sqlj.jar_descriptor " +
+						"(jarId, ordinal, entryId) AS SELECT " +
+						"CAST(jarId AS INT), CAST(0 AS INT2), " +
+						"deploymentDesc FROM sqlj.jar_repository " +
+						"WHERE deploymentDesc IS NOT NULL");
+					s.execute(
+						"ALTER TABLE sqlj.jar_repository " +
+						"DROP deploymentDesc");
+					s.execute(
+						"ALTER TABLE sqlj.jar_descriptor " +
+						"ADD FOREIGN KEY (jarId) " +
+						"REFERENCES sqlj.jar_repository ON DELETE CASCADE, " +
+						"ADD PRIMARY KEY (jarId, ordinal), " +
+						"ALTER COLUMN entryId SET NOT NULL, " +
+						"ADD FOREIGN KEY (entryId) REFERENCES sqlj.jar_entry " +
+						"ON DELETE CASCADE");
+					s.execute(
+						"GRANT SELECT ON sqlj.jar_descriptor TO PUBLIC");
+					break;
+				case UNREL20130301a:
+					s.execute(
+						"ALTER TABLE sqlj.jar_descriptors " +
+						"RENAME TO jar_descriptor");
+					break;
+				default:
+					super.migrateFrom( sv, c, s);
+				}
+			}
+		},
+		UNREL20130301a ("624d78ca98d80ff2ded215eeca92035da5126bc0"),
+		REL_1_3_0      ("d23804a7e1154de58181a8aa48bfbbb2c8adf68b"),
+		UNREL20060212  ("671eadf7f13a7996af31f1936946bf6677ecdc73"),
+		UNREL20060125  ("8afd33ccb8a2a56e92dee9c9ced81185ff0bb34d"),
+		REL_1_1_0      ("039db412fa91a23b67ceb8d90d30bc540fef7c5d"),
+		REL_1_0_0      ("94e23ba02b55e8008a935fcf3e397db0adb4671b"),
+		UNREL20040121  ("67eea979bcd4575f285c30c581fd0d674c13c1fa"),
+		UNREL20040120  ("5e4131738cd095b7ff6367d64f809f6cec6a7ba7");
+
+		String sha;
+		SchemaVariant( String sha)
+		{
+			this.sha = sha;
+		}
+
+		void migrateFrom( SchemaVariant sv, Connection c, Statement s)
+		throws SQLException
+		{
+			throw new SQLNonTransientException(
+				"Detected older PL/Java SQLJ schema " + sv.name() +
+				", from which no automatic migration is implemented", "55000");
+		}
 	}
 }

--- a/pljava/src/main/java/org/postgresql/pljava/internal/Session.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/Session.java
@@ -110,9 +110,12 @@ public class Session implements org.postgresql.pljava.Session
 			ResultSet rs = null;
 			AclId sessionUser = AclId.getSessionUser();
 			AclId effectiveUser = AclId.getUser();
+			boolean wasLocalChange = false;
+			boolean changeSucceeded = false;
 			try
 			{
-				_setUser(sessionUser);
+				wasLocalChange = _setUser(sessionUser, true);
+				changeSucceeded = true;
 				if(stmt.execute(statement))
 				{
 					rs = stmt.getResultSet();
@@ -123,7 +126,8 @@ public class Session implements org.postgresql.pljava.Session
 			{
 				SQLUtils.close(rs);
 				SQLUtils.close(stmt);
-				_setUser(effectiveUser);
+				if ( changeSucceeded )
+					_setUser(effectiveUser, wasLocalChange);
 			}
 		}
 	}
@@ -142,5 +146,5 @@ public class Session implements org.postgresql.pljava.Session
 		return System.identityHashCode(Thread.currentThread());
 	}
 
-	private static native void _setUser(AclId userId);
+	private static native boolean _setUser(AclId userId, boolean isLocalChange);
 }

--- a/pljava/src/main/java/org/postgresql/pljava/management/Commands.java
+++ b/pljava/src/main/java/org/postgresql/pljava/management/Commands.java
@@ -237,6 +237,11 @@ import static org.postgresql.pljava.annotation.Function.Security.DEFINER;
  * </table></blockquote>
  * 
  * @author Thomas Hallgren
+ * @author Chapman Flack
+ */
+/*
+ * Attention: any evolution of the schema here needs to be reflected in
+ * o.p.p.internal.InstallHelper.SchemaVariant and .recognizeSchema().
  */
 @SQLAction(install={
 "	CREATE TABLE sqlj.jar_repository(" +

--- a/pljava/src/main/java/org/postgresql/pljava/management/Commands.java
+++ b/pljava/src/main/java/org/postgresql/pljava/management/Commands.java
@@ -43,6 +43,11 @@ import org.postgresql.pljava.internal.Oid;
 import org.postgresql.pljava.jdbc.SQLUtils;
 import org.postgresql.pljava.sqlj.Loader;
 
+import org.postgresql.pljava.annotation.Function;
+import org.postgresql.pljava.annotation.SQLAction;
+import org.postgresql.pljava.annotation.SQLType;
+import static org.postgresql.pljava.annotation.Function.Security.DEFINER;
+
 /**
  * This methods of this class are implementations of SQLJ commands.
  * <h1>SQLJ functions</h1>
@@ -233,6 +238,53 @@ import org.postgresql.pljava.sqlj.Loader;
  * 
  * @author Thomas Hallgren
  */
+@SQLAction(install={
+"	CREATE TABLE sqlj.jar_repository(" +
+"		jarId       SERIAL PRIMARY KEY," +
+"		jarName     VARCHAR(100) UNIQUE NOT NULL," +
+"		jarOrigin   VARCHAR(500) NOT NULL," +
+"		jarOwner    NAME NOT NULL," +
+"		jarManifest TEXT" +
+"	)",
+"	GRANT SELECT ON sqlj.jar_repository TO public",
+
+"	CREATE TABLE sqlj.jar_entry(" +
+"		entryId     SERIAL PRIMARY KEY," +
+"		entryName   VARCHAR(200) NOT NULL," +
+"		jarId       INT NOT NULL" +
+"					REFERENCES sqlj.jar_repository ON DELETE CASCADE," +
+"		entryImage  BYTEA NOT NULL," +
+"		UNIQUE(jarId, entryName)" +
+"	)",
+"	GRANT SELECT ON sqlj.jar_entry TO public",
+
+"	CREATE TABLE sqlj.jar_descriptor(" +
+"		jarId       INT REFERENCES sqlj.jar_repository ON DELETE CASCADE," +
+"		ordinal     INT2," +
+"		PRIMARY KEY (jarId, ordinal)," +
+"		entryId     INT NOT NULL REFERENCES sqlj.jar_entry ON DELETE CASCADE" +
+"	)",
+"	GRANT SELECT ON sqlj.jar_descriptor TO public",
+
+"	CREATE TABLE sqlj.classpath_entry(" +
+"		schemaName  VARCHAR(30) NOT NULL," +
+"		ordinal     INT2 NOT NULL," +
+"		jarId       INT NOT NULL" +
+"					REFERENCES sqlj.jar_repository ON DELETE CASCADE," +
+"		PRIMARY KEY(schemaName, ordinal)" +
+"	)",
+"	GRANT SELECT ON sqlj.classpath_entry TO public",
+
+"	CREATE TABLE sqlj.typemap_entry(" +
+"		mapId       SERIAL PRIMARY KEY," +
+"		javaName    VARCHAR(200) NOT NULL," +
+"		sqlName     NAME NOT NULL" +
+"	)",
+"	GRANT SELECT ON sqlj.typemap_entry TO public"
+}, remove={
+"	DROP TABLE sqlj.typemap_entry",
+"	DROP TABLE sqlj.jar_repository CASCADE"
+})
 public class Commands
 {
 	private final static Logger s_logger = Logger.getLogger(Commands.class
@@ -432,6 +484,7 @@ public class Commands
 	 *            the classpath in effect for the current schema
 	 * @throws SQLException
 	 */
+	@Function(schema="sqlj", name="add_type_mapping", security=DEFINER)
 	public static void addTypeMapping(String sqlTypeName, String javaClassName)
 	throws SQLException
 	{
@@ -473,6 +526,7 @@ public class Commands
 	 *            <code>search_path</code>.
 	 * @throws SQLException
 	 */
+	@Function(schema="sqlj", name="drop_type_mapping", security=DEFINER)
 	public static void dropTypeMapping(String sqlTypeName) throws SQLException
 	{
 		PreparedStatement stmt = null;
@@ -501,6 +555,7 @@ public class Commands
 	 *         no classpath.
 	 * @throws SQLException
 	 */
+	@Function(schema="sqlj", name="get_classpath", security=DEFINER)
 	public static String getClassPath(String schemaName) throws SQLException
 	{
 		ResultSet rs = null;
@@ -572,7 +627,9 @@ public class Commands
 	 *             system.
 	 * @see #setClassPath
 	 */
-	public static void installJar(byte[] image, String jarName, boolean deploy)
+	@Function(schema="sqlj", name="install_jar", security=DEFINER)
+	public static void installJar(
+		@SQLType("bytea") byte[] image, String jarName, boolean deploy)
 	throws SQLException
 	{
 		installJar("streamed byte image", jarName, deploy, image);
@@ -593,6 +650,7 @@ public class Commands
 	 *             system.
 	 * @see #setClassPath
 	 */
+	@Function(schema="sqlj", name="install_jar", security=DEFINER)
 	public static void installJar(String urlString, String jarName,
 		boolean deploy) throws SQLException
 	{
@@ -610,6 +668,7 @@ public class Commands
 	 *            descriptor of the jar.
 	 * @throws SQLException if the named jar cannot be found in the repository.
 	 */
+	@Function(schema="sqlj", name="remove_jar", security=DEFINER)
 	public static void removeJar(String jarName, boolean undeploy)
 	throws SQLException
 	{
@@ -658,7 +717,9 @@ public class Commands
 	 *            deployment descriptor of the new jar.
 	 * @throws SQLException if the named jar cannot be found in the repository.
 	 */
-	public static void replaceJar(byte[] jarImage, String jarName,
+	@Function(schema="sqlj", name="replace_jar", security=DEFINER)
+	public static void replaceJar(
+		@SQLType("bytea") byte[] jarImage, String jarName,
 		boolean redeploy) throws SQLException
 	{
 		replaceJar("streamed byte image", jarName, redeploy, jarImage);
@@ -676,6 +737,7 @@ public class Commands
 	 *            deployment descriptor of the new jar.
 	 * @throws SQLException if the named jar cannot be found in the repository.
 	 */
+	@Function(schema="sqlj", name="replace_jar", security=DEFINER)
 	public static void replaceJar(String urlString, String jarName,
 		boolean redeploy) throws SQLException
 	{
@@ -695,6 +757,7 @@ public class Commands
 	 *             if one or several names of the path denotes a nonexistant jar
 	 *             file.
 	 */
+	@Function(schema="sqlj", name="set_classpath", security=DEFINER)
 	public static void setClassPath(String schemaName, String path)
 	throws SQLException
 	{

--- a/pljava/src/main/java/org/postgresql/pljava/management/DDRExecutor.java
+++ b/pljava/src/main/java/org/postgresql/pljava/management/DDRExecutor.java
@@ -150,7 +150,7 @@ public abstract class DDRExecutor
 		throws SQLException
 		{
 			Session session = SessionManager.current();
-			session.executeAsSessionUser( conn, sql);
+			session.executeAsOuterUser( conn, sql);
 		}
 	}
 }

--- a/src/site/markdown/build/build.md
+++ b/src/site/markdown/build/build.md
@@ -1,0 +1,178 @@
+# Building PL/Java
+
+**For the impatient:**
+
+    mvn  clean  package
+
+PL/Java is built using [Apache Maven][mvn]. The above command will build it
+and package up the resulting files that you need to then
+[install it into PostgreSQL][inst].
+
+[mvn]: https://maven.apache.org/
+
+There are prerequisites, of course:
+
+0. You need the C compiling and linking tools for your platform.
+    On many platforms that means `gcc` and `g++`, and your normal search
+    path should include them, which you can test with
+
+        g++  --version
+
+    at the command line, which should tell you the version you have installed.
+
+0. The Java Development Kit (not just the Java Runtime Environment) version
+    that you plan to use should be installed, also ideally in your search path
+    so that
+
+        javac  -version
+
+    just works.
+
+0. The PostgreSQL server version that you intend to use should be installed,
+    and on your search path so that the command
+
+        pg_config
+
+    succeeds.
+
+0. Development files (mostly `.h` files) for that PostgreSQL version must also
+   be installed. To check, look in the output of that `pg_config` command for
+   an `INCLUDEDIR-SERVER` line, and list the directory it refers to. There
+   should be a bunch of `*.h` files there. If not, you probably installed
+   PostgreSQL from a packaged distribution, and there is probably another
+   package with a similar name but a suffix like `-devel` that needs to be
+   installed to provide the `.h` files.
+
+0. Naturally, [Maven][mvn] needs to be installed.
+
+If you have more than one version installed of PostgreSQL, Java, or the
+compile/link tools, make sure the ones found on your search path are the
+ones you plan to use, and the version-test commands above give the output
+you expect.
+
+## Special topics
+
+Please review any of the following that apply to your situation:
+
+* [Version compatibility](versions.html)
+
+## Obtaining PL/Java sources
+
+The best way to obtain up-to-date PL/Java sources is to have [git][] installed
+and `clone` the PL/Java GitHub repository, using either of these commands:
+
+    git clone https://github.com/tada/pljava.git
+    git clone ssh://git@github.com/tada/pljava.git
+
+The second only works if you have a GitHub account, but has the advantage
+of being faster if you do `git pull` later on to stay in sync with updated
+sources.
+
+[git]: https://git-scm.com/
+
+## The build
+
+To start the build, your current directory should be the one the sources were
+checked out into. Looking around, there should be a `pom.xml` file there, and
+several subdirectories `pljava`, `pljava-api`, `pljava-so`, etc.
+
+A successful `mvn clean package` should produce output like this near the end:
+
+```
+[INFO] PostgreSQL PL/Java ................................ SUCCESS
+[INFO] PL/Java API ....................................... SUCCESS
+[INFO] PL/Java backend Java code ......................... SUCCESS
+[INFO] PL/Java backend native code ....................... SUCCESS
+[INFO] PL/Java Deploy .................................... SUCCESS
+[INFO] PL/Java Ant tasks ................................. SUCCESS
+[INFO] PL/Java examples .................................. SUCCESS
+[INFO] PL/Java packaging ................................. SUCCESS
+```
+(the real output will include timings on each line). You will then be ready
+to [try out PL/Java in PostgreSQL][inst].
+
+[inst]: ../install/install.html
+
+### I know PostgreSQL and PGXS. Explain Maven!
+
+[Maven][mvn] is a widely used tool for building and maintaining projects in
+Java. The `pom.xml` file contains the information Maven needs not only for
+building the project, but obtaining its dependencies and generating reports
+and documentation (including the web site you see here).
+
+If this is your first use of Maven, your first `mvn clean package` command will
+do a lot of downloading, obtaining all of PL/Java's dependencies as declared in
+its `pom.xml` files, and those dependencies' dependencies, etc. Most of the
+dependencies are the various Maven plugins used in the build, and the libraries
+they depend on.
+
+Maven will create a local "maven repository" to store what it downloads, so
+your later `mvn` commands will complete much faster, with no downloading or
+only a few artifacts downloaded if versions have updated.
+
+With default settings, Maven will create this local repository under your home
+directory. It will grow to contain artifacts you have built with Maven and all
+the artifacts downloaded as dependencies, which can be a large set, especially
+if you work on several different Maven-built projects requiring different
+versions of the same dependencies. (It may reach 50 MB after building only
+PL/Java.) If you would like Maven to create the local repository elsewhere,
+the `<localRepository>` element of your [Maven settings][mvnset] can specify
+a path.
+
+[mvnset]: https://maven.apache.org/settings.html
+
+It is thinkable to place the repository on storage that is not backed up, as
+it contains nothing that cannot be redownloaded or rebuilt from your sources.
+
+#### Shouldn't that command be `mvn clean install`?
+
+There is a Maven goal called `install`, but it has a Maven-specific meaning:
+it does not, as you might be thinking, set up your newly-built PL/Java as a
+language in PostgreSQL. (Neither does the `deploy` goal, if you are wondering.)
+
+What Maven's `install` does is save the newly-built artifact into the local
+repository, so other Maven-built projects can list it as a dependency. That
+_is_ useful for the `pljava-api` subproject: if you run `mvn clean install`
+instead of just `package`, you can then easily
+[build your Java projects that _use_ PL/Java][jproj].
+
+To "install" your built PL/Java as a language in PostgreSQL, proceed to
+the [installation instructions][inst].
+
+[jproj]: ../use/hello.html
+[inst]: ../install/install.html
+
+### I know Java and Maven. Explain the PostgreSQL picture!
+
+The process of downloading and building PL/Java with Maven will be familiar
+to you, but the step saving artifacts into the local repository with the
+`install` goal is not necessary or useful for most of PL/Java; PostgreSQL itself
+is not Maven-aware and will not find them there. Instead, once the `package`
+goal has been reached, just proceed to the [installation instructions][inst].
+
+The exception is the `pljava-api` subproject. Installing `pljava-api` into
+the local Maven repository will allow you to declare it like any other Maven
+dependency when [building your own projects that _use_ PL/Java][jproj].
+
+### Troubleshooting the build
+
+If something fails, two tricks may be helpful. The C compilation may produce
+a lot of nuisance warnings, because the Maven plugin driving it enables many
+types of warning that would be impractical to fix. With many warnings it may
+be difficult to pick out messages that matter.
+
+If the compiler is `gcc`, an extra option `-Pwnosign` can be given on the
+`mvn` command line, and will suppress the most voluminous and least useful
+warnings. It adds the compiler option `-Wno-sign-conversion` which might not
+be understood by other compilers, so may not have the intended effect if the
+compiler is not `gcc`.
+
+On a machine with many cores, messages from several compilation threads may be
+intermingled in the output so that related messages are hard to identify.
+The option `-Dnar.cores=1` will force the messages into a sequential order
+(and has little effect on the speed of a PL/Java build).
+
+The `-X` option will add a lot of information on the details of Maven's
+build activities.
+
+    mvn  -X  -Pwnosign  -Dnar.cores=1  clean  package

--- a/src/site/markdown/build/build.md
+++ b/src/site/markdown/build/build.md
@@ -2,11 +2,11 @@
 
 **For the impatient:**
 
-    mvn  clean  package
+    mvn  clean  install
 
 PL/Java is built using [Apache Maven][mvn]. The above command will build it
-and package up the resulting files that you need to then
-[install it into PostgreSQL][inst].
+and produce the files you need, but *not* install them into PostgreSQL.
+To do that, continue with the [installation instructions][inst].
 
 [mvn]: https://maven.apache.org/
 [java]: http://www.oracle.com/technetwork/java/javase/downloads/index.html
@@ -37,12 +37,12 @@ There are prerequisites, of course:
     succeeds.
 
 0. Development files (mostly `.h` files) for that PostgreSQL version must also
-   be installed. To check, look in the output of that `pg_config` command for
-   an `INCLUDEDIR-SERVER` line, and list the directory it refers to. There
-   should be a bunch of `*.h` files there. If not, you probably installed
-   PostgreSQL from a packaged distribution, and there is probably another
-   package with a similar name but a suffix like `-devel` that needs to be
-   installed to provide the `.h` files.
+    be installed. To check, look in the output of that `pg_config` command for
+    an `INCLUDEDIR-SERVER` line, and list the directory it refers to. There
+    should be a bunch of `*.h` files there. If not, you probably installed
+    PostgreSQL from a packaged distribution, and there is probably another
+    package with a similar name but a suffix like `-devel` that needs to be
+    installed to provide the `.h` files.
 
 0. Naturally, [Maven][mvn] needs to be installed.
 
@@ -56,6 +56,9 @@ you expect.
 Please review any of the following that apply to your situation:
 
 * [Version compatibility](versions.html)
+* Building on Microsoft Windows: [with Visual Studio](buildmsvc.html)
+* Building on [Mac OS X](macosx.html)
+* Building on [FreeBSD](freebsd.html)
 
 ## Obtaining PL/Java sources
 
@@ -77,7 +80,7 @@ To start the build, your current directory should be the one the sources were
 checked out into. Looking around, there should be a `pom.xml` file there, and
 several subdirectories `pljava`, `pljava-api`, `pljava-so`, etc.
 
-A successful `mvn clean package` should produce output like this near the end:
+A successful `mvn clean install` should produce output like this near the end:
 
 ```
 [INFO] PostgreSQL PL/Java ................................ SUCCESS
@@ -101,7 +104,7 @@ Java. The `pom.xml` file contains the information Maven needs not only for
 building the project, but obtaining its dependencies and generating reports
 and documentation (including the web site you see here).
 
-If this is your first use of Maven, your first `mvn clean package` command will
+If this is your first use of Maven, your first `mvn clean install` command will
 do a lot of downloading, obtaining all of PL/Java's dependencies as declared in
 its `pom.xml` files, and those dependencies' dependencies, etc. Most of the
 dependencies are the various Maven plugins used in the build, and the libraries
@@ -125,16 +128,15 @@ a path.
 It is thinkable to place the repository on storage that is not backed up, as
 it contains nothing that cannot be redownloaded or rebuilt from your sources.
 
-#### Shouldn't that command be `mvn clean install`?
+#### Why does `mvn clean install` not "install" PL/Java into PostgreSQL?
 
-There is a Maven goal called `install`, but it has a Maven-specific meaning:
-it does not, as you might be thinking, set up your newly-built PL/Java as a
+The Maven goal called `install` has a meaning specific to Maven:
+it does not set up your newly-built PL/Java as a
 language in PostgreSQL. (Neither does the `deploy` goal, if you are wondering.)
 
 What Maven's `install` does is save the newly-built artifact into the local
 repository, so other Maven-built projects can list it as a dependency. That
-_is_ useful for the `pljava-api` subproject: if you run `mvn clean install`
-instead of just `package`, you can then easily
+is useful for the `pljava-api` subproject, so you can then easily
 [build your Java projects that _use_ PL/Java][jproj].
 
 To "install" your built PL/Java as a language in PostgreSQL, proceed to
@@ -147,12 +149,12 @@ the [installation instructions][inst].
 
 The process of downloading and building PL/Java with Maven will be familiar
 to you, but the step saving artifacts into the local repository with the
-`install` goal is not necessary or useful for most of PL/Java; PostgreSQL itself
-is not Maven-aware and will not find them there. Instead, once the `package`
-goal has been reached, just proceed to the [installation instructions][inst].
+`install` goal is only a first step; PostgreSQL itself
+is not Maven-aware and will not find them there. After the
+`mvn clean install`, just proceed to the [installation instructions][inst].
 
-The exception is the `pljava-api` subproject. Installing `pljava-api` into
-the local Maven repository will allow you to declare it like any other Maven
+The `pljava-api` subproject does benefit from being saved in your local
+Maven repository; you can then declare it like any other Maven
 dependency when [building your own projects that _use_ PL/Java][jproj].
 
 ### Troubleshooting the build
@@ -176,4 +178,4 @@ The option `-Dnar.cores=1` will force the messages into a sequential order
 The `-X` option will add a lot of information on the details of Maven's
 build activities.
 
-    mvn  -X  -Pwnosign  -Dnar.cores=1  clean  package
+    mvn  -X  -Pwnosign  -Dnar.cores=1  clean  install

--- a/src/site/markdown/build/build.md
+++ b/src/site/markdown/build/build.md
@@ -44,7 +44,11 @@ There are prerequisites, of course:
     package with a similar name but a suffix like `-devel` that needs to be
     installed to provide the `.h` files.
 
-0. Naturally, [Maven][mvn] needs to be installed.
+0. Naturally, [Maven][mvn] needs to be installed. When it properly is,
+
+        mvn --version
+
+    succeeds.
 
 If you have more than one version installed of PostgreSQL, Java, or the
 compile/link tools, make sure the ones found on your search path are the

--- a/src/site/markdown/build/buildmsvc.md
+++ b/src/site/markdown/build/buildmsvc.md
@@ -1,27 +1,27 @@
-# Building PL/Java
+# Building PL/Java with Microsoft Visual Studio
 
-**For the impatient:**
-
-    mvn  clean  package
-
-PL/Java is built using [Apache Maven][mvn]. The above command will build it
-and package up the resulting files that you need to then
-[install it into PostgreSQL][inst].
-
+[edb]: http://www.enterprisedb.com/products-services-training/pgdownload
+[msvc]: https://www.visualstudio.com/downloads/download-visual-studio-vs
+[java]: http://www.oracle.com/technetwork/java/javase/downloads/index.html
+[ant]: https://ant.apache.org/bindownload.cgi
+[git]: https://git-scm.com/downloads
+[github]: https://desktop.github.com/
 [mvn]: https://maven.apache.org/
 
-There are prerequisites, of course:
 
-0. You need the C compiling and linking tools for your platform.
-    On many platforms that means `gcc` and `g++`, and your normal search
-    path should include them, which you can test with
+PL/Java may be built on Windows using the compilers in Microsoft Visual Studio (including the Express and Community editions). 
 
-        g++  --version
+Most Windows users will install Postgresql using the binary distributions from [EnterpriseDB][edb]. You may find that using the same version of Visual Studio to compile PL/Java as that used by EnterpriseDB to compile their Postgresql distribution will result in fewer compile warnings and a somewhat smaller runtime memory footprint because the same runtime DLLs will be used by both Postgresql and PL/Java. Using a **newer** version of Visual Studio (including the Community 2015 version) will generally work, while older versions are more likely to be problematic.
 
-    at the command line, which should tell you the version you have installed.
+* Postgresql 9.1 to 9.3 were built using Visual Studio 2010.
+* Postgresql 9.4 was built using Visual Studio 2013.
 
-0. The Java Development Kit (not just the Java Runtime Environment) version
-    that you plan to use should be installed, also ideally in your search path
+## Software Prerequisites
+0. You will need an appropriate version of [Microsoft Visual Studio][msvc]. When installing Visual Studio be
+   sure to select the "compiler tools" option so that the command line compiler is installed.
+
+0. The [Java Development Kit][java] (not just the Java Runtime Environment) version that you plan to use.
+    that you plan to use should be installed, also ideally in your PATH environment variable
     so that
 
         javac  -version
@@ -29,7 +29,7 @@ There are prerequisites, of course:
     just works.
 
 0. The PostgreSQL server version that you intend to use should be installed,
-    and on your search path so that the command
+    and on your PATH so that the command
 
         pg_config
 
@@ -38,28 +38,60 @@ There are prerequisites, of course:
 0. Development files (mostly `.h` files) for that PostgreSQL version must also
    be installed. To check, look in the output of that `pg_config` command for
    an `INCLUDEDIR-SERVER` line, and list the directory it refers to. There
-   should be a bunch of `*.h` files there. If not, you probably installed
-   PostgreSQL from a packaged distribution, and there is probably another
-   package with a similar name but a suffix like `-devel` that needs to be
-   installed to provide the `.h` files.
+   should be a bunch of `*.h` files there.
 
-0. Naturally, [Maven][mvn] needs to be installed.
+0. You will need to install [Maven][mvn] and add it to your PATH so that
+
+		mvn -version
+
+    just works.
+
+0. You will need to install [Ant][ant] and add it to your PATH so that
+
+		ant -version
+
+    just works.
+
+0. You will need either [Git][git] or [GitHub for Windows][github]. If you are using Git, add it to your PATH
+    so that
+
+		git --version
+
+    just works.
+
+You **must** match the 32-bit vs 64-bit version of the Java JVM, C compiler and PostgreSQL installation 
+used to build PL/Java. (All must be either 32-bit or 64-bit.)
 
 If you have more than one version installed of PostgreSQL, Java, or the
 compile/link tools, make sure the ones found on your search path are the
 ones you plan to use, and the version-test commands above give the output
 you expect.
 
-## Special topics
+## Visual C Configuration
 
-Please review any of the following that apply to your situation:
+You will need to open a command window with the appropriate Visual C native tools environment variables defined.
+You may do this by using the preconfigured links accessible from the Start menu
+(for example at Visual Studio 2013 | Visual Studio Tools) or by creating a desktop shortcut for the tools. 
 
-* [Version compatibility](versions.html)
+* Visual Studio 2013:
+
+		"C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat" x86
+		"C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat" amd64
+* Visual Studio 2010:
+
+		"C:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\vcvarsall.bat" x86
+		"C:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\vcvarsall.bat" amd64
 
 ## Obtaining PL/Java sources
 
-The best way to obtain up-to-date PL/Java sources is to have [git][] installed
-and `clone` the PL/Java GitHub repository, using either of these commands:
+You may use GitHub for Windows to `clone` the PL/Java GitHub repository by opening your browser to
+
+	https://github.com/tada/pljava
+
+and clicking on the appropriate icon. At the time these notes were written, the icon is located to the left
+of the "Download ZIP" button.
+
+Alternatively you may use [git][] to `clone` the PL/Java GitHub repository, using either of these commands:
 
     git clone https://github.com/tada/pljava.git
     git clone ssh://git@github.com/tada/pljava.git
@@ -68,73 +100,42 @@ The second only works if you have a GitHub account, but has the advantage
 of being faster if you do `git pull` later on to stay in sync with updated
 sources.
 
-[git]: https://git-scm.com/
 
-## The build
+## Building PL/Java
 
-To start the build, your current directory should be the one the sources were
-checked out into. Looking around, there should be a `pom.xml` file there, and
-several subdirectories `pljava`, `pljava-api`, `pljava-so`, etc.
+0. Open a command window using the Visual Studio shortcut for the appropriate version.
+
+0. To start the build, your current directory should be the one the sources were
+   checked out into. Looking around, there should be a `pom.xml` file there, and
+   several subdirectories `pljava`, `pljava-api`, `pljava-so`, etc.
+   In the command window, change the directory to the location of the cloned PL/Java repository. For example,
+
+		cd C:\GitHub\pljava
+
+0. PL/Java is built using [Apache Maven][mvn]. The above command will build it
+   and package up the resulting files that you need to then
+   [install it into PostgreSQL][inst].
+
+	    mvn  clean  package
+
+
 
 A successful `mvn clean package` should produce output like this near the end:
 
-```
-[INFO] PostgreSQL PL/Java ................................ SUCCESS
-[INFO] PL/Java API ....................................... SUCCESS
-[INFO] PL/Java backend Java code ......................... SUCCESS
-[INFO] PL/Java backend native code ....................... SUCCESS
-[INFO] PL/Java Deploy .................................... SUCCESS
-[INFO] PL/Java Ant tasks ................................. SUCCESS
-[INFO] PL/Java examples .................................. SUCCESS
-[INFO] PL/Java packaging ................................. SUCCESS
-```
+	[INFO] PostgreSQL PL/Java ................................ SUCCESS
+	[INFO] PL/Java API ....................................... SUCCESS
+	[INFO] PL/Java backend Java code ......................... SUCCESS
+	[INFO] PL/Java backend native code ....................... SUCCESS
+	[INFO] PL/Java Deploy .................................... SUCCESS
+	[INFO] PL/Java Ant tasks ................................. SUCCESS
+	[INFO] PL/Java examples .................................. SUCCESS
+	[INFO] PL/Java packaging ................................. SUCCESS
+
 (the real output will include timings on each line). You will then be ready
 to [try out PL/Java in PostgreSQL][inst].
 
 [inst]: ../install/install.html
 
-### I know PostgreSQL and PGXS. Explain Maven!
-
-[Maven][mvn] is a widely used tool for building and maintaining projects in
-Java. The `pom.xml` file contains the information Maven needs not only for
-building the project, but obtaining its dependencies and generating reports
-and documentation (including the web site you see here).
-
-If this is your first use of Maven, your first `mvn clean package` command will
-do a lot of downloading, obtaining all of PL/Java's dependencies as declared in
-its `pom.xml` files, and those dependencies' dependencies, etc. Most of the
-dependencies are the various Maven plugins used in the build, and the libraries
-they depend on.
-
-Maven will create a local "maven repository" to store what it downloads, so
-your later `mvn` commands will complete much faster, with no downloading or
-only a few artifacts downloaded if versions have updated.
-
-With default settings, Maven will create this local repository under your home
-directory. It will grow to contain artifacts you have built with Maven and all
-the artifacts downloaded as dependencies, which can be a large set, especially
-if you work on several different Maven-built projects requiring different
-versions of the same dependencies. (It may reach 50 MB after building only
-PL/Java.) If you would like Maven to create the local repository elsewhere,
-the `<localRepository>` element of your [Maven settings][mvnset] can specify
-a path.
-
-[mvnset]: https://maven.apache.org/settings.html
-
-It is thinkable to place the repository on storage that is not backed up, as
-it contains nothing that cannot be redownloaded or rebuilt from your sources.
-
-#### Shouldn't that command be `mvn clean install`?
-
-There is a Maven goal called `install`, but it has a Maven-specific meaning:
-it does not, as you might be thinking, set up your newly-built PL/Java as a
-language in PostgreSQL. (Neither does the `deploy` goal, if you are wondering.)
-
-What Maven's `install` does is save the newly-built artifact into the local
-repository, so other Maven-built projects can list it as a dependency. That
-_is_ useful for the `pljava-api` subproject: if you run `mvn clean install`
-instead of just `package`, you can then easily
-[build your Java projects that _use_ PL/Java][jproj].
 
 To "install" your built PL/Java as a language in PostgreSQL, proceed to
 the [installation instructions][inst].
@@ -161,11 +162,11 @@ a lot of nuisance warnings, because the Maven plugin driving it enables many
 types of warning that would be impractical to fix. With many warnings it may
 be difficult to pick out messages that matter.
 
-If the compiler is `gcc`, an extra option `-Pwnosign` can be given on the
-`mvn` command line, and will suppress the most voluminous and least useful
-warnings. It adds the compiler option `-Wno-sign-conversion` which might not
-be understood by other compilers, so may not have the intended effect if the
-compiler is not `gcc`.
+If the link step of the build reports that the symbol `rint` is undefined
+you are probably using an older version of Visual Studio (2010) with a newer
+version of Postgresql (9.4). This symbol is defined in Visual Studio 2013 and
+later and the Postgresql 9.4 headers lack the appropriate conditional options for
+the older compilers. You will need to use a newer version of Visual Studio.
 
 On a machine with many cores, messages from several compilation threads may be
 intermingled in the output so that related messages are hard to identify.
@@ -175,4 +176,4 @@ The option `-Dnar.cores=1` will force the messages into a sequential order
 The `-X` option will add a lot of information on the details of Maven's
 build activities.
 
-    mvn  -X  -Pwnosign  -Dnar.cores=1  clean  package
+    mvn  -X  -Dnar.cores=1  clean  package

--- a/src/site/markdown/build/buildmsvc.md
+++ b/src/site/markdown/build/buildmsvc.md
@@ -5,20 +5,30 @@
 [java]: http://www.oracle.com/technetwork/java/javase/downloads/index.html
 [ant]: https://ant.apache.org/bindownload.cgi
 [git]: https://git-scm.com/downloads
-[github]: https://desktop.github.com/
+[ghd]: https://desktop.github.com/
 [mvn]: https://maven.apache.org/
 
 
-PL/Java may be built on Windows using the compilers in Microsoft Visual Studio (including the Express and Community editions). 
+PL/Java may be built on Windows using the compilers in Microsoft Visual Studio
+(including the Express and Community editions).
 
-Most Windows users will install Postgresql using the binary distributions from [EnterpriseDB][edb]. You may find that using the same version of Visual Studio to compile PL/Java as that used by EnterpriseDB to compile their Postgresql distribution will result in fewer compile warnings and a somewhat smaller runtime memory footprint because the same runtime DLLs will be used by both Postgresql and PL/Java. Using a **newer** version of Visual Studio (including the Community 2015 version) will generally work, while older versions are more likely to be problematic.
+Most Windows users will install PostgreSQL using the binary distributions from
+[EnterpriseDB][edb]. You may find that using the same version of Visual Studio
+to compile PL/Java as that used by EnterpriseDB to compile their PostgreSQL
+distribution will result in fewer compile warnings and a somewhat smaller
+runtime memory footprint because the same runtime DLLs will be used by both
+PostgreSQL and PL/Java. Using a *newer* version of Visual Studio (including
+the Community 2015 version) will generally work, while older versions are more
+likely to be problematic.
 
-* Postgresql 9.1 to 9.3 were built using Visual Studio 2010.
-* Postgresql 9.4 was built using Visual Studio 2013.
+* PostgreSQL 9.1 to 9.3 were built using Visual Studio 2010.
+* PostgreSQL 9.4 was built using Visual Studio 2013.
 
 ## Software Prerequisites
-0. You will need an appropriate version of [Microsoft Visual Studio][msvc]. When installing Visual Studio be
-   sure to select the "compiler tools" option so that the command line compiler is installed.
+
+0. You will need an appropriate version of [Microsoft Visual Studio][msvc]. When
+    installing Visual Studio be sure to select the "compiler tools" option so
+    that the command line compiler is installed.
 
 0. The [Java Development Kit][java] (not just the Java Runtime Environment) version that you plan to use.
     that you plan to use should be installed, also ideally in your PATH environment variable
@@ -36,31 +46,32 @@ Most Windows users will install Postgresql using the binary distributions from [
     succeeds.
 
 0. Development files (mostly `.h` files) for that PostgreSQL version must also
-   be installed. To check, look in the output of that `pg_config` command for
-   an `INCLUDEDIR-SERVER` line, and list the directory it refers to. There
-   should be a bunch of `*.h` files there.
+    be installed. To check, look in the output of that `pg_config` command for
+    an `INCLUDEDIR-SERVER` line, and list the directory it refers to. There
+    should be a bunch of `*.h` files there.
 
 0. You will need to install [Maven][mvn] and add it to your PATH so that
 
-		mvn -version
+        mvn -version
 
     just works.
 
 0. You will need to install [Ant][ant] and add it to your PATH so that
 
-		ant -version
+        ant -version
 
     just works.
 
-0. You will need either [Git][git] or [GitHub for Windows][github]. If you are using Git, add it to your PATH
+0. You will need either [Git][git] or [GitHub for Windows][ghd]. If you are using Git, add it to your PATH
     so that
 
-		git --version
+        git --version
 
     just works.
 
-You **must** match the 32-bit vs 64-bit version of the Java JVM, C compiler and PostgreSQL installation 
-used to build PL/Java. (All must be either 32-bit or 64-bit.)
+You **must** match the 32-bit vs 64-bit version of the Java JVM, C compiler and
+PostgreSQL installation  used to build PL/Java. (All must be either 32-bit or
+64-bit.)
 
 If you have more than one version installed of PostgreSQL, Java, or the
 compile/link tools, make sure the ones found on your search path are the
@@ -69,24 +80,28 @@ you expect.
 
 ## Visual C Configuration
 
-You will need to open a command window with the appropriate Visual C native tools environment variables defined.
-You may do this by using the preconfigured links accessible from the Start menu
-(for example at Visual Studio 2013 | Visual Studio Tools) or by creating a desktop shortcut for the tools. 
+You will need to open a command window with the appropriate Visual C native
+tools environment variables defined. You may do this by using the preconfigured
+links accessible from the Start menu (for example at
+`Visual Studio 2013 | Visual Studio Tools`) or by creating a desktop shortcut
+for the tools. 
 
 * Visual Studio 2013:
 
-		"C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat" x86
-		"C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat" amd64
+        "C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat" x86
+        "C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat" amd64
+
 * Visual Studio 2010:
 
-		"C:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\vcvarsall.bat" x86
-		"C:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\vcvarsall.bat" amd64
+        "C:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\vcvarsall.bat" x86
+        "C:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\vcvarsall.bat" amd64
 
 ## Obtaining PL/Java sources
 
-You may use GitHub for Windows to `clone` the PL/Java GitHub repository by opening your browser to
+You may use GitHub for Windows to `clone` the PL/Java GitHub repository by
+opening your browser to
 
-	https://github.com/tada/pljava
+    https://github.com/tada/pljava
 
 and clicking on the appropriate icon. At the time these notes were written, the icon is located to the left
 of the "Download ZIP" button.
@@ -103,43 +118,74 @@ sources.
 
 ## Building PL/Java
 
-0. Open a command window using the Visual Studio shortcut for the appropriate version.
+0. Open a command window using the Visual Studio shortcut for the appropriate
+    version.
 
 0. To start the build, your current directory should be the one the sources were
-   checked out into. Looking around, there should be a `pom.xml` file there, and
-   several subdirectories `pljava`, `pljava-api`, `pljava-so`, etc.
-   In the command window, change the directory to the location of the cloned PL/Java repository. For example,
+    checked out into. In the
+    command window, change the directory to the location of the cloned PL/Java
+    repository. For example,
 
-		cd C:\GitHub\pljava
+        cd C:\GitHub\pljava
 
-0. PL/Java is built using [Apache Maven][mvn]. The above command will build it
-   and package up the resulting files that you need to then
-   [install it into PostgreSQL][inst].
+    Looking around, there should be a `pom.xml` file there,
+    and several subdirectories `pljava`, `pljava-api`, `pljava-so`, etc.
 
-	    mvn  clean  package
+0. PL/Java is built using [Apache Maven][mvn].
+
+        mvn  clean  install
+
+    This command will build PL/Java and produce the files you need, but
+    does not install them as a language in PostgreSQL. To complete that step,
+    proceed to the [installation instructions][inst].
 
 
+A successful `mvn clean install` should produce output like this near the end:
 
-A successful `mvn clean package` should produce output like this near the end:
-
-	[INFO] PostgreSQL PL/Java ................................ SUCCESS
-	[INFO] PL/Java API ....................................... SUCCESS
-	[INFO] PL/Java backend Java code ......................... SUCCESS
-	[INFO] PL/Java backend native code ....................... SUCCESS
-	[INFO] PL/Java Deploy .................................... SUCCESS
-	[INFO] PL/Java Ant tasks ................................. SUCCESS
-	[INFO] PL/Java examples .................................. SUCCESS
-	[INFO] PL/Java packaging ................................. SUCCESS
+    [INFO] PostgreSQL PL/Java ................................ SUCCESS
+    [INFO] PL/Java API ....................................... SUCCESS
+    [INFO] PL/Java backend Java code ......................... SUCCESS
+    [INFO] PL/Java backend native code ....................... SUCCESS
+    [INFO] PL/Java Deploy .................................... SUCCESS
+    [INFO] PL/Java Ant tasks ................................. SUCCESS
+    [INFO] PL/Java examples .................................. SUCCESS
+    [INFO] PL/Java packaging ................................. SUCCESS
 
 (the real output will include timings on each line). You will then be ready
 to [try out PL/Java in PostgreSQL][inst].
 
 [inst]: ../install/install.html
 
+### I know PostgreSQL and PGXS. Explain Maven!
+
+If Maven is unfamiliar, please see the "Explain Maven!" section on the
+[main build page](build.html), which covers most of the subject. However,
+there are some Windows-specific details:
+
+* The Maven project has an extra page on [Windows prerequisites][wprq].
+* They don't very clearly document the location of your Maven settings file
+    when running on Windows. If you want to change any Maven settings, it may
+    be easiest to run
+
+        mvn -X
+
+    and look for the lines
+
+        [DEBUG] Reading global settings from (somewhere)/settings.xml
+        [DEBUG] Reading user settings from (somewhere)/settings.xml
+
+    to find and edit a settings file.
+
+A last reminder, `mvn install` does not add PL/Java as a language in your
+PostgreSQL database; the Maven `install` goal only adds things to your
+Maven repository. That isn't even necessary for installing the language in
+PostgreSQL, but it will be convenient when you
+[build your Java projects that _use_ PL/Java][jproj].
 
 To "install" your built PL/Java as a language in PostgreSQL, proceed to
 the [installation instructions][inst].
 
+[wprq]: https://maven.apache.org/guides/getting-started/windows-prerequisites.html
 [jproj]: ../use/hello.html
 [inst]: ../install/install.html
 
@@ -147,12 +193,12 @@ the [installation instructions][inst].
 
 The process of downloading and building PL/Java with Maven will be familiar
 to you, but the step saving artifacts into the local repository with the
-`install` goal is not necessary or useful for most of PL/Java; PostgreSQL itself
-is not Maven-aware and will not find them there. Instead, once the `package`
-goal has been reached, just proceed to the [installation instructions][inst].
+`install` goal is only a first step; PostgreSQL itself
+is not Maven-aware and will not find them there. After the `mvn clean install`,
+just proceed to the [installation instructions][inst].
 
-The exception is the `pljava-api` subproject. Installing `pljava-api` into
-the local Maven repository will allow you to declare it like any other Maven
+The `pljava-api` subproject does benefit from being saved in your local
+Maven repository; you can then declare it like any other Maven
 dependency when [building your own projects that _use_ PL/Java][jproj].
 
 ### Troubleshooting the build
@@ -176,4 +222,4 @@ The option `-Dnar.cores=1` will force the messages into a sequential order
 The `-X` option will add a lot of information on the details of Maven's
 build activities.
 
-    mvn  -X  -Dnar.cores=1  clean  package
+    mvn  -X  -Dnar.cores=1  clean  install

--- a/src/site/markdown/build/buildmsvc.md
+++ b/src/site/markdown/build/buildmsvc.md
@@ -30,9 +30,9 @@ likely to be problematic.
     installing Visual Studio be sure to select the "compiler tools" option so
     that the command line compiler is installed.
 
-0. The [Java Development Kit][java] (not just the Java Runtime Environment) version that you plan to use.
-    that you plan to use should be installed, also ideally in your PATH environment variable
-    so that
+0. The [Java Development Kit][java] (not just the Java Runtime Environment)
+    version that you plan to use. that you plan to use should be installed, also
+    ideally in your PATH environment variable so that
 
         javac  -version
 
@@ -52,18 +52,12 @@ likely to be problematic.
 
 0. You will need to install [Maven][mvn] and add it to your PATH so that
 
-        mvn -version
+        mvn --version
 
     just works.
 
-0. You will need to install [Ant][ant] and add it to your PATH so that
-
-        ant -version
-
-    just works.
-
-0. You will need either [Git][git] or [GitHub for Windows][ghd]. If you are using Git, add it to your PATH
-    so that
+0. You will need either [Git][git] or [GitHub for Windows][ghd]. If you are
+    using Git, add it to your PATH so that
 
         git --version
 
@@ -103,10 +97,11 @@ opening your browser to
 
     https://github.com/tada/pljava
 
-and clicking on the appropriate icon. At the time these notes were written, the icon is located to the left
-of the "Download ZIP" button.
+and clicking on the appropriate icon. At the time these notes were written, the
+icon is located to the left of the "Download ZIP" button.
 
-Alternatively you may use [git][] to `clone` the PL/Java GitHub repository, using either of these commands:
+Alternatively you may use [git][] to `clone` the PL/Java GitHub repository,
+using either of these commands:
 
     git clone https://github.com/tada/pljava.git
     git clone ssh://git@github.com/tada/pljava.git
@@ -208,11 +203,11 @@ a lot of nuisance warnings, because the Maven plugin driving it enables many
 types of warning that would be impractical to fix. With many warnings it may
 be difficult to pick out messages that matter.
 
-If the link step of the build reports that the symbol `rint` is undefined
-you are probably using an older version of Visual Studio (2010) with a newer
-version of Postgresql (9.4). This symbol is defined in Visual Studio 2013 and
-later and the Postgresql 9.4 headers lack the appropriate conditional options for
-the older compilers. You will need to use a newer version of Visual Studio.
+If the link step of the build reports that the symbol `rint` is undefined you
+are probably using an older version of Visual Studio (2010) with a newer version
+of Postgresql (9.4). This symbol is defined in Visual Studio 2013 and later and
+the Postgresql 9.4 headers lack the appropriate conditional options for the
+older compilers. You will need to use a newer version of Visual Studio.
 
 On a machine with many cores, messages from several compilation threads may be
 intermingled in the output so that related messages are hard to identify.

--- a/src/site/markdown/build/buildmsvc.md
+++ b/src/site/markdown/build/buildmsvc.md
@@ -9,7 +9,6 @@ and package up the resulting files that you need to then
 [install it into PostgreSQL][inst].
 
 [mvn]: https://maven.apache.org/
-[java]: http://www.oracle.com/technetwork/java/javase/downloads/index.html
 
 There are prerequisites, of course:
 
@@ -21,9 +20,9 @@ There are prerequisites, of course:
 
     at the command line, which should tell you the version you have installed.
 
-0. The [Java Development Kit][java] (not just the Java Runtime Environment)
-    version that you plan to use should be installed, also ideally in your
-    search path so that
+0. The Java Development Kit (not just the Java Runtime Environment) version
+    that you plan to use should be installed, also ideally in your search path
+    so that
 
         javac  -version
 

--- a/src/site/markdown/build/freebsd.md
+++ b/src/site/markdown/build/freebsd.md
@@ -1,0 +1,23 @@
+# Building on FreeBSD
+
+At one time, [FreeBSD][]'s threading library would malfunction if it was
+dynamically loaded after the start of a program that did not use threads
+itself. That was a problem for PL/Java on FreeBSD, because PostgreSQL
+itself does not use threads, but Java does. The only known workaround was
+to build PostgreSQL itself from source, with the thread library included
+in linking.
+
+The same problem was [reported to affect other PostgreSQL extensions][rep]
+such as `plv8` and `imcs` also.
+
+The [manual page for FreeBSD's libthr][manthr] was edited
+[in February 2015][thrdif] to remove the statement of that limitation,
+and the updated manual page appears first in [FreeBSD 10.2][rel102],
+so in FreeBSD 10.2 or later, PL/Java (and other affected extensions)
+may work without the need to build PostgreSQL from source.
+
+[FreeBSD]: https://www.freebsd.org/
+[rep]: https://lists.freebsd.org/pipermail/freebsd-hackers/2014-April/044961.html
+[manthr]: https://www.freebsd.org/cgi/man.cgi?query=libthr&amp;apropos=0&amp;sektion=3&amp;manpath=FreeBSD+10.2-RELEASE&amp;arch=default&amp;format=html
+[thrdif]: https://svnweb.freebsd.org/base/head/lib/libthr/libthr.3?r1=272153&amp;r2=278627
+[rel102]: https://www.freebsd.org/releases/10.2R/announce.html

--- a/src/site/markdown/build/macosx.md.vm
+++ b/src/site/markdown/build/macosx.md.vm
@@ -1,0 +1,48 @@
+# Building on Mac OS X
+#set($h2 = '##')
+
+Given the Unix heritage of Mac OS X, the PL/Java
+[build instructions](build.html) apply with few differences.
+After installing a suitably recent Java Development Kit
+([JDK, not just JRE][jdk8osx]) from Oracle, a quick  
+  
+`mvn -version`  
+  
+should confirm that it is installed, and is the version of Java
+that Maven will use in the build.
+
+[jdk8osx]: https://docs.oracle.com/javase/8/docs/technotes/guides/install/mac_jdk.html
+
+$h2 Note the PL/Java shared object name
+
+On OS X, the shared object file that results from the build will have a name
+that ends in `.bundle`. Because `.bundle` is not a suffix the PostgreSQL `LOAD`
+command automatically tries, it must be spelled out in full:
+
+    LOAD 'libpljava-so-${project.version}.bundle';
+
+As always, unless the file is installed in `$libdir` or in one of the
+directories named in `dynamic_library_path`, then the `LOAD` command must
+also be given the path to the file.
+
+$h2 No need to edit JDK task capabilities
+
+Apple's Java framework allows Java installations to be selectively enabled
+for five different types of task: `Applets`, `WebStart`, `BundledApp`,
+`JNI`, and `CommandLine`, as documented for Apple's [`java_home`][jh] tool.
+
+[jh]: https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man1/java_home.1.html
+
+Some procedures have been posted for editing an `Info.plist` file after
+installing Oracle's Java to enable it for additional task types.
+**Nothing of the sort is needed for PL/Java**, because PL/Java does not use
+the Apple Java framework to locate the Java runtime. Instead, you simply
+set PostgreSQL's `pljava.libjvm_location` variable to identify the exact
+`libjvm.dylib` that PL/Java will use.
+
+For example, if the `mvn -v` shows "Java home" to be  
+`/Library/Java/JavaVirtualMachines/jdk1.8.0_65.jdk/Contents/Home/jre`  
+then you will probably set `pljava.libjvm_location` so:
+
+    SET pljava.libjvm_location TO
+    '/Library/Java/JavaVirtualMachines/jdk1.8.0_65.jdk/Contents/Home/jre/lib/server/libjvm.dylib`;

--- a/src/site/markdown/build/versions.md
+++ b/src/site/markdown/build/versions.md
@@ -1,0 +1,39 @@
+# Versions of external packages needed to build and use PL/Java
+
+As of November 2015, the following version constraints are known.
+
+## Java
+
+No version of Java before 1.6 ("Java 6") is supported. The PL/Java code
+makes use of Java features first appearing in Java 6.
+
+As for later versions of Java, backward compatibility in the language is
+generally good. The most likely problem areas with a new Java version will
+be additions to the JDBC API that PL/Java has not yet implemented.
+
+## Maven
+
+PL/Java can be built with Maven versions at least as far back as 3.0.4.
+As shown in the [Maven release history][mvnhist], **Maven releases after
+3.2.5 require Java 7 or later**. If you wish to *build* PL/Java using a
+Java 6 development kit, you must use a Maven version not newer than 3.2.5.
+
+[mvnhist]: https://maven.apache.org/docs/history.html
+
+## gcc
+
+If you are building on a platform where `gcc` is the compiler,
+versions 4.3.0 or later are recommended in order to avoid a
+[sea of unhelpful compiler messages][gcc35214].
+
+[gcc35214]: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=35214
+
+## PostgreSQL
+
+PL/Java does not currently support PostgreSQL releases before 8.1.
+Recent work is known to have introduced dependencies on 8.1 features.
+
+The current aim is to avoid deliberately breaking compatibility back
+to 8.2. (A former commercial fork of PostgreSQL 8.2 recently returned
+to the open-source fold with a *really* old version of PL/Java, so
+the aim is that the current PL/Java should be a possible upgrade there.)

--- a/src/site/markdown/build/versions.md
+++ b/src/site/markdown/build/versions.md
@@ -30,8 +30,8 @@ versions 4.3.0 or later are recommended in order to avoid a
 
 ## PostgreSQL
 
-PL/Java does not currently support PostgreSQL releases before 8.1.
-Recent work is known to have introduced dependencies on 8.1 features.
+PL/Java does not currently support PostgreSQL releases before 8.2.
+Recent work is known to have introduced dependencies on 8.2 features.
 
 The current aim is to avoid deliberately breaking compatibility back
 to 8.2. (A former commercial fork of PostgreSQL 8.2 recently returned

--- a/src/site/markdown/examples/examples.md.vm
+++ b/src/site/markdown/examples/examples.md.vm
@@ -1,0 +1,97 @@
+# The examples built with PL/Java
+
+## This is a comment, according to Apache Velocity, which is why you'll see
+## extraordinary measures taken below to make ## or lower level headings....
+## Also, if you do not know all the ins and outs of the Velocity template
+## language and would like to spend less time than I did to find the docs:
+## http://velocity.apache.org/engine/devel/user-guide.html
+#set($h2 = '##')
+#set($h3 = '###')
+
+#set($gitdir = "$project.scm.url/pljava-examples/src/main/java/org/postgresql/pljava/example")
+
+The PL/Java source includes a number of [examples][] that are built into
+a jar that can be installed in the same way as a jar of your own PL/Java
+functions and types.
+
+[examples]: $gitdir
+
+You can extract `examples.jar` from the [packaged archive][locate], or use
+the direct path to where it was built: relative to the build root,
+`pljava-examples/target/pljava-examples-\${project.version}.jar`, with
+`\${project.version}` expanded the obvious way, for example
+`${project.version}`.
+
+[locate]: ../install/locate.html
+
+$h2 Loading the examples
+
+Assuming you are connected to a database where PL/Java has been successfully
+loaded, use the `sqlj.install_jar` function, which takes three parameters.
+The first is a URL to the jar file to be loaded. The simplest case would be
+a `file:` URL giving a path on the PostgreSQL server host to the jar file,
+with permissions set so the backend can read it. Other forms of URL are also
+accepted, so `install_jar` could retrieve a jar from the web, for example.
+
+The second parameter is a short name to identify the jar within PL/Java,
+and the third is a boolean controlling whether to execute the
+[deployment descriptor][depdesc] included in the jar as part of installing it.
+
+[depdesc]: https://github.com/tada/pljava/wiki/Sql-deployment-descriptor
+
+Therefore:
+
+```sql
+SELECT sqlj.install_jar(
+  'file://'
+  '/buildroot/pljava-examples/target/pljava-examples-${project.version}.jar',
+  'examples', true);
+```
+
+will install the `examples.jar` file (assuming the build was done in
+`/buildroot`), giving it the identifier `examples` and executing the
+deployment descriptor.
+
+A typical deployment descriptor will merely declare functions or types provided
+by the jar, create tables they rely on, etc. The `examples.jar` deployment
+descriptor goes farther, and calls several functions provided as test cases,
+so this use of `install_jar` may take a few extra seconds and produce some
+test-related output. (To see _successful_ test-related output, be sure to
+set `client_min_messages` to a level at least as detailed as `INFO` before
+invoking `install_jar`.)
+
+$h2 Trying the examples
+
+While the deployment descriptor itself runs some of the examples, once the
+jar is installed, they are all available for you to run, as functions in
+the `javatest` schema.
+
+First, be sure the `javatest` schema is on your `search_path`:
+
+```sql
+SHOW search_path;
+```
+It will be, after `install_jar` returns (though that is arguably a bug and
+could change), but that will not persist into new sessions.
+
+Make sure that the Java classpath for that schema includes the ID for this
+jar:
+
+```sql
+SELECT sqlj.get_classpath('javatest');
+```
+
+If it does not, set the classpath:
+
+```sql
+SELECT sqlj.set_classpath('javatest', 'examples');
+```
+
+Then use some example function:
+
+```sql
+ SELECT javatest.java_addone(3);
+ java_addone 
+-------------
+           4
+```

--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -11,14 +11,18 @@ and benefits of PL/Java can be read on the [wiki][].
 
 ## About this site
 
-You have reached the web site for comprehensive (largely machine generated)
-information on PL/Java, suitable for advanced use or for those interested in
-contributing to the project. More basic information on how to [set up][iguide]
-or [use][uguide] PL/Java can be found on the [wiki][]. The following sections
-offer very brief summaries.
+This site includes reference
+information on PL/Java, covering how to [build][] it, [install][] it,
+and [use][] it. There is also a [wiki][] with more information and examples,
+though in some cases dated. While information from the wiki is gradually
+being migrated to this site and brought up to date, you should still check
+the wiki for information you do not find here.
 
-[iguide]: https://github.com/tada/pljava/wiki/Installation-guide
-[uguide]: https://github.com/tada/pljava/wiki/User-guide
+The following sections offer very brief summaries.
+
+[build]: build/build.html
+[install]: install/install.html
+[use]: use/use.html
 
 ## Use of PL/Java, in a nutshell
 
@@ -29,6 +33,7 @@ provides, with enhanced capabilities found in the [PL/Java API][pljapi].
 PL/Java source files can use Java [annotations][] from the
 [org.postgresql.pljava.annotation package][oppa] to identify the methods and
 types that should be seen in PostgreSQL, as in this [example code][trgann].
+For a step-by-step example, there is always [Hello, world][helwo].
 
 When the sources are compiled, the Java
 compiler will also write an [SQLJ deployment descriptor][depdesc] containing
@@ -49,6 +54,7 @@ use.
 [depdesc]: https://github.com/tada/pljava/wiki/Sql-deployment-descriptor
 [jar]: https://docs.oracle.com/javase/tutorial/deployment/jar/index.html
 [install_jar]: https://github.com/tada/pljava/wiki/SQL%20Functions#wiki-install_jar
+[helwo]: use/hello.html
 
 ## Installation, in a nutshell
 
@@ -56,9 +62,7 @@ PL/Java can be downloaded, then [built using Maven][build]. The build produces
 a native code library (file with name ending in .so, .dll, etc., depending on
 the plaform) and a JAR file. PostgreSQL must be configured to know where these
 are, in addition to the native library for the Java runtime itself. The
-[installation guide][iguide] has details.
-
-[build]: https://github.com/tada/pljava/wiki/Building-pl-java
+[installation guide][install] has details.
 
 ## Moving PL/Java forward
 

--- a/src/site/markdown/install/install.md
+++ b/src/site/markdown/install/install.md
@@ -76,20 +76,28 @@ in the [`examples.jar` supplied in the build][examples].
 
 [examples]: ../examples/examples.html
 
+Although typically only `pljava.libjvm_location` and `pljava.classpath` need
+to be set, there is a [reference to PL/Java configuration variables][varref]
+if you need it.
+
+[varref]: ../use/variables.html
+
+### Choosing where to place the files
+
 Exactly where you place the files, and what pathnames you use in the
 above commands, can depend on your situation:
 
-* You are a superuser on the OS where PostgreSQL is installed (or you are
-    a distribution maintainer building a PL/Java package for that platform).
-* You are not an OS superuser, but you have PostgreSQL superuser rights and
-    OS permissions as the user that runs `postgres`.
-* You have only PostgreSQL superuser rights, cannot write locations owned
-    by the user `postgres` runs as, but you can write some locations that are
-    readable by that user.
-* You have PostgreSQL superuser rights and want to quickly test that you have
-    built a working PL/Java.
+* Are you a superuser on the OS where PostgreSQL is installed (or are you
+    a distribution maintainer building a PL/Java package for that platform)?
+* Are you not an OS superuser, but you have PostgreSQL superuser rights and
+    OS permissions as the user that runs `postgres`?
+* Do you have only PostgreSQL superuser rights, no ability to write locations
+    owned by the user `postgres` runs as, but the ability to write some
+    locations that user can read?
+* Do you have PostgreSQL superuser rights and want to quickly test that you have
+    built a working PL/Java?
 
-First, the quick check.
+The rest of this page will cover those cases. First, the quick check.
 
 ### A quick install check
 

--- a/src/site/markdown/install/install.md
+++ b/src/site/markdown/install/install.md
@@ -1,0 +1,160 @@
+# Installing PL/Java
+
+The PL/Java [build process][bld] using `mvn clean package` produces files
+needed to install the language in PostgreSQL, but does not place those
+files in their final locations or configure PostgreSQL to use them. (Even
+though Maven also has an `install` command, that's not what it does, either.)
+Once the build is done, these instructions cover how to make PL/Java available
+in your database. 
+
+[bld]: ../build/build.html
+
+The successful build will have produced two important files:
+
+* The PL/Java `jar` file, which contains Java classes, so it is
+    architecture-independent.
+
+* The PL/Java native library, which is architecture-specific. Its filename
+    extension can depend on the operating system: `.so` on many systems,
+    `.dll` on Windows, `.bundle` on Mac OS X / Darwin.
+
+For a final installation, you will want to copy these files from the build tree
+to more permanent locations, though a quick test that PL/Java works can be made
+with the files right where they are. See [locating the built files][locate] for
+how to find their exact names in your build tree.
+
+A third path name you will need to know is the one to your Java Runtime
+Environment's `libjvm` shared object (`.so`, `.dll`, etc.), usually a few
+levels deep under the directory where Java is installed on your platform.
+See [locating libjvm][jvmloc] for help finding it.
+
+[locate]: locate.html
+[jvmloc]: locatejvm.html
+
+## Special topics
+
+Be sure to read these additional sections if:
+
+* You are installing to [a PostgreSQL release earlier than 9.2][pre92]
+* You are installing on [a system using SELinux][selinux]
+
+[pre92]: prepg92.html
+[selinux]: selinux.html
+
+## Install, configure, check
+
+Because PL/Java, by design, runs entirely in the backend process created
+for each connection to PostgreSQL, to configure it does not require any
+cluster-wide actions such as stopping or restarting the server, or editing
+the configuration file; any necessary settings can be made in SQL over
+an ordinary connection.
+
+_Caution: if you are installing a new, little-tested PL/Java build, be aware
+that in the unexpected case of a crash, the `postmaster` will kick other
+sessions out of the database for a moment to verify integrity, and then let
+them reconnect. If that would be disruptive, it may be best to `initdb` a
+new cluster in some temporary location and test PL/Java there, installing to
+a production server only when satisfied._
+
+After connecting to the desired database (the connection must be as a
+PostgreSQL superuser), the commands for first-time PL/Java setup are:
+
+```
+SET client_min_messages TO NOTICE; -- or anything finer (INFO, DEBUG, ...)
+SET pljava.libjvm_location TO ' use the libjvm path here ';
+SET pljava.classpath TO ' use the pljava.jar path here ';
+LOAD ' use the PL/Java native library path here ';
+```
+(The `client_min_messages` setting is only to ensure you do not miss
+the `NOTICE` message in case of success.) If you see
+
+    NOTICE: PL/Java loaded
+
+then you are ready to test some PL/Java functions, such as the ones
+in the [`examples.jar` supplied in the build][examples].
+
+[examples]: ../examples/examples.html
+
+Exactly where you place the files, and what pathnames you use in the
+above commands, can depend on your situation:
+
+* You are a superuser on the OS where PostgreSQL is installed (or you are
+    a distribution maintainer building a PL/Java package for that platform).
+* You are not an OS superuser, but you have PostgreSQL superuser rights and
+    OS permissions as the user that runs `postgres`.
+* You have only PostgreSQL superuser rights, cannot write locations owned
+    by the user `postgres` runs as, but you can write some locations that are
+    readable by that user.
+* You have PostgreSQL superuser rights and want to quickly test that you have
+    built a working PL/Java.
+
+First, the quick check.
+
+### A quick install check
+
+For a quick sanity test, there is no need to move the built files to more
+permanent locations, as long as the build tree location and permissions are
+such that the PostgreSQL backend can read them where they are. Use those
+pathnames directly in the `SET` and `LOAD` commands.
+
+For the lowest-impact quick test, begin a transaction first, load PL/Java
+and run [any tests you like][examples], then roll the transaction back.
+
+### OS superuser or distribution maintainer
+
+If you fall in this category, you can minimize configuration within
+PostgreSQL by placing the built files into standard locations,
+so `SET` commands are not needed for PostgreSQL to find them. For example,
+if the PL/Java native library is copied into the PostgreSQL `$libdir`
+(shown by `pg_config` as `PKGLIBDIR`), then the `LOAD` command can be
+given just the basename of the file instead of a full path. Or, if
+`dynamic_library_path` is already set, the file can be placed in any
+directory on that list for the same effect.
+
+_Todo: proclaim and implement default location for pljava.classpath_
+
+**If you are a distribution maintainer** packaging PL/Java for a certain
+platform, and you know or control that platform's conventions for where
+the Java `libjvm` should be found, or where PostgreSQL extension files
+(architecture-dependent and -independent) should go, please build your
+PL/Java package with those locations as the defaults for the corresponding
+PL/Java variables, and with the built files in those locations.
+
+_Todo: add maven build options usable by distro spinners to set those defaults._
+
+### PostgreSQL superuser with access as user running postgres
+
+If you are not a superuser on the OS, you may not be able to place the
+PL/Java files in the default locations PostgreSQL was built with.
+If you have permissions as the user running `postgres`, you might choose
+locations in a directory associated with that user, such as the `DATADIR`,
+and set the `pljava.*` variables to point to them. Use a `LOAD` command
+with the full path of the native library, or set `dynamic_library_path` to
+include its location, and give only the basename to `LOAD`.
+
+If you would rather ensure that the user running `postgres`, if compromised,
+could not modify these files, then the next case will be more appropriate.
+
+### PostgreSQL superuser, OS user distinct from the user running postgres
+
+In this case, simply place the files in any location where you can make them
+readable by the user running `postgres`, and set the `pljava.*` variables
+accordingly.
+
+## Making the configuration settings persistent
+
+If you have loaded PL/Java successfully after making necessary changes to
+some `pljava.*` variables, you will want those settings to stick. The simplest
+way is to reissue the same `SET` commands as `ALTER DATABASE ` *databasename*`
+SET ...` commands, which will be effective when any user connects to the same
+database.
+
+Another approach is to save them to the server's configuration file.
+If you wish PL/Java to be available for all databases in a cluster, it may
+be more convenient to put the settings in the file than to issue
+`ALTER DATABASE` for several databases, but `pg_ctl reload` will be needed
+to make changed settings effective. Starting with PostgreSQL 9.4,
+`ALTER SYSTEM` may be used as an alternative to editing the file.
+
+For PostgreSQL releases [earlier than 9.2][pre92], the configuration file is
+the _only_ way to make your settings persistent.

--- a/src/site/markdown/install/install.md
+++ b/src/site/markdown/install/install.md
@@ -156,9 +156,9 @@ accordingly.
 
 If you have loaded PL/Java successfully after making necessary changes to
 some `pljava.*` variables, you will want those settings to stick. The simplest
-way is to reissue the same `SET` commands as `ALTER DATABASE ` *databasename*`
-SET ...` commands, which will be effective when any user connects to the same
-database.
+way is to reissue the same `SET` commands as
+`ALTER DATABASE ` *databasename* ` SET ...` commands, which will be effective
+when any user connects to the same database.
 
 Another approach is to save them to the server's configuration file.
 If you wish PL/Java to be available for all databases in a cluster, it may

--- a/src/site/markdown/install/install.md
+++ b/src/site/markdown/install/install.md
@@ -1,9 +1,8 @@
 # Installing PL/Java
 
-The PL/Java [build process][bld] using `mvn clean package` produces files
+The PL/Java [build process][bld] using `mvn clean install` produces files
 needed to install the language in PostgreSQL, but does not place those
-files in their final locations or configure PostgreSQL to use them. (Even
-though Maven also has an `install` command, that's not what it does, either.)
+files in their final locations or configure PostgreSQL to use them.
 Once the build is done, these instructions cover how to make PL/Java available
 in your database. 
 
@@ -37,9 +36,11 @@ Be sure to read these additional sections if:
 
 * You are installing to [a PostgreSQL release earlier than 9.2][pre92]
 * You are installing on [a system using SELinux][selinux]
+* You are installing on [Mac OS X][osx]
 
 [pre92]: prepg92.html
 [selinux]: selinux.html
+[osx]: ../build/macosx.html
 
 ## Install, configure, check
 

--- a/src/site/markdown/install/install.md
+++ b/src/site/markdown/install/install.md
@@ -120,7 +120,9 @@ given just the basename of the file instead of a full path. Or, if
 `dynamic_library_path` is already set, the file can be placed in any
 directory on that list for the same effect.
 
-_Todo: proclaim and implement default location for pljava.classpath_
+If the `pljava-${project.version}.jar` file is placed in the default location
+(typically a `pljava` subdirectory of the PostgreSQL "share" directory), then
+`pljava.classpath` will not need to be set.
 
 **If you are a distribution maintainer** packaging PL/Java for a certain
 platform, and you know or control that platform's conventions for where

--- a/src/site/markdown/install/locate.md.vm
+++ b/src/site/markdown/install/locate.md.vm
@@ -1,0 +1,91 @@
+# Finding the files produced by a PL/Java build
+
+## This is a comment, according to Apache Velocity, which is why you'll see
+## extraordinary measures taken below to make ## or lower level headings....
+## Also, if you do not know all the ins and outs of the Velocity template
+## language and would like to spend less time than I did to find the docs:
+## http://velocity.apache.org/engine/devel/user-guide.html
+#set($h2 = '##')
+#set($h3 = '###')
+
+The PL/Java [build process][bld] using `mvn clean package` produces files
+needed to install the language in PostgreSQL, which need to be copied to
+appropriate permanent locations, and their pathnames may have to be set
+in `pljava.*` variables, as the [installation page][inst] describes.
+
+They are produced in different locations in the build tree and their
+exact names can depend on platform and version details, so these tips
+may help in finding them.
+
+[bld]: ../build/build.html
+[inst]: install.html
+
+$h2 The packaged tar or zip file
+
+The `packaging` subproject builds a single `.tar.gz` or `.zip` file
+(depending on the platform where the build is done). Relative to the
+root of the build tree, it is found at
+
+`packaging/target/pljava-${pgversion}-${naraol}.tar.gz` (or `.zip`)
+
+where `${pgversion}` resembles `pg9.4` and `${naraol}` is an
+*architecture-os-linker* triple, for example `amd64-Linux-gpp`
+or `amd64-Windows-msvc`. It contains these things:
+
+`pljava/pljava.jar`
+: The architecture-independent, Java portion of the PL/Java implementation
+    (more below).
+
+`pljava/pljava.so` (or `.dll`, etc.)
+: The architecture-dependent, native library portion of the PL/Java
+    implementation (more below).
+
+`pljava/examples.jar`
+: A set of [examples demonstrating PL/Java usage][examples], usable also
+    as rudimentary tests.
+
+`pljava/docs.tar`
+: A collection of historical-interest and design documents from the origins
+    of PL/Java.
+
+`pljava/install.sql`, `pljava/uninstall.sql`
+: _Deprecated_ In normal circumstances, these are no longer needed to install
+    or uninstall PL/Java.
+
+`pljava/deploy.jar`
+: _Deprecated_ In normal circumstances, this tool is no longer needed to install
+    or uninstall PL/Java.
+
+[examples]: ../examples/examples.html
+
+Extract the needed files from this archive and place them in appropriate
+locations, then complete the [installation][inst].
+
+$h2 Naming the built files directly
+
+When the only purpose is to quickly check the built PL/Java, it is faster
+not to extract files from the packaged archive into some other location,
+but simply to `SET` the `pljava.*` variables to point to the files right
+where they were generated in the build tree.
+
+$h3 The architecture-independent PL/Java `jar` file
+
+This file is built by the `pljava` subproject,
+so relative to the source root where the build was
+done, it will be found in `pljava/target/pljava-\${project.version}.jar`
+with `\${project.version}` replaced in the obvious way,
+for example `${project.version}`.
+
+$h3 The architecture-dependent PL/Java native library
+
+This is built by the `pljava-so` subproject. Its filename extension can depend
+on the operating system: `.so` on many systems, `.dll` on Windows, `.bundle` on
+Mac OS X / Darwin. Relative to the source root where the build was performed, it
+is at the end of a long and redundant path that contains the project version
+(twice), an "architecture-OS-linker" string (twice), and a build type
+("plugin"), also twice.
+
+An example, for version `${project.version}` and arch-os-linker of
+`amd64-Linux-gpp` is (very deep breath):
+
+`pljava-so/target/nar/pljava-so-${project.version}-amd64-Linux-gpp-shared/lib/amd64-Linux-gpp/shared/libpljava-so-${project.version}.so`

--- a/src/site/markdown/install/locate.md.vm
+++ b/src/site/markdown/install/locate.md.vm
@@ -76,6 +76,10 @@ done, it will be found in `pljava/target/pljava-\${project.version}.jar`
 with `\${project.version}` replaced in the obvious way,
 for example `${project.version}`.
 
+In the simplest installation, determine the default value of `pljava.classpath`
+and place the jar file at that exact name. In a typical distribution, the
+default will be `$sharedir/pljava/pljava-\${project.version}.jar`.
+
 $h3 The architecture-dependent PL/Java native library
 
 This is built by the `pljava-so` subproject. Its filename extension can depend

--- a/src/site/markdown/install/locate.md.vm
+++ b/src/site/markdown/install/locate.md.vm
@@ -8,7 +8,7 @@
 #set($h2 = '##')
 #set($h3 = '###')
 
-The PL/Java [build process][bld] using `mvn clean package` produces files
+The PL/Java [build process][bld] using `mvn clean install` produces files
 needed to install the language in PostgreSQL, which need to be copied to
 appropriate permanent locations, and their pathnames may have to be set
 in `pljava.*` variables, as the [installation page][inst] describes.

--- a/src/site/markdown/install/locatejvm.md
+++ b/src/site/markdown/install/locatejvm.md
@@ -1,0 +1,50 @@
+# Finding the Java Runtime Environment `libjvm` library
+
+PL/Java [installation][inst] requires knowing the filesystem paths
+to some items produced by the [build][], and also to the `libjvm`
+shared object for the Java Runtime Environment that is to be used.
+
+[build]: ../build/build.html
+[inst]: install.html
+
+To find that object can be a bit of an exercise, because of
+the variety of locations and naming schemes for the Java runtime on
+different platforms. It may be simplest to do a filesystem search for
+the name `libjvm.*` under the Java home directory (which is reported
+by `mvn -v` assuming the JRE that you used for running Maven is the
+one you intend to use at run time).
+
+The filename extension may be `.so` on many systems, `.dll` on Windows,
+etc.
+
+_Todo: add details for Mac, which may be different enough to be confusing._
+
+_Todo: make this whole part easier._
+
+If a tool such as Linux `strace` is available to see what files are opened
+by a process, this works:
+
+```
+strace -e open java 2>&1 | grep libjvm
+```
+
+## Using a less-specific path
+
+The methods above may find the `libjvm` object on a very specific path
+(for example, including the JRE vendor, major, minor, version, and patch
+numbers). If that exact path is used to `SET pljava.libjvm_location`
+in PostgreSQL, PL/Java will stop working as soon as the next Java patch
+is applied.
+
+Typical OS distributions will also provide some less specific, alias
+paths to the Java runtime environment. On Linux, for example, there
+may be a `/usr/lib/jvm` directory with entries using only the major
+and minor Java version that are symbolic links to the fully specified
+JRE. By using such an alias instead of the absolutely specific Java
+path, you can avoid headaches when Java is updated.
+
+By the same token, the directory of aliases may contain a completely
+generic one like `jre`, linked to whichever Java version is considered
+current. Using an alias that is too generic could possibly invite headaches
+if the default Java version is ever changed to one your PL/Java modules
+were not written for (or PL/Java itself was not built for).

--- a/src/site/markdown/install/locatejvm.md
+++ b/src/site/markdown/install/locatejvm.md
@@ -15,11 +15,8 @@ by `mvn -v` assuming the JRE that you used for running Maven is the
 one you intend to use at run time).
 
 The filename extension may be `.so` on many systems, `.dll` on Windows,
-etc.
-
-_Todo: add details for Mac, which may be different enough to be confusing._
-
-_Todo: make this whole part easier._
+etc. On Mac OS X, the name will end with `.dylib` (see the
+[Mac OS X build notes](../build/macosx.html) for more about Mac OS X).
 
 If a tool such as Linux `strace` is available to see what files are opened
 by a process, this works:

--- a/src/site/markdown/install/prepg92.md
+++ b/src/site/markdown/install/prepg92.md
@@ -1,0 +1,63 @@
+# Installation on PostgreSQL releases earlier than 9.2
+
+In PostgreSQL releases 9.2 and later, PL/Java can be installed entirely
+without disturbing the `postgresql.conf` file or reloading/restarting the
+server: the configuration variables can be set interactively in a session
+until PL/Java loads sucessfully, then saved with a simple
+`ALTER DATABASE` _dbname_ `SET` _var_ `FROM CURRENT` for each setting
+that had to be changed.
+
+Releases earlier than 9.2 are slightly less convenient. It is still possible
+to work out the right settings in an interactive session, but once found,
+the settings must be added to `postgresql.conf` to be persistent, and the
+postmaster signalled (with `pg_ctl reload`) to pick up the new settings.
+
+Releases before 9.2 also require setting `custom_variable_classes` in
+`postgresql.conf` to include the prefix `pljava`, and that assignment must
+be earlier in the file than any settings of `pljava.*` variables.
+
+## Trying settings interactively
+
+It is still possible to do an exploratory session to find the variable settings
+that work before touching `postgresql.conf` at all, but
+the details are slightly different.
+
+In later PostgreSQL versions, you would typically use some `SET` commands
+followed by a `LOAD` (followed, perhaps, by more `SET` commands unless you
+always get things right on the first try).
+
+Before release 9.2, however, the order has to be `LOAD` first, which typically
+will lead to an incompletely-started warning because the configuration settings
+have not been made yet. _Then_, because the module has been loaded,
+`pljava.*` variables will be recognized and can be set and changed until
+PL/Java successfully loads, just as in the newer releases.
+
+Once working settings are found, edit `postgresql.conf`, make sure that
+`custom_variable_classes` includes `pljava`, copy in the variable settings
+that worked, and use `pg_ctl reload` to make the new settings effective.
+
+## But what if I want the load to fail and it doesn't?
+
+The procedure above relies on the way loading stops when the settings are not
+right, giving you a chance to adjust them interactively. That turns out to be
+a problem if there are previously-saved settings, or the original defaults,
+that happen to *work* even if they are not the settings you want. In that case,
+the `LOAD` command starts PL/Java right up, leaving you no chance in the
+interactive session to change anything.
+
+To escape that behavior, there is one more very simple configuration variable,
+`pljava.enable`. If it is `false`, `LOAD`ing PL/Java will always stop early and
+allow you to set other variables before setting `pljava.enable` to `true`.
+
+To answer the hen-and-egg question of how to set `pljava.enable` to `false`
+before loading the module, it defaults to `false` on PostgreSQL releases
+earlier than 9.2, so you will always have the chance to test your settings
+interactively (and you will always have to set it explicitly `true` when
+you are ready).
+
+If it is already `true` because of an earlier configuration saved in
+`postgresql.conf`, it will be recognized in your interactive session and you
+can set it `false` as needed.
+
+On later PostgreSQL releases with no such complications, it defaults to `true`
+and can be ignored.

--- a/src/site/markdown/install/prepg92.md
+++ b/src/site/markdown/install/prepg92.md
@@ -30,7 +30,7 @@ Before release 9.2, however, the order has to be `LOAD` first, which typically
 will lead to an incompletely-started warning because the configuration settings
 have not been made yet. _Then_, because the module has been loaded,
 `pljava.*` variables will be recognized and can be set and changed until
-PL/Java successfully loads, just as in the newer releases.
+PL/Java successfully loads, just as in the newer versions of PostgreSQL.
 
 Once working settings are found, edit `postgresql.conf`, make sure that
 `custom_variable_classes` includes `pljava`, copy in the variable settings
@@ -46,18 +46,18 @@ the `LOAD` command starts PL/Java right up, leaving you no chance in the
 interactive session to change anything.
 
 To escape that behavior, there is one more very simple configuration variable,
-`pljava.enable`. If it is `false`, `LOAD`ing PL/Java will always stop early and
-allow you to set other variables before setting `pljava.enable` to `true`.
+`pljava.enable`. If it is `off`, `LOAD`ing PL/Java will always stop early and
+allow you to set other variables before setting `pljava.enable` to `on`.
 
-To answer the hen-and-egg question of how to set `pljava.enable` to `false`
-before loading the module, it defaults to `false` on PostgreSQL releases
+To answer the hen-and-egg question of how to set `pljava.enable` to `off`
+before loading the module, it _defaults_ to `off` on PostgreSQL releases
 earlier than 9.2, so you will always have the chance to test your settings
-interactively (and you will always have to set it explicitly `true` when
+interactively (and you will always have to set it explicitly `on` when
 you are ready).
 
-If it is already `true` because of an earlier configuration saved in
+If it is already `on` because of an earlier configuration saved in
 `postgresql.conf`, it will be recognized in your interactive session and you
-can set it `false` as needed.
+can set it `off` as needed.
 
-On later PostgreSQL releases with no such complications, it defaults to `true`
+On later PostgreSQL releases with no such complications, it defaults to `on`
 and can be ignored.

--- a/src/site/markdown/install/selinux.md
+++ b/src/site/markdown/install/selinux.md
@@ -1,0 +1,97 @@
+# Using PL/Java with SELinux
+
+These notes were made running PostgreSQL and PL/Java on a Red Hat system,
+but should be applicable--with possible changes to details--on other systems
+running SELinux.
+
+Anything that gets run by `postgres` itself runs under a special SELinux context
+with type `postgresql_t` that severely limits things it can do.  This is
+generally good.
+
+## File contexts
+
+SELinux may prevent it from opening important files, such as
+`libpljava-[version].so` or `pljava-[version].jar`, depending
+on the SELinux contexts set on those files. The contexts can be
+listed using `ls -Z`.
+
+The exact SELinux rules being applied, and the file contexts they
+would allow, can be different. For example, a `.so` file is considered
+executable and triggers one kind of rule, while to SELinux a `.jar` file
+is just an ordinary file that Java is trying to open.
+
+Whether a failure is being caused by SELinux can be determined by
+searching the system log for `avc denied` messages. If that is the
+problem, it can be solved in more than one way. For example:
+
+* Search the system's existing SELinux policy (using [apol][] or
+    [sesearch][], perhaps) to find the rules that apply to what
+    the program is trying to do, and what target contexts *would be*
+    allowed, then use [chcon][] to set one of those contexts on the
+    file in question. For example, on a Red Hat box, changing the
+    context type on `libpljava-[version].so` to `lib_t` and on
+    `pljava-[version].jar` to `usr_t` did the trick.
+* Write and load a new [SELinux policy module][sepolmod] with rules
+    that allow the needed operations.
+
+[apol]:     https://raw.githubusercontent.com/wiki/TresysTechnology/setools3/files/images/setools-3.3/apol-rule-search.png
+[sesearch]: https://raw.githubusercontent.com/wiki/TresysTechnology/setools3/files/images/setools-3.3/sesearch-help.png
+[chcon]:    http://www.gnu.org/software/coreutils/manual/html_node/chcon-invocation.html
+[sepolmod]: http://docs.fedoraproject.org/en-US/Fedora/13/html/SELinux_FAQ/index.html#faq-entry-whatare-policy-modules
+
+### Issues requiring policy modules
+
+Something in the JVM uses the `sched_get{param,priority,scheduler}` system
+calls, so a process of type `postgresql_t` has to be given the `getsched`
+SELinux permission. Also, for SSL connections to work, access to the
+`random_device` needs to be allowed. Both of these rules can be added in
+a policy module:
+
+```
+policy_module(mod-pljava, 1.0)
+
+require {
+    type postgresql_t;
+    type random_device_t;
+}
+
+allow postgresql_t postgresql_t : process { getsched };
+allow postgresql_t random_device_t : chr_file { getattr };
+```
+
+If that is placed in a file `pljava.te` then
+
+    make -f /usr/share/selinux/devel/Makefile
+    semodule -i pljava.pp
+
+will build and install it.
+
+As another example, suppose a PL/Java function needs to make an `ssh`
+connection to a remote host. In the default policy, nothing running as
+`postgresql_t` is allowed to connect network sockets to remote `ssh` ports.
+Again, a policy module can do the trick:
+
+```
+policy_module(mod-pgsql-ssh, 1.0)
+
+require {
+    type postgresql_t;
+    type ssh_port_t;
+}
+
+allow postgresql_t ssh_port_t : tcp_socket { name_connect };
+```
+
+As it stands, this is quite broad, and would allow connections to the `ssh`
+port at _any_ remote address, exactly what the SELinux policy was trying
+to prevent. It is reportedly possible (if fiddly) to allow only connecting
+to the `ssh` port on the _intended_ remote machine, using the right
+[melange of SELinux and iptables][melange].
+
+[melange]: http://serverfault.com/questions/366922/selinux-limit-httpd-outbound-connections-by-address-and-port
+
+## How to break things
+
+One of the best ways to cause a PL/Java installation to stop working, after
+being trouble-free for ages, is to replace or update one of the files it
+depends on, and forget to reapply the needed SELinux context to the file.

--- a/src/site/markdown/install/selinux.md
+++ b/src/site/markdown/install/selinux.md
@@ -21,7 +21,7 @@ executable and triggers one kind of rule, while to SELinux a `.jar` file
 is just an ordinary file that Java is trying to open.
 
 Whether a failure is being caused by SELinux can be determined by
-searching the system log for `avc denied` messages. If that is the
+searching the system log for `avc: denied` messages. If that is the
 problem, it can be solved in more than one way. For example:
 
 * Search the system's existing SELinux policy (using [apol][] or

--- a/src/site/markdown/install/selinux.md
+++ b/src/site/markdown/install/selinux.md
@@ -39,7 +39,7 @@ problem, it can be solved in more than one way. For example:
 [chcon]:    http://www.gnu.org/software/coreutils/manual/html_node/chcon-invocation.html
 [sepolmod]: http://docs.fedoraproject.org/en-US/Fedora/13/html/SELinux_FAQ/index.html#faq-entry-whatare-policy-modules
 
-### Issues requiring policy modules
+## Issues requiring policy modules
 
 Something in the JVM uses the `sched_get{param,priority,scheduler}` system
 calls, so a process of type `postgresql_t` has to be given the `getsched`
@@ -89,6 +89,25 @@ to the `ssh` port on the _intended_ remote machine, using the right
 [melange of SELinux and iptables][melange].
 
 [melange]: http://serverfault.com/questions/366922/selinux-limit-httpd-outbound-connections-by-address-and-port
+
+### avc: denied { execstack }
+
+At one time, log messages saying `avc: denied { execstack }` might be seen,
+because Sun had released a Java distribution with a `libjvm.so` with the
+`execstack` attribute missing entirely, which SELinux interprets to mean that
+the library _might_ need to execute code on the stack, even if it doesn't
+really.
+
+If seen, the problem can be confirmed by running
+`execstack -q` ([manual page][execstack]) on the
+`libjvm.so` file and seeing that it has no `execstack` attribute.
+
+Recent Java distributions have properly included the attribute, set to false,
+so SELinux knows the JVM will not need to execute code on the stack. Therefore,
+the best resolution to the issue is to upgrade to a JDK distribution that is
+not missing the attribute.
+
+[execstack]: http://man7.org/linux/man-pages/man8/execstack.8.html
 
 ## How to break things
 

--- a/src/site/markdown/use/hello.md.vm
+++ b/src/site/markdown/use/hello.md.vm
@@ -231,7 +231,7 @@ proj
    | src
    |   | main
    |        | java
-   |	         | Hello.java
+   |             | Hello.java
    | target
           | proj-0.0.1-SNAPSHOT.jar
 ```
@@ -420,7 +420,7 @@ even calling the function_ any time a parameter is null.
   ...
 ```
 
-Another optimization rests on the observation that the `hello` function has
+Another optimization suggests itself because the `hello` function has
 no side effects, and its result depends on nothing except the parameter passed
 to it. By default, functions are assumed to possibly have side effects, depend
 on database contents or outside influences, and otherwise be harder to reason

--- a/src/site/markdown/use/hello.md.vm
+++ b/src/site/markdown/use/hello.md.vm
@@ -1,0 +1,461 @@
+# The obligatory Hello example
+#set($h2 = '##')
+#set($h3 = '###')
+
+Every employee of `example.com` is required to write a function that says
+`Hello, world!`. There is no escape from this requirement. This page is
+dedicated to all those `example.com` employees faced with that terrible task.
+
+$h2 The goal
+
+Clearly, a function that only returns `Hello, world!` is useless for
+illustrating how to pass parameters. So, the goal will be a function
+that works like this:
+
+```sql
+# \df
+                           List of functions
+ Schema | Name  | Result data type  |   Argument data types    |  Type  
+--------+-------+-------------------+--------------------------+--------
+ public | hello | character varying | towhom character varying | normal
+(1 row)
+# select hello('world');
+     hello     
+---------------
+ Hello, world!
+(1 row)
+```
+
+$h2 A start: the Java program
+
+Employees of `example.com` never forget to put their Java code in a package
+that begins with `com.example`, so very quickly this program takes shape:
+
+```java
+package com.example.proj;
+
+public class Hello {
+
+  public static String hello(String toWhom) {
+    return "Hello, " + toWhom + "!";
+  }
+
+}
+```
+
+$h2 How to build it: a Maven project
+
+Such a small program might not need a build system like Maven, but like any
+project, the requirements could grow over time, so it might as well be set up
+right from the beginning.
+
+In preparation, PL/Java must have been built, using the command
+`mvn clean install`. Recall from the [installation][inst] page that
+the `install` Maven goal has nothing to do with installing PL/Java into
+PostgreSQL--that requires only `mvn clean package` plus further non-Maven
+steps--but the `install` goal _does_ register PL/Java in your Maven
+repository. With that done, any project of your own needs only declare
+`pljava-api` as a dependency, and Maven can compile and package it for you.
+
+[inst]: ../install/install.html
+
+$h3 The POM file
+
+The project begins as an empty directory (named `proj` in this example),
+and the first thing to go in that directory is a `pom.xml` file. The
+Project Object Model is what tells Maven all it needs to know about
+this project. It is XML and verbose, and more lines than the Hello program
+itself! But it is mostly unchanging boilerplate and, as you can see, only
+has a few places to change for information specific to the project.
+
+An important Maven feature is POM inheritance. In an organization with many
+similar projects, there might be one `pom.xml` like this one, and many
+individual projects with shorter `pom.xml` files naming this as the parent.
+
+```xml
+<project
+ xmlns="http://maven.apache.org/POM/4.0.0"
+ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+ xsi:schemaLocation=
+ "http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+>
+  <modelVersion>4.0.0</modelVersion>
+
+  <!-- Above is all boilerplate. Next: your project's "Maven coordinates" -->
+
+  <groupId>com.example</groupId>
+  <artifactId>proj</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+
+  <!-- Coordinates are nice, but so are names and descriptions for humans. -->
+
+  <name>Hello in PL/Java</name>
+  <description>Project that provides a Hello function</description>
+
+  <!--
+    Many Maven plugins care what character set encoding your files are in.
+    For this example I've chosen the most restrictive (US-ASCII). Change if
+    your files use a different encoding, but be sure not to lie. You should
+    be sure the encoding named here IS the way your source files are coded.
+  -->
+  
+  <properties>
+    <project.build.sourceEncoding>US-ASCII</project.build.sourceEncoding>
+  </properties>
+
+  <!-- Here's where you say your project depends on a pljava-api version. -->
+
+  <dependencies>
+    <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>pljava-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+
+  <!-- The rest here is pretty much boilerplate. -->
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>2.6</version>
+        <configuration>
+          <archive>
+            <manifest>
+              <!-- This identifies and version-stamps the jar.
+                 Not essential, but easy and useful. -->
+              <addDefaultImplementationEntries>
+                true
+              </addDefaultImplementationEntries>
+            </manifest>
+
+            <manifestSections>
+              <!-- This identifies a file in the jar named
+                 pljava.ddr as an SQLJDeploymentDescriptor. -->
+              <manifestSection>
+                <name>pljava.ddr</name>
+                <manifestEntries>
+                  <SQLJDeploymentDescriptor>
+                    true
+                  </SQLJDeploymentDescriptor>
+                </manifestEntries>
+              </manifestSection>
+            </manifestSections>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>
+```
+
+So far, so good. There is a new `proj` directory with only this `pom.xml` file
+in it:
+
+```
+proj
+   | pom.xml
+```
+
+What happens if `mvn clean package` is run in this directory, even before
+any Java code has been written?
+
+```
+[WARNING] JAR will be empty - no content was marked for inclusion!
+[INFO] Building jar: /var/tmp/proj/target/proj-0.0.1-SNAPSHOT.jar
+[INFO] ------------------------------------------------------------------------
+[INFO] BUILD SUCCESS
+[INFO] ------------------------------------------------------------------------
+```
+
+Now there is a `target` subdirectory with something in it:
+
+```
+proj
+   | pom.xml
+   | target
+          | proj-0.0.1-SNAPSHOT.jar
+```
+
+Although Maven warned the jar would be empty, in fact it is not _completely_
+empty:
+
+```
+$ jar tf target/proj-0.0.1-SNAPSHOT.jar 
+META-INF/
+META-INF/MANIFEST.MF
+META-INF/maven/
+META-INF/maven/com.example/
+META-INF/maven/com.example/proj/
+META-INF/maven/com.example/proj/pom.xml
+META-INF/maven/com.example/proj/pom.properties
+```
+
+It has a manifest file, and a couple of files Maven adds to save information
+about the build. What is in the manifest?
+
+```
+$ unzip -c target/proj-0.0.1-SNAPSHOT.jar META-INF/MANIFEST.MF
+Manifest-Version: 1.0
+Implementation-Title: Hello in PL/Java
+Implementation-Version: 0.0.1-SNAPSHOT
+Implementation-Vendor-Id: com.example
+
+Name: pljava.ddr
+SQLJDeploymentDescriptor: true
+```
+
+Clearly, Maven did what the POM told it to do. It created a manifest with
+naming and version information for the project, and declaring that the file
+`pljava.ddr` (if there were such a file in the jar) is special because it is
+an [SQLJ deployment descriptor][depdesc].
+
+**This proves that Maven can successfully build an empty project with no code!**
+
+[depdesc]: https://github.com/tada/pljava/wiki/Sql-deployment-descriptor
+
+$h3 Adding the Java code
+
+Maven has a _convention over configuration_ philosophy: it has strict
+expectations of how the project directories will be laid out, and if those
+expectations are followed, it knows what to do, without need to add more
+information in the POM. Sources go in `src`, and they are split between `main`
+and `test` for sources that are only built for tests. Sources written in Java
+go in a `java` subdirectory. So, the Java class that was shown earlier could be
+saved as `Hello.java`, here:
+
+```
+proj
+   | pom.xml
+   | src
+   |   | main
+   |        | java
+   |	         | Hello.java
+   | target
+          | proj-0.0.1-SNAPSHOT.jar
+```
+
+After running `mvn clean package` again, what is now in the jar?
+
+
+```
+$ jar tf target/proj-0.0.1-SNAPSHOT.jar 
+META-INF/
+META-INF/MANIFEST.MF
+com/
+com/example/
+com/example/proj/
+com/example/proj/Hello.class
+META-INF/maven/
+META-INF/maven/com.example/
+META-INF/maven/com.example/proj/
+META-INF/maven/com.example/proj/pom.xml
+META-INF/maven/com.example/proj/pom.properties
+```
+
+This is good progress. The class file is placed in the jar at its correct,
+package-based path, even though the Java file was saved directly in
+`src/main/java`. That is convenient for such a small project. A larger project
+with many classes would probably organize the source files into package-based
+subdirectories of `src/main/java` also.
+
+But something is still missing from this jar. It does not contain any
+`pljava.ddr` file to tell PL/Java what to do when loading it.
+
+$h3 Annotating the Java code
+
+That can be fixed by adding two lines to the Java code:
+
+```java
+package com.example.proj;
+
+import org.postgresql.pljava.annotation.Function;
+
+public class Hello {
+
+  @Function
+  public static String hello(String toWhom) {
+    return "Hello, " + toWhom + "!";
+  }
+
+}
+```
+
+The [@Function annotation][funcanno] declares that the `hello` function should
+be available from SQL, so a `pljava.ddr` file will be added to the jar,
+containing the SQL commands to make that happen.
+
+[funcanno]: ../pljava-api/apidocs/index.html?org/postgresql/pljava/annotation/Function.html
+
+One more try with `mvn clean package` and there it is:
+
+```
+$ jar tf target/proj-0.0.1-SNAPSHOT.jar 
+META-INF/
+META-INF/MANIFEST.MF
+com/
+com/example/
+com/example/proj/
+com/example/proj/Hello.class
+pljava.ddr
+META-INF/maven/
+META-INF/maven/com.example/
+META-INF/maven/com.example/proj/
+META-INF/maven/com.example/proj/pom.xml
+META-INF/maven/com.example/proj/pom.properties
+```
+
+Curious about what is _in_ the `pljava.ddr` file?
+
+```
+$ unzip -c target/proj-0.0.1-SNAPSHOT.jar pljava.ddr
+SQLActions[]={
+"BEGIN INSTALL
+BEGIN PostgreSQL
+CREATE OR REPLACE FUNCTION hello(
+	toWhom varchar)
+	RETURNS varchar
+	LANGUAGE java VOLATILE
+	AS 'com.example.proj.Hello.hello(java.lang.String)'
+END PostgreSQL;
+END INSTALL",
+"BEGIN REMOVE
+BEGIN PostgreSQL
+DROP FUNCTION hello(
+	toWhom varchar)
+END PostgreSQL;
+END REMOVE"
+}
+```
+
+There you have it. A jar file containing the new class, and the instructions
+PL/Java needs when installing or removing it.
+
+$h2 Using the jar in PostgreSQL
+
+The time has come to load this jar file into PostgreSQL and try it out!
+Within PL/Java, each jar has a short name; this one can be `myjar`. The
+final `true` parameter to `install_jar` means that the deployment descriptor
+commands should be used.
+
+```sql
+# select sqlj.install_jar(
+  'file:///home/me/proj/target/proj-0.0.1-SNAPSHOT.jar', 'myjar', true);
+ install_jar 
+-------------
+ 
+(1 row)
+```
+
+The result returned by `install_jar` isn't very interesting, but it does not
+show an error, so is the function ready to use?
+
+```sql
+# \df
+                           List of functions
+ Schema | Name  | Result data type  |   Argument data types    |  Type  
+--------+-------+-------------------+--------------------------+--------
+ public | hello | character varying | towhom character varying | normal
+(1 row)
+# select hello('world');
+ERROR:  java.lang.ClassNotFoundException: com.example.proj.Hello
+```
+
+Not so fast! In PL/Java, there is a classpath for every schema. (This is
+not quite what the SQL-JRT standard intended, but it is manageable for
+some related functions grouped into a schema.) The `hello` function was put
+into the `public` schema. Why could the class not be found?
+
+```sql
+# select sqlj.get_classpath('public');
+ get_classpath 
+---------------
+ 
+(1 row)
+```
+
+An empty classpath would have that effect. The short name `myjar` should be
+added.
+
+```sql
+# select sqlj.set_classpath('public', 'myjar');
+ set_classpath 
+---------------
+ 
+(1 row)
+
+# select hello('world');
+     hello     
+---------------
+ Hello, world!
+(1 row)
+```
+
+**Success!**
+
+$h3 One or two refinements
+
+The function says hello, but it also does this:
+
+```sql
+# select hello(null);
+    hello     
+--------------
+ Hello, null!
+(1 row)
+```
+
+The function has not been written to notice when the parameter is null.
+In this case, Java substitutes the word `null` and nothing worse happens,
+but perhaps the function should do something different. If the function
+should _return_ null whenever a parameter is null, there is no need to
+even add any code to the function. It can be annotated to declare that
+behavior, and then PostgreSQL will consider it to return null _without
+even calling the function_ any time a parameter is null.
+
+```java
+  @Function(onNullInput=Function.OnNullInput.RETURNS_NULL)
+  public static String hello(String toWhom) {
+  ...
+```
+
+Another optimization rests on the observation that the `hello` function has
+no side effects, and its result depends on nothing except the parameter passed
+to it. By default, functions are assumed to possibly have side effects, depend
+on database contents or outside influences, and otherwise be harder to reason
+about. The PostgreSQL optimizer will be helped if this function is declared
+`IMMUTABLE`. That leads to a program like this:
+
+```java
+package com.example.proj;
+
+import org.postgresql.pljava.annotation.Function;
+
+import static org.postgresql.pljava.annotation.Function.Type.IMMUTABLE;
+import static
+  org.postgresql.pljava.annotation.Function.OnNullInput.RETURNS_NULL;
+
+public class Hello {
+
+  @Function(onNullInput=RETURNS_NULL, type=IMMUTABLE)
+  public static String hello(String toWhom) {
+    return "Hello, " + toWhom + "!";
+  }
+
+}
+```
+
+$h2 Further reading
+
+From here, consider:
+
+* The documentation for [@Function][funcanno] and the rest of the
+    [PL/Java API][pljapi]
+* The user guide pages [on the wiki][uwik]
+* The many pre-built [examples][]
+
+[pljapi]: ../pljava-api/apidocs/index.html?org/postgresql/pljava/package-summary.html#package_description
+[uwik]: https://github.com/tada/pljava/wiki/User-guide
+[examples]: ../examples/examples.html

--- a/src/site/markdown/use/hello.md.vm
+++ b/src/site/markdown/use/hello.md.vm
@@ -52,8 +52,7 @@ right from the beginning.
 In preparation, PL/Java must have been built, using the command
 `mvn clean install`. Recall from the [installation][inst] page that
 the `install` Maven goal has nothing to do with installing PL/Java into
-PostgreSQL--that requires only `mvn clean package` plus further non-Maven
-steps--but the `install` goal _does_ register PL/Java in your Maven
+PostgreSQL, but _does_ register PL/Java in your Maven
 repository. With that done, any project of your own needs only declare
 `pljava-api` as a dependency, and Maven can compile and package it for you.
 

--- a/src/site/markdown/use/use.md
+++ b/src/site/markdown/use/use.md
@@ -1,0 +1,16 @@
+# User guide (non-wiki version)
+
+Content will gradually be migrated here and updated from the
+[user guide pages on the wiki][uwik].
+
+For now, this only suggests a few sources:
+
+* The obligatory [Hello world][hello] tutorial example
+* The [PL/Java API][pljapi] documentation
+* The user guide pages [on the wiki][uwik]
+* The many pre-built [examples][]
+
+[hello]: hello.html
+[pljapi]: ../pljava-api/apidocs/index.html?org/postgresql/pljava/package-summary.html#package_description
+[uwik]: https://github.com/tada/pljava/wiki/User-guide
+[examples]: ../examples/examples.html

--- a/src/site/markdown/use/variables.md
+++ b/src/site/markdown/use/variables.md
@@ -1,0 +1,99 @@
+# PL/Java configuration variable reference
+
+These PostgreSQL configuration variables can influence PL/Java's operation:
+
+`dynamic_library_path`
+: Although strictly not a PL/Java variable, `dynamic_library_path` influences
+    where the PL/Java native code object (`.so`, `.dll`, `.bundle`, etc.) can
+    be found, if the full path is not given to the `LOAD` command.
+
+`server_encoding`
+: Another non-PL/Java variable, this affects all text/character strings
+    exchanged between PostgreSQL and Java. `UTF8` as the database and server
+    encoding is _strongly_ recommended. If a different encoding is used, it
+    should be any of the available _fully defined_ character encodings. In
+    particular, the PostgreSQL pseudo-encoding `SQL_ASCII` (which means
+    "characters within ASCII are ASCII, others are no-one-knows-what") will
+    not work well with PL/Java, raising exceptions whenever strings contain
+    non-ASCII characters.
+
+`pljava.classpath`
+: The class path to be passed to the Java application class loader. There
+    must be at least one (and usually only one) entry, the PL/Java jar file
+    itself. To determine the proper setting, see
+    [finding the files produced by a PL/Java build](../install/locate.html).
+
+`pljava.debug`
+: A boolean variable that, if set `on`, stops the process on first entry to
+    PL/Java before the Java virtual machine is started. The process cannot
+    proceed until a debugger is attached and used to set the static
+    `Backend.c` variable `pljavaDebug` to zero. This may be useful for debugging
+    PL/Java problems only seen in the context of some larger application
+    that can't be stepped through.
+
+`pljava.enable`
+: Setting this variable `off` prevents PL/Java startup from completing, until
+    the variable is later set `on`. It can be useful when
+    [installing PL/Java on PostgreSQL versions before 9.2][pre92].
+
+`pljava.implementors`
+: A list of "implementor names" that PL/Java will recognize when processing
+    [deployment descriptors][depdesc] inside a jar file being installed or
+    removed. Deployment descriptors can contain commands with no implementor
+    name, which will be executed always, or with an implementor name, executed
+    only on a system recognizing that name. By default, this list contains only
+    the entry `PostgreSQL`. A deployment descriptor that contains commands with
+    other implementor names can achieve a rudimentary kind of conditional
+    execution if earlier commands adjust this list of names.
+
+`pljava.libjvm_location`
+: Used by PL/Java to load the Java runtime. The full path to a `libjvm` shared
+    object (filename typically ending with `.so`, `.dll`, or `.dylib`).
+    To determine the proper setting, see [finding the `libjvm` library][fljvm].
+
+`pljava.release_lingering_savepoints`
+: How the return from a PL/Java function will treat any savepoints created
+    within it that have not been explicitly either released (the savepoint
+    analog of "committed") or rolled back.
+    If `off` (the default), they will be rolled back. If `on`, they will be
+    released/committed. If possible, rather than setting this variable `on`,
+    it would be better to fix the function to release its own savepoints when
+    appropriate.
+
+`pljava.statement_cache_size`
+: The number of most-recently-prepared statements PL/Java will keep open.
+
+`pljava.vmoptions`
+: Any options to be passed to the Java runtime, in the same form as the
+    documented options for the `java` command ([windows][jow],
+    [Unix family][jou]). The string is split on whitespace unless found
+    between single or double quotes. A backslash treats the following
+    character literally, but the backslash itself remains in the string,
+    so not all values can be expressed with these rules. If the server
+    encoding is not `UTF8`, only ASCII characters should be used in
+    `pljava.vmoptions`. The exact quoting and encoding rules for this variable
+    may be adjusted in a future PL/Java version.
+
+    The default value for this variable is `-XX:+DisableAttachMechanism`
+    so that [Java Management Extensions][jmx] tools such as
+    [`jvisualvm`][jvvm] are prevented by default from attaching to the
+    process. If you set any explicit value for `pljava.vmoptions`, you should
+    include `-XX:+DisableAttachMechanism` if you wish to prevent such tools
+    from attaching. If you intend to use the advanced features of such tools
+    (such as code profiling in VisualVM), then simply set any value for
+    `pljava.vmoptions` that does not contain `-XX:+DisableAttachMechanism`.
+    You may also need to do so if you are using a non-Oracle Java runtime
+    and it rejects that option as unknown.
+
+    Even with attachment disabled, a tool such as VisualVM can display some
+    basic information about PL/Java processes (as long as it runs as the same
+    operating system user as the `postmaster`), including the arguments,
+    system properties, class and thread counts, and overall heap usage.
+
+[pre92]: ../install/prepg92.html
+[depdesc]: https://github.com/tada/pljava/wiki/Sql-deployment-descriptor
+[fljvm]: ../install/locatejvm.html
+[jmx]: http://www.oracle.com/technetwork/articles/java/javamanagement-140525.html
+[jvvm]: http://docs.oracle.com/javase/8/docs/technotes/guides/visualvm/
+[jow]: https://docs.oracle.com/javase/8/docs/technotes/tools/windows/java.html
+[jou]: https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html

--- a/src/site/markdown/use/variables.md
+++ b/src/site/markdown/use/variables.md
@@ -14,8 +14,10 @@ These PostgreSQL configuration variables can influence PL/Java's operation:
     should be any of the available _fully defined_ character encodings. In
     particular, the PostgreSQL pseudo-encoding `SQL_ASCII` (which means
     "characters within ASCII are ASCII, others are no-one-knows-what") will
-    not work well with PL/Java, raising exceptions whenever strings contain
-    non-ASCII characters.
+    _not_ work well with PL/Java, raising exceptions whenever strings contain
+    non-ASCII characters. (PL/Java can still be used in such a database, but
+    the application code needs to know what it's doing and use the right
+    conversion functions where needed.)
 
 `pljava.classpath`
 : The class path to be passed to the Java application class loader. There
@@ -42,7 +44,7 @@ These PostgreSQL configuration variables can influence PL/Java's operation:
     removed. Deployment descriptors can contain commands with no implementor
     name, which will be executed always, or with an implementor name, executed
     only on a system recognizing that name. By default, this list contains only
-    the entry `PostgreSQL`. A deployment descriptor that contains commands with
+    the entry `postgresql`. A deployment descriptor that contains commands with
     other implementor names can achieve a rudimentary kind of conditional
     execution if earlier commands adjust this list of names.
 
@@ -57,7 +59,7 @@ These PostgreSQL configuration variables can influence PL/Java's operation:
     analog of "committed") or rolled back.
     If `off` (the default), they will be rolled back. If `on`, they will be
     released/committed. If possible, rather than setting this variable `on`,
-    it would be better to fix the function to release its own savepoints when
+    it would be safer to fix the function to release its own savepoints when
     appropriate.
 
 `pljava.statement_cache_size`

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -19,11 +19,13 @@
 			 href='http://lists.pgfoundry.org/pipermail/pljava-dev/'/>
 			<item name='Code' href='${project.scm.url}'/>
 		</links>
-		<menu name='Wiki shortcuts' inherit='top'>
-			<item name='Installation guide'
-			 href='https://github.com/tada/pljava/wiki/Installation-guide'/>
+		<menu name='Usage' inherit='top'>
+			<item name='Building PL/Java'
+			 href='build/build.html'/>
+			<item name='Installing into PostgreSQL'
+			 href='install/install.html'/>
 			<item name='User guide'
-			 href='https://github.com/tada/pljava/wiki/User-guide'/>
+			 href='use/use.html'/>
 		</menu>
 		<menu ref='modules'/>
 		<menu ref='reports' inherit='top'/>


### PR DESCRIPTION
This is the branch in the oven for a while to provide (and document) a new approach to installation, using only `SET` and `LOAD` in an ordinary `psql` session, and usually able to tell you what's needed if all is not in order. Should relieve a good deal of frustration especially for first-time PL/Java adopters.

The simplest experience is in PostgreSQL 9.2 and later, but even back to 8.2 it is improved. This patch does _not_ integrate with the PostgreSQL 9.1+ `CREATE EXTENSION` facility, but another patch will add that soon.

Schema migration (issue #12) is provided, back to PL/Java 1.3.0 in December 2006 anyway, so closes #12.

I will say closes #9 though there is still no change to the `packaging` subproject to put the built files into known places on the filesystem. Not everyone installing PL/Java will have root on the box, or have the ability to write in the same known places, and the correct places can vary by platform or distribution (or the database admin may simply have reasons to choose other locations). So the approach here is to make it as easy as possible to tell PostgreSQL where the files have been placed, rather than to try to place them always in certain locations. That said, it would be great if any maintainers of package repositories, offering PL/Java for particular distributions, would choose the appropriate installation locations for their distributions and arrange for the files to be installed there, and patch the configuration variable defaults to match.

New documentation covers what was overlooked in issue #17, so closes #17.

Has been tested over the last month repeatedly by Ken Olson, covering Windows/MSVC, and Daniel Blanch Bataller, covering Mac OS X and Centos, and up to PostgreSQL 9.4, so I will say optimistically: closes #22, #23, #28, #63, #64, #71.

I'm thinking it will soon be appropriate to declare a new numbered release, which will be the way to address downstream packaging issues like #27.