### PR TITLE
Alter project version to 1.5.0-SNAPSHOT.

### DIFF
--- a/packaging/pom.xml
+++ b/packaging/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.postgresql</groupId>
 		<artifactId>pljava.app</artifactId>
-		<version>0.0.2-SNAPSHOT</version>
+		<version>1.5.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>packaging</artifactId>
 	<name>PL/Java packaging</name>
@@ -15,22 +15,22 @@
 		<dependency>
 			<groupId>org.postgresql</groupId>
 			<artifactId>pljava</artifactId>
-			<version>0.0.2-SNAPSHOT</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.postgresql</groupId>
 			<artifactId>pljava-deploy</artifactId>
-			<version>0.0.2-SNAPSHOT</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.postgresql</groupId>
 			<artifactId>pljava-examples</artifactId>
-			<version>0.0.2-SNAPSHOT</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.postgresql</groupId>
 			<artifactId>pljava-so</artifactId>
-			<version>0.0.2-SNAPSHOT</version>
+			<version>${project.version}</version>
 			<type>nar</type>
 		</dependency>
 	</dependencies>

--- a/pljava-ant/pom.xml
+++ b/pljava-ant/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.postgresql</groupId>
 		<artifactId>pljava.app</artifactId>
-		<version>0.0.2-SNAPSHOT</version>
+		<version>1.5.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>pljava-ant</artifactId>
 	<name>PL/Java Ant tasks</name>

--- a/pljava-api/pom.xml
+++ b/pljava-api/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.postgresql</groupId>
 		<artifactId>pljava.app</artifactId>
-		<version>0.0.2-SNAPSHOT</version>
+		<version>1.5.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>pljava-api</artifactId>
 	<name>PL/Java API</name>

--- a/pljava-deploy/pom.xml
+++ b/pljava-deploy/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.postgresql</groupId>
 		<artifactId>pljava.app</artifactId>
-		<version>0.0.2-SNAPSHOT</version>
+		<version>1.5.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>pljava-deploy</artifactId>
 	<name>PL/Java Deploy</name>

--- a/pljava-examples/pom.xml
+++ b/pljava-examples/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.postgresql</groupId>
 		<artifactId>pljava.app</artifactId>
-		<version>0.0.2-SNAPSHOT</version>
+		<version>1.5.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>pljava-examples</artifactId>
 	<name>PL/Java examples</name>
@@ -13,7 +13,7 @@
 		<dependency>
 			<groupId>org.postgresql</groupId>
 			<artifactId>pljava-api</artifactId>
-			<version>0.0.2-SNAPSHOT</version>
+			<version>${project.version}</version>
 		</dependency>
 	</dependencies>
 	<build>

--- a/pljava-so/pom.xml
+++ b/pljava-so/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.postgresql</groupId>
 		<artifactId>pljava.app</artifactId>
-		<version>0.0.2-SNAPSHOT</version>
+		<version>1.5.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>pljava-so</artifactId>
 	<name>PL/Java backend native code</name>

--- a/pljava/pom.xml
+++ b/pljava/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.postgresql</groupId>
 		<artifactId>pljava.app</artifactId>
-		<version>0.0.2-SNAPSHOT</version>
+		<version>1.5.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>pljava</artifactId>
 	<name>PL/Java backend Java code</name>
@@ -13,7 +13,7 @@
 		<dependency>
 			<groupId>org.postgresql</groupId>
 			<artifactId>pljava-api</artifactId>
-			<version>0.0.2-SNAPSHOT</version>
+			<version>${project.version}</version>
 		</dependency>
 	</dependencies>
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.postgresql</groupId>
 	<artifactId>pljava.app</artifactId>
-	<version>0.0.2-SNAPSHOT</version>
+	<version>1.5.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>PostgreSQL PL/Java</name>
 	<url>https://tada.github.io/pljava/</url>


### PR DESCRIPTION
For a couple of years it has been 0.0.2-SNAPSHOT, not even in the same
sequence as PL/Java versions before moving to Maven. Fix it to
accurately show that this snapshot is on the way to a 1.5.0 release.