### PR TITLE
Feature/master/extension

### DIFF
--- a/pljava-ant/pom.xml
+++ b/pljava-ant/pom.xml
@@ -13,7 +13,7 @@
 		<dependency>
 			<groupId>org.apache.ant</groupId>
 			<artifactId>ant</artifactId>
-			<version>1.7.0</version>
+			<version>[1.7.0,)</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/pljava-packaging/build.xml
+++ b/pljava-packaging/build.xml
@@ -34,10 +34,8 @@
 		"pljava/sharedir/pljava/pljava--unpackaged--${project.version}.sql"/>
 			<zipfileset dir="target/classes" prefix="pljava/sharedir/pljava/"
 				includes="*.sql" excludes="pljava.sql pljava--unpackaged.sql"/>
-			<zipfileset dir="../src/sql" includes="*.sql" prefix="pljava/"/>
 			<zipfileset dir="../pljava/target" includes="pljava*.jar"
 				prefix="pljava/sharedir/pljava/"/>
-			<zipfileset dir="../pljava-deploy/target" includes="pljava-deploy*.jar" fullpath="pljava/deploy.jar"/>
 			<zipfileset dir="../pljava-examples/target"
 				includes="pljava-examples*.jar"
 				prefix="pljava/sharedir/pljava"/>

--- a/pljava-packaging/build.xml
+++ b/pljava-packaging/build.xml
@@ -111,8 +111,7 @@ if ( filesep == '/' ) {
 		return p;
 	}
 } else {
-	var fseprx =
-	java.util.regex.Pattern.compile(filesep, java.util.regex.Pattern.LITERAL);
+	var fseprx = java.util.regex.Pattern.quote(filesep);
 	function pathxfrm(p) {
 		return p.replaceAll(fseprx, '/');
 	}

--- a/pljava-packaging/build.xml
+++ b/pljava-packaging/build.xml
@@ -25,31 +25,49 @@
 
 	<target name="package-zip" depends="init">
 		<zip destfile="target/pljava-${suffix}.zip">
+			<zipfileset dir="target/classes" includes="pljava.control"
+				prefix="pljava/sharedir/extension/"/>
+			<zipfileset dir="target/classes" includes="pljava.sql"
+				fullpath="pljava/sharedir/pljava/pljava--${project.version}.sql"/>
+			<zipfileset dir="target/classes" includes="pljava--unpackaged.sql"
+				fullpath=
+		"pljava/sharedir/pljava/pljava--unpackaged--${project.version}.sql"/>
+			<zipfileset dir="target/classes" prefix="pljava/sharedir/pljava/"
+				includes="*.sql" excludes="pljava.sql pljava--unpackaged.sql"/>
 			<zipfileset dir="../src/sql" includes="*.sql" prefix="pljava/"/>
-			<zipfileset dir="../pljava/target" includes="pljava*.jar" fullpath="pljava/pljava.jar"/>
+			<zipfileset dir="../pljava/target" includes="pljava*.jar"
+				prefix="pljava/sharedir/pljava/"/>
 			<zipfileset dir="../pljava-deploy/target" includes="pljava-deploy*.jar" fullpath="pljava/deploy.jar"/>
-			<zipfileset dir="../pljava-examples/target" includes="pljava-examples*.jar" fullpath="pljava/examples.jar"/>
-			<zipfileset dir="../pljava-so/target/nar" includes="**/pljava-so*.dll"
-				fullpath="pljava/pljava.dll" erroronmissingarchive="false"
-				filemode="755"/>
-			<zipfileset dir="../pljava-so/target/nar" includes="**/libpljava-so*.so"
-				fullpath="pljava/pljava.so" erroronmissingarchive="false"
-				filemode="755"/>
+			<zipfileset dir="../pljava-examples/target"
+				includes="pljava-examples*.jar"
+				prefix="pljava/sharedir/pljava"/>
+			<zipfileset prefix="pljava/pkglibdir/" filemode="755" dir=
+"../pljava-so/target/nar/pljava-so-${project.version}-${naraol}-plugin/lib/${naraol}/plugin"
+				includes="**/*pljava-so*"/>
 		</zip>
 	</target>
 
 	<target name="package-targz" depends="init">
 		<tar destfile="target/pljava.tar">
-		<zipfileset dir="../src/sql" includes="*.sql" prefix="pljava/"/>
-			<zipfileset dir="../pljava/target" includes="pljava*.jar" fullpath="pljava/pljava.jar"/>
+			<zipfileset dir="target/classes" includes="pljava.control"
+				prefix="pljava/sharedir/extension/"/>
+			<zipfileset dir="target/classes" includes="pljava.sql"
+				fullpath="pljava/sharedir/pljava/pljava--${project.version}.sql"/>
+			<zipfileset dir="target/classes" includes="pljava--unpackaged.sql"
+				fullpath=
+		"pljava/sharedir/pljava/pljava--unpackaged--${project.version}.sql"/>
+			<zipfileset dir="target/classes" prefix="pljava/sharedir/pljava/"
+				includes="*.sql" excludes="pljava.sql pljava--unpackaged.sql"/>
+			<zipfileset dir="../src/sql" includes="*.sql" prefix="pljava/"/>
+			<zipfileset dir="../pljava/target" includes="pljava*.jar"
+				prefix="pljava/sharedir/pljava"/>
 			<zipfileset dir="../pljava-deploy/target" includes="pljava-deploy*.jar" fullpath="pljava/deploy.jar"/>
-			<zipfileset dir="../pljava-examples/target" includes="pljava-examples*.jar" fullpath="pljava/examples.jar"/>
-			<zipfileset dir="../pljava-so/target/nar" includes="**/pljava-so*.dll"
-				fullpath="pljava/pljava.dll" erroronmissingarchive="false"
-				filemode="755"/>
-			<zipfileset dir="../pljava-so/target/nar" includes="**/libpljava-so*.so"
-				fullpath="pljava/pljava.so" erroronmissingarchive="false"
-				filemode="755"/>
+			<zipfileset dir="../pljava-examples/target"
+				includes="pljava-examples*.jar"
+				prefix="pljava/sharedir/pljava"/>
+			<zipfileset prefix="pljava/pkglibdir/" filemode="755" dir=
+"../pljava-so/target/nar/pljava-so-${project.version}-${naraol}-plugin/lib/${naraol}/plugin"
+				includes="**/*pljava-so*"/>
 		</tar>
 		<gzip src="target/pljava.tar" destfile="target/pljava-${suffix}.tar.gz"/>
 	</target>

--- a/pljava-packaging/build.xml
+++ b/pljava-packaging/build.xml
@@ -25,13 +25,27 @@
 
 	<target name="package" depends="init">
 		<zip destfile="target/pljava-${suffix}.zip">
-			<zipfileset dir="target/classes" includes="pljava.control"
-				prefix="pljava/sharedir/extension/"/>
-			<zipfileset dir="target/classes" includes="pljava.sql"
-				fullpath="pljava/sharedir/pljava/pljava--${project.version}.sql"/>
-			<zipfileset dir="target/classes" includes="pljava--unpackaged.sql"
-				fullpath=
-		"pljava/sharedir/pljava/pljava--unpackaged--${project.version}.sql"/>
+			<concat resourcename="pljava/sharedir/extension/pljava.control">
+				<fileset dir="target/classes" includes="pljava.control"/>
+				<filterchain>
+					<fixcrlf eol="crlf" eof="remove"/>
+				</filterchain>
+			</concat>
+			<concat resourcename=
+				"pljava/sharedir/pljava/pljava--${project.version}.sql">
+				<fileset dir="target/classes" includes="pljava.sql"/>
+				<filterchain>
+					<fixcrlf eol="crlf" eof="remove"/>
+				</filterchain>
+			</concat>
+			<concat resourcename=
+			"pljava/sharedir/pljava/pljava--unpackaged--${project.version}.sql">
+				<fileset dir="target/classes"
+					includes="pljava--unpackaged.sql"/>
+				<filterchain>
+					<fixcrlf eol="crlf" eof="remove"/>
+				</filterchain>
+			</concat>
 			<zipfileset dir="target/classes" prefix="pljava/sharedir/pljava/"
 				includes="*.sql" excludes="pljava.sql pljava--unpackaged.sql"/>
 			<zipfileset dir="../pljava/target" includes="pljava*.jar"

--- a/pljava-packaging/build.xml
+++ b/pljava-packaging/build.xml
@@ -24,39 +24,286 @@
 	</target>
 
 	<target name="package" depends="init">
-		<zip destfile="target/pljava-${suffix}.zip">
-			<concat resourcename="pljava/sharedir/extension/pljava.control">
-				<fileset dir="target/classes" includes="pljava.control"/>
-				<filterchain>
-					<fixcrlf eol="crlf" eof="remove"/>
-				</filterchain>
-			</concat>
-			<concat resourcename=
-				"pljava/sharedir/pljava/pljava--${project.version}.sql">
-				<fileset dir="target/classes" includes="pljava.sql"/>
-				<filterchain>
-					<fixcrlf eol="crlf" eof="remove"/>
-				</filterchain>
-			</concat>
-			<concat resourcename=
-			"pljava/sharedir/pljava/pljava--unpackaged--${project.version}.sql">
-				<fileset dir="target/classes"
-					includes="pljava--unpackaged.sql"/>
-				<filterchain>
-					<fixcrlf eol="crlf" eof="remove"/>
-				</filterchain>
-			</concat>
-			<zipfileset dir="target/classes" prefix="pljava/sharedir/pljava/"
-				includes="*.sql" excludes="pljava.sql pljava--unpackaged.sql"/>
-			<zipfileset dir="../pljava/target" includes="pljava*.jar"
-				prefix="pljava/sharedir/pljava/"/>
-			<zipfileset dir="../pljava-examples/target"
-				includes="pljava-examples*.jar"
-				prefix="pljava/sharedir/pljava"/>
-			<zipfileset prefix="pljava/pkglibdir/" filemode="755" dir=
+
+		<!--
+			Create a new ant task <jarxbuild> for building a jar that self-
+			extracts by including org/gjt/cuspy/JarX.class. <jarxbuild> takes
+			one attribute, destfile= (which should be absolute, consider
+			specifying ${basedir} at the front). To specify what goes IN the
+			jar, supply nested zipfileset elements; that class was chosen
+			because it already supports prefix=, fullpath=, and filemode=
+			attributes to control the stored path and permission info, as well
+			as all the scanning/inclusion/exclusion rules you could want. But by
+			itself, it isn't enough to tell JarX which files are binary or text,
+			or the encodings of the text files. That is conveyed by which alias
+			is used for each zipfileset. That is, you don't literally use
+			nested <zipfileset> elements, but instead <binary>, <ascii>, or
+			<utf8> elements, which all are zipfilesets behind the scenes and
+			have all the same attributes and elements. Any files supplied in
+			a <binary> element will be archived and unarchived unchanged.
+			Files supplied in an <ascii> or <utf8> element will be treated as
+			text and have their line endings converted to local conventions on
+			extraction; they won't be transcoded, but will be stored in and
+			extracted from the jar in the specified encoding (and verified to
+			be well-formed in it). That obviously isn't a fully-general way to
+			specify the text handling, but it gets the job done, and if you have
+			another case to handle, just add another zipfileset <element> with
+			another name, and edit the javascript below to know what to do
+			with it.
+
+			To emphasize, files given in an <ascii> or <utf8> element are
+			extracted in exactly that encoding on any target platform regardless
+			of the platform's default encoding. That's appropriate for an
+			extension .control file (which must be <ascii> because PostgreSQL
+			assumes it), and any extension .sql scripts we supply (which must
+			be <utf8> because the .control file says so). It's possible that
+			for some other text files we might include (general docs or
+			what not), it would be nicer to let them be extracted into the
+			platform's default encoding (achieved by specifying a fixed value
+			such as UTF-8 for _JarX_CharsetInArchive while entirely omitting
+			_JarX_CharsetWhenUnpacked). But at the moment no such files are
+			being included, so I haven't provided another element name to give
+			that behavior.
+
+			There has to be a <binary> element supplying JarX.class itself.
+
+			The <jarxbuild> task also accepts nested text, which will be treated
+			as a path-resolver script (the language is assumed to be
+			application/javascript; I'm lazy). It will be stuffed into the
+			manifest in a form that survives manifest line-wrapping, and JarX
+			will use it at extraction time to rewrite pathnames. In this case,
+			that script (see further below) will use pg_config or system
+			properties to determine the extraction paths.
+		-->
+
+		<scriptdef name='jarxbuild' language='javascript'>
+			<attribute name='destfile'/>
+			<element type='zipfileset' name='binary'/>
+			<element type='zipfileset' name='ascii'/>
+			<element type='zipfileset' name='utf8'/>
+			<classpath>
+				<pathelement path='${classpath}'/>
+				<pathelement location='target/classes'/> <!-- JarX is there -->
+			</classpath>
+<![CDATA[
+var manifest = new java.util.jar.Manifest();
+var sections = manifest.getEntries();
+var mainsect = manifest.getMainAttributes();
+mainsect.putValue('Manifest-Version', '1.0');
+mainsect.putValue('Created-By', project.getProperty('project.name') + ' ' +
+								project.getProperty('project.version'));
+mainsect.putValue('Main-Class', 'org.gjt.cuspy.JarX');
+
+/* Declare default permissions for entries that don't have their own.
+ */
+mainsect.putValue('_JarX_Permissions', 'read=all,write=none,execute=none');
+
+/* Munge a name (obtained directly from a resource in a fileset) according to
+   the prefix or fullpath given for the fileset itself.
+ */
+function munge(rsrc, fileset) {
+	var fullpath = fileset.getFullpath(project);
+	var prefix = fileset.getPrefix(project);
+	var n = rsrc.getName();
+	if ( !(null === fullpath || '' == fullpath) )
+		n = fullpath;
+	else if ( !(null === prefix) )
+		n = prefix + n;
+	return n;
+}
+
+/* Given one fileset, compute a set of manifest per-entry attributes from the
+   specified charset (caller supplied according to the alias name that was used
+   for the fileset) and file mode specified on the fileset, if any, then enter
+   a manifest section with those attributes for every resource name in the
+   fileset. Caller supplies charset === null for a fileset to be treated as
+   binary.
+ */
+function mksections(charset, fileset) {
+	var atts = new java.util.jar.Attributes();
+	if ( !(null === charset) ) {
+		atts.putValue('Content-Type', 'text/plain');
+		atts.putValue('_JarX_CharsetInArchive', charset);
+		atts.putValue('_JarX_CharsetWhenUnpacked', charset);
+	}
+	if ( fileset.hasFileModeBeenSet() ) {
+		var m = fileset.getFileMode(project) - 32768; /* don't ask me why */
+		if ( 0444 == m )
+			atts.putValue('_JarX_Permissions',
+							'read=all,write=none,execute=none');
+		else if ( 0555 == m )
+			atts.putValue('_JarX_Permissions',
+							'read=all,write=none,execute=all');
+		else
+			self.fail('File mode '+m+' not covered in script.');
+	}
+	var it = fileset.iterator();
+	while ( it.hasNext() ) {
+		var rsrc = it.next();
+		sections.put(munge(rsrc, fileset), atts);
+	}
+}
+
+/* Given a fileset and JarOutputStream, for each resource look up the manifest
+   per-entry section earlier created, pass that to builder.classify() to set
+   how shovel() will handle the contents, then make the next jar entry and
+   shovel the resource contents in.
+ */
+function storeset(fileset, jos) {
+	var it = fileset.iterator();
+	while ( it.hasNext() ) {
+		var rsrc = it.next();
+		var n = munge(rsrc, fileset);
+		var atts = sections.get(n);
+		builder.classify(atts, true);
+		var je = new java.util.jar.JarEntry(n);
+		jos.putNextEntry(je);
+		var instream = rsrc.getInputStream();
+		print(n+' ');
+		builder.shovel(instream, jos);
+		jos.closeEntry();
+	}
+}
+
+/* If there is text nested in the <jarxbuild> element, it is a path-resolver
+   script. Munge it to the manifest-attribute-linewrap-resistant style JarX
+   expects (first \-escape every \ and " then turn every line ending to the
+   three characters "/" then add " at start and end), and place into the main
+   manifest section as _JarX_PathResolver, with the language tag
+   application/javascript (hardcoded here, you weren't thinking of using
+   a different script language anyway).
+ */
+var pathresolver = self.text.trim() + ''; /* ensure js string not java string */
+if ( !(null === pathresolver || '' == pathresolver) ) {
+	pathresolver = pathresolver.replace(/["\\]/g, "\\$&");
+	pathresolver = pathresolver.replace(/\r\n?|\n/g, '"/"');
+	pathresolver = '"' + pathresolver + '"';
+	mainsect.putValue('_JarX_PathResolver',
+						'application/javascript' + pathresolver);
+}
+
+/* For each element name that can be used to supply a zipfileset, get all the
+   zipfilesets supplied under that name and pass them to mksections with the
+   appropriate charset parameter according to the element name.
+ */
+var binary = elements.get("binary");
+for ( i = 0; i < binary.size(); ++i ) {
+	var fset = binary.get(i);
+	mksections(null, fset);
+}
+var ascii = elements.get("ascii");
+for ( i = 0; i < ascii.size(); ++i ) {
+	var fset = ascii.get(i);
+	mksections('US-ASCII', fset);
+}
+var utf = elements.get("utf8");
+for ( i = 0; i < utf.size(); ++i ) {
+	var fset = utf.get(i);
+	mksections('UTF-8', fset);
+}
+
+/* Set up the output archive...
+ */
+var builder = new org.gjt.cuspy.JarX.Build();
+builder.setDefaults(mainsect);
+var destf = attributes.get('destfile');
+var fos = new java.io.FileOutputStream(destf);
+var jos = new java.util.jar.JarOutputStream(fos, manifest);
+
+/* Go through the supplied filesets once again, passing them to storeset...
+ */
+for ( i = 0; i < binary.size(); ++i ) {
+	var fset = binary.get(i);
+	storeset(fset, jos);
+}
+for ( i = 0; i < ascii.size(); ++i ) {
+	var fset = ascii.get(i);
+	storeset(fset, jos);
+}
+for ( i = 0; i < utf.size(); ++i ) {
+	var fset = utf.get(i);
+	storeset(fset, jos);
+}
+
+/* And finalize the output.
+ */
+jos.close();
+]]>
+		</scriptdef>
+
+		<!-- Now build the jar using the <jarxbuild> task just created. -->
+
+		<jarxbuild destfile="${basedir}/target/pljava-${suffix}.jar">
+			<binary dir="target/classes" includes="**/JarX.class"/>
+			<binary prefix="pljava/pkglibdir/" filemode="555" dir=
 "../pljava-so/target/nar/pljava-so-${project.version}-${naraol}-plugin/lib/${naraol}/plugin"
 				includes="**/*pljava-so*"/>
-		</zip>
+			<binary dir="../pljava/target" includes="pljava*.jar"
+				prefix="pljava/sharedir/pljava/"/>
+			<binary dir="../pljava-examples/target"
+				includes="pljava-examples*.jar"
+				prefix="pljava/sharedir/pljava/"/>
+			<ascii dir="target/classes" includes="pljava.control"
+				prefix="pljava/sharedir/extension/"/>
+			<utf8 dir="target/classes" includes="pljava.sql"
+				fullpath="pljava/sharedir/pljava/pljava--${project.version}.sql"
+			/>
+			<utf8 dir="target/classes" includes="pljava--unpackaged.sql"
+				fullpath=
+			"pljava/sharedir/pljava/pljava--unpackaged--${project.version}.sql"
+			/>
+			<utf8 dir="target/classes" prefix="pljava/sharedir/pljava/"
+				includes="*.sql" excludes="pljava.sql pljava--unpackaged.sql"/>			
+<!-- If editing the script below, expand tabs to spaces (at 4 columns, and only
+	 for the lines of the script) before saving. Line-wrapped into the manifest,
+	 it looks horrible with tabs.
+-->
+<![CDATA[
+/*
+    At extraction time, JarX invokes this for each entry, with these bindings:
+    properties   - the Java system properties object
+    storedPath   - the full path of the archive member as stored
+                   in the archive
+    platformPath - the name after changing only file.separator
+                   for the platform (if different from /)
+    computedPath - initially the same as platformPath
+    If the script updates computedPath, that is where the member
+    will be extracted.
+*/
+var re = new RegExp('^pljava/([^/]+dir)(?![^/])');
+var found = re.exec(storedPath);
+if (found) {
+    var prefix = found[0];
+    var key = found[1];
+    var propkey = 'pgconfig.' + key;
+    var replacement = properties.getProperty(propkey);
+    if ( null === replacement ) {
+        var pgc = properties.getProperty('pgconfig');
+        if ( null === pgc )
+            pgc = 'pg_config';
+        var pb = new java.lang.ProcessBuilder(pgc, '--'+key);
+        pb.redirectErrorStream(true);
+        var proc = pb.start();
+        var instream = proc.getInputStream();
+        var scanner =
+            new java.util.Scanner(instream).useDelimiter('\\A');
+        var output = scanner.next();
+        var status = proc.waitFor();
+        if ( 0 != status ) {
+            java.lang.System.err.println(
+                'ERROR: pg_config status is '+status+':\n'+output);
+            java.lang.System.exit(1);
+        }
+        replacement = output.trim();
+        properties.setProperty(propkey, replacement);
+    }
+    var fsep = properties.getProperty('file.separator');
+    var plen = fsep.length() - 1; /* original separator had length 1 */
+    plen += prefix.length;
+    computedPath = replacement + computedPath.slice(plen);
+}
+]]>
+		</jarxbuild>
 	</target>
 	
 </project>

--- a/pljava-packaging/build.xml
+++ b/pljava-packaging/build.xml
@@ -98,13 +98,37 @@ mainsect.putValue('Main-Class', 'org.gjt.cuspy.JarX');
  */
 mainsect.putValue('_JarX_Permissions', 'read=all,write=none,execute=none');
 
+/* Declare a function pathxfrm(p) if needed to convert from this platform's
+   file separator to the / used in the jar (just an identity function
+   if they are the same). The overcomplicated look is mostly to avoid using
+   replace(), which is a method (with different behavior) on both Java and
+   JavaScript strings, and Rhino and Nashorn have different rules about which
+   one you get.
+ */
+var filesep = project.getProperty('file.separator');
+if ( filesep == '/' ) {
+	function pathxfrm(p) {
+		return p;
+	}
+} else {
+	var fseprx =
+	java.util.regex.Pattern.compile(filesep, java.util.regex.Pattern.LITERAL);
+	function pathxfrm(p) {
+		return p.replaceAll(fseprx, '/');
+	}
+}
+
 /* Munge a name (obtained directly from a resource in a fileset) according to
    the prefix or fullpath given for the fileset itself.
  */
 function munge(rsrc, fileset) {
 	var fullpath = fileset.getFullpath(project);
 	var prefix = fileset.getPrefix(project);
-	var n = rsrc.getName();
+	var n = pathxfrm(rsrc.getName());
+	/*
+	 * The fullpath or prefix parts do not need to be pathxfrm()d; they are
+	 * defined here in build.xml with / as the separator already.
+	 */
 	if ( !(null === fullpath || '' == fullpath) )
 		n = fullpath;
 	else if ( !(null === prefix) )

--- a/pljava-packaging/build.xml
+++ b/pljava-packaging/build.xml
@@ -23,7 +23,7 @@
 		<property name="suffix" value="${PGSQL_VER_CLASSIFIER}-${naraol}"/>
 	</target>
 
-	<target name="package-zip" depends="init">
+	<target name="package" depends="init">
 		<zip destfile="target/pljava-${suffix}.zip">
 			<zipfileset dir="target/classes" includes="pljava.control"
 				prefix="pljava/sharedir/extension/"/>
@@ -45,31 +45,6 @@
 "../pljava-so/target/nar/pljava-so-${project.version}-${naraol}-plugin/lib/${naraol}/plugin"
 				includes="**/*pljava-so*"/>
 		</zip>
-	</target>
-
-	<target name="package-targz" depends="init">
-		<tar destfile="target/pljava.tar">
-			<zipfileset dir="target/classes" includes="pljava.control"
-				prefix="pljava/sharedir/extension/"/>
-			<zipfileset dir="target/classes" includes="pljava.sql"
-				fullpath="pljava/sharedir/pljava/pljava--${project.version}.sql"/>
-			<zipfileset dir="target/classes" includes="pljava--unpackaged.sql"
-				fullpath=
-		"pljava/sharedir/pljava/pljava--unpackaged--${project.version}.sql"/>
-			<zipfileset dir="target/classes" prefix="pljava/sharedir/pljava/"
-				includes="*.sql" excludes="pljava.sql pljava--unpackaged.sql"/>
-			<zipfileset dir="../src/sql" includes="*.sql" prefix="pljava/"/>
-			<zipfileset dir="../pljava/target" includes="pljava*.jar"
-				prefix="pljava/sharedir/pljava"/>
-			<zipfileset dir="../pljava-deploy/target" includes="pljava-deploy*.jar" fullpath="pljava/deploy.jar"/>
-			<zipfileset dir="../pljava-examples/target"
-				includes="pljava-examples*.jar"
-				prefix="pljava/sharedir/pljava"/>
-			<zipfileset prefix="pljava/pkglibdir/" filemode="755" dir=
-"../pljava-so/target/nar/pljava-so-${project.version}-${naraol}-plugin/lib/${naraol}/plugin"
-				includes="**/*pljava-so*"/>
-		</tar>
-		<gzip src="target/pljava.tar" destfile="target/pljava-${suffix}.tar.gz"/>
 	</target>
 	
 </project>

--- a/pljava-packaging/pom.xml
+++ b/pljava-packaging/pom.xml
@@ -94,6 +94,13 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-antrun-plugin</artifactId>
 				<version>1.7</version>
+				<dependencies>
+					<dependency>
+						<groupId>org.apache.ant</groupId>
+						<artifactId>ant</artifactId>
+						<version>[1.8.3,)</version>
+					</dependency>
+				</dependencies>
 				<executions>
 					<execution>
 						<id>pljava package distribution</id>

--- a/pljava-packaging/pom.xml
+++ b/pljava-packaging/pom.xml
@@ -36,8 +36,6 @@
 	</dependencies>
 
 	<properties>
-		<sharedsuffix>so</sharedsuffix>
-		<distrotype>targz</distrotype>
 		<module.pathname>libpljava-so-${project.version}</module.pathname>
 	</properties>
 
@@ -62,8 +60,6 @@
 				</os>
 			</activation>
 			<properties>
-				<sharedsuffix>dll</sharedsuffix>
-				<distrotype>zip</distrotype>
 				<module.pathname>pljava-so-${project.version}</module.pathname>
 			</properties>
 		</profile>
@@ -107,7 +103,7 @@
 						</goals>
 						<configuration>
 							<target>
-								<ant target="package-${distrotype}" dir="${project.basedir}"/>
+								<ant target="package" dir="${project.basedir}"/>
 							</target>
 						</configuration>
 					</execution>

--- a/pljava-packaging/pom.xml
+++ b/pljava-packaging/pom.xml
@@ -92,6 +92,20 @@
 
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>compile the jar extractor</id>
+						<phase>compile</phase>
+						<goals>
+							<goal>compile</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-antrun-plugin</artifactId>
 				<version>1.7</version>
 				<dependencies>

--- a/pljava-packaging/pom.xml
+++ b/pljava-packaging/pom.xml
@@ -38,8 +38,22 @@
 	<properties>
 		<sharedsuffix>so</sharedsuffix>
 		<distrotype>targz</distrotype>
+		<module.pathname>libpljava-so-${project.version}</module.pathname>
 	</properties>
+
 	<profiles>
+		<profile>
+			<id>osx</id>
+			<activation>
+				<os>
+					<name>mac os x</name>
+				</os>
+			</activation>
+			<properties>
+				<module.pathname>libpljava-so-${project.version}.bundle</module.pathname>
+			</properties>
+		</profile>
+
 		<profile>
 			<id>windows</id>
 			<activation>
@@ -50,12 +64,36 @@
 			<properties>
 				<sharedsuffix>dll</sharedsuffix>
 				<distrotype>zip</distrotype>
+				<module.pathname>pljava-so-${project.version}</module.pathname>
 			</properties>
 		</profile>
 	</profiles>
 
 	<build>
+		<resources>
+			<resource>
+				<directory>${basedir}/src/main/resources</directory>
+				<filtering>true</filtering>
+			</resource>
+		</resources>
+
 		<plugins>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-resources-plugin</artifactId>
+				<version>2.7</version>
+				<executions>
+					<execution>
+						<id>pljava extension files</id>
+						<phase>process-resources</phase>
+						<goals>
+							<goal>resources</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-antrun-plugin</artifactId>
@@ -75,6 +113,7 @@
 					</execution>
 				</executions>
 			</plugin>
+
 		</plugins>
 	</build>
 </project>

--- a/pljava-packaging/src/main/java/JarX.java
+++ b/pljava-packaging/src/main/java/JarX.java
@@ -1,0 +1,1282 @@
+package org.gjt.cuspy;
+
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.OutputStreamWriter;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.OutputStream;
+import java.nio.charset.Charset;
+import java.nio.charset.CharsetDecoder;
+import java.nio.charset.CharsetEncoder;
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.HashMap;
+import java.net.URL;
+import java.util.jar.Attributes;
+import java.util.jar.JarEntry;
+import java.util.jar.JarInputStream;
+import java.util.jar.Manifest;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+import javax.script.ScriptEngine;
+import javax.script.ScriptEngineManager;
+import javax.script.ScriptException;
+
+/**
+ * Distribute your work as a self-extracting jar file by including one file,
+ * JarX.class, that also safely converts text files to the receiver's encoding
+ * and newline conventions, and adds less than 7 kB to your jar.
+ *<P>
+ * A self-extracting file is handy if your recipient might have a
+ * Java runtime environment but not the jar tool.
+ * The text conversion offered by JarX is useful if your distribution will
+ * include text files, source, documentation, scripts, etc., and your recipients
+ * have platforms with different newline conventions.
+ *<H3>Text conversion background</H3>
+ * There are two issues in the cross-platform delivery of text files.
+ *<OL><LI>Different platforms indicate the end of a line differently.
+ * The UNIX convention uses the single character LINE FEED; the (old) Macintosh
+ * used only the CARRIAGE RETURN character, and DOS/Windows systems require
+ * every line to end with a CARRIAGE RETURN followed by a LINE FEED.
+ * If some conversion isn't done, a Windows file appears to have garbage
+ * characters at the ends of lines if moved to UNIX, or the beginnings of lines
+ * if moved to a Mac; UNIX and Mac files moved to Windows, or Mac files moved
+ * to UNIX, appear to be squished into one insanely long line.
+ * These effects can complicate viewing and editing the files, and interfere
+ * with automated processes like diff or version control.
+ *<LI>Different platforms may use different default character encodings.
+ * Ideally, text files within a jar should be extracted into the local encoding.
+ *</OL><P>
+ * It's important to apply such transformations <EM>only</EM> to the files
+ * within the archive that are actually <EM>known</EM> to contain text.
+ * Passing binary data or class files through character and newline
+ * transformations will corrupt them.
+ *<H4>The ZIP approach and why it loses</H4>
+ * The popular zip format on which jar is based already has a provision for
+ * newline (but not character set) conversion. Each entry includes a text/binary
+ * bit, and the unzip program applies newline conversion while extracting, but
+ * only to the files flagged as text.
+ *<P>
+ * One problem, though not the fatal one, with this scheme is that there is no
+ * single convention for newlines inside the zip file.  Instead, files are
+ * stored just as they are found on the source system, and a code indicating the
+ * source operating system is stored in the archive.  The receiving unzip
+ * program must interpret the code and know what newline convention that
+ * operating system used, in order to convert newlines appropriately.
+ *<P>
+ * The fatal flaw, however, has to do with the way the text/binary
+ * bit gets set in the first place.  While building the archive, the common zip
+ * programs look at statistical properties of byte frequencies in the input,
+ * and set the text bit for any entry that looks like it might be text!  If a
+ * binary file happens to contain an unlucky sequence of bytes, it will be
+ * flagged as text and then silently corrupted by any unzip program that honors
+ * the text bit.  That can happen, and has happened, to class files in zip
+ * archives if the recipient uses unzip -a, and causes significant misery if
+ * the package is widely distributed.
+ *<H4>A better way</H4>
+ * Even though the jar format is based on zip, it would be a mistake to make jar
+ * tools that rely on the zip text/binary bit, because common
+ * practice has made that bit unreliable.  What's needed is a standard way for
+ * the developer to explicitly indicate the processing needed for each entry
+ * in the jar.  Also, a single representation should be adopted for newlines
+ * in text files inside a jar, so an extracting program only needs to convert
+ * from that representation to the local one, and does not need to concern
+ * itself with details of the system where the jar was created.
+ *<P>
+ * As of JDK 1.3, Sun has extended the
+ *<A
+ HREF="http://java.sun.com/products/jdk/1.3/docs/guide/jar/jar.html#Per-Entry%20Attributes">
+ *Jar File Specification</A> to allow a <CODE>Content-Type</CODE> in the
+ * Manifest for each jar entry.  The value of <CODE>Content-Type</CODE> is a
+ *<A HREF="http://www.isi.edu/in-notes/iana/assignments/media-types/media-types">MIME
+ * type</A>, and with this a developer can specify exactly which entries in a
+ * jar should be treated as text.  The question of a standard representation
+ * for newlines inside the jar is settled, because
+ * <A HREF="ftp://ftp.isi.edu/in-notes/rfc2046.txt">[RFC2046 section 4.1.1]</A>
+ * establishes a canonical line break representation for all subtypes of the
+ * <CODE>text</CODE> MIME type.  Therefore, correct translation of line breaks from any
+ * platform to any platform can be achieved if a jar-building program just
+ * converts from its local convention to the canonical CRLF form, and a jar
+ * extraction program just converts the canonical to its own local form. Neither
+ * program needs to know anything about the other environment.
+ * Finally, the <CODE>charset</CODE> parameter of the <CODE>text</CODE> type
+ * allows explicit specification of the character encoding used in a jar entry,
+ * and the extracting program can automatically convert into the encoding used
+ * on the local system. (But see <STRONG>Call to action</STRONG> below.)
+ *<H3>What JarX Does</H3>
+ * <CODE>Content-Type</CODE> entries in a Manifest were introduced in Java 1.3
+ * but are compatible with earlier jar specifications; a jar file containing
+ * such entries can be processed without any trouble by any jar tool compliant
+ * with the old or new standard.  However, there is not yet a full jar tool
+ * available that will honor the content types and do automatic transformation
+ * of text entries.  To fill the need until that functionality is added to the
+ * widely-available jar tools, JarX is available now.
+ *<P>
+ * JarX.Build produces a jar, working from a manifest file prepared by the
+ * developer.  Entries with any <CODE>text</CODE> type will be translated from
+ * the local encoding into the specified <CODE>charset</CODE> if given, and
+ * entries with the specific type <CODE>text/plain</CODE> will have their line
+ * endings converted to the CRLF canonical form.  Line endings are left alone
+ * for all other subtypes of <CODE>text</CODE>, but this decision is open to
+ * comment.
+ *<P>
+ * The file produced by JarX.Build is a fully compliant jar and can be unpacked
+ * by any jar or unzip tool, but current tools will not automatically convert
+ * the text files to the local conventions.  By including the single class file
+ * <CODE>JarX.class</CODE> in the jar, a developer produces a self-extracting
+ * archive that can be executed to unpack itself on any Java 1.6 or later
+ * virtual machine, performing all automatic conversions and requiring no jar
+ * tool at all.
+ *<H3>Building a Jar</H3>
+ * To build a jar file, first prepare the manifest, using any text editor or,
+ * more likely, a script.  Include a <CODE>Name:</CODE> entry for every file
+ * to be included in the jar.  JarX.Build archives only the files named in
+ * the manifest.  Be sure to include <CODE>Manifest-Version: 1.0</CODE> as
+ * the first line of the manifest; JarX.Build does not do it for you.  To make
+ * the jar self-extracting, make the next line<BR>
+ * <CODE>Main-Class: org.gjt.cuspy.JarX</CODE><BR> and be sure to include a
+ * <CODE>Name:</CODE> entry for <CODE>org/gjt/cuspy/JarX.class</CODE>.
+ *<P>
+ * Add an appropriate <CODE>Content-Type:</CODE> line after the
+ * <CODE>Name:</CODE> line for every entry that needs one.  JarX itself only
+ * distinguishes the <CODE>text</CODE> types from nontext (everything else),
+ * and treats a missing <CODE>Content-Type:</CODE> as nontext, so for purposes
+ * of JarX you only need to add content types for text files.  For other
+ * purposes you may wish to include the types of other entries as well.
+ * In the simplest case, just omit content types for your non-text files,
+ * and add <CODE>Content-Type: text/plain; charset=UTF-8</CODE> for files that
+ * you want auto-converted.  Then give the command<BR>
+ * <CODE>java org.gjt.cuspy.JarX$Build foo.jar manifest</CODE><BR> if
+ * <CODE>manifest</CODE> is the name of your prepared manifest file and
+ * <CODE>foo.jar</CODE> names the jar you want to create.
+ * The order of files in the jar will be the order of their names in the
+ * manifest.
+ *<H4>Special manifest attributes</H4>
+ * For 2016, JarX now recognizes some special manifest attributes:
+ * <DL>
+ *  <DT>_JarX_CharsetInArchive</DT>
+ *  <DD>As a per-entry attribute, identifies the character set of the associated
+ *   text member as stored in the archive. This is entirely equivalent to the
+ *   earlier method using {@code ;charset=} on the Content-Type attribute,
+ *   which JarX still supports, but has not been widely adopted. As a main
+ *   attribute, sets a default for any text members without a per-entry value.
+ *  </DD>
+ *  <DT>_JarX_CharsetWhenUnpacked</DT>
+ *  <DD>As a per-entry attribute, identifies the character set of the associated
+ *   text member when not in the archive. At Build time, the member will be
+ *   transcoded from this charset (instead of the platform's default) to the
+ *   specified InArchive charset, and, on extraction, will be transcoded back
+ *   to this charset regardless of the platform's default encoding. This
+ *   attribute can be used for files conforming to specifications that define
+ *   a fixed encoding. In other cases, omitting this attribute allows the
+ *   member to be extracted into the receiving platform's default charset.
+ *   As a main attribute, sets a default for text members without a per-entry
+ *   value.</DD>
+ *  <DT>_JarX_Permissions</DT>
+ *  <DD>As a per-entry attribute, declares permissions to apply to the
+ *   extracted file. (At present, not applied to directories.) Only the
+ *   Java SE 6 {@link java.io.File} permissions are supported, a small subset
+ *   of what most platforms support. A comma-separated list of
+ *   <em>usage</em>{@code =}<em>bywhom</em>, where <em>usage</em> can be
+ *   {@code read}, {@code write}, or {@code execute} and <em>bywhom</em> can be
+ *   {@code none}, {@code owner}, or {@code all}. As a main attribute, sets a
+ *   default for members without a per-entry attribute. For any <em>usage</em>
+ *   that is left unspecified, no {@link java.io.File File} method will be
+ *   called to change that permission, so the system's defaults will apply.
+ *  </DD>
+ *  <DT>_JarX_PathResolver</DT>
+ *  <DD>Only recognized as a main attribute, this specifies a script that JarX
+ *   will invoke for every archive member, with the following bindings in scope:
+ *    <DL>
+ *     <DT>properties</DT><DD>The Java system Properties object.</DD>
+ *     <DT>storedPath</DT><DD>The full pathname of the member, exactly as
+ *      stored in the archive.</DD>
+ *     <DT>platformPath</DT><DD>The full pathname after only replacing the
+ *      {@code /} separator character with the platform's {@code file.separator}
+ *      if different.
+ *     </DD>
+ *     <DT>computedPath</DT><DD>Initially the same as {@code platformPath}.
+ *      If the script stores a new value in {@code computedPath}, the member
+ *      will be extracted to that full path.</DD>
+ *    </DL>
+ *   The script is given as the value of this attribute, using the same
+ *   RFC822-ish lexical conventions the jar spec says it was "inspired by".
+ *   The value must begin with a MIME type (two atoms separated by a slash,
+ *   as in {@code application/javascript}, followed by at least one
+ *   {@code QUOTEDSTRING}. RFC822 uses the double-quote for this purpose, and
+ *   backslash to escape it when needed, which also means you must double any
+ *   backslash intended for the script. Additional {@code QUOTEDSTRING}s simply
+ *   append to the script. The RFC822 line-continuation rule can be exploited
+ *   by supplying the script as multiple quoted strings, one per line, each
+ *   indented by a space. The strings are appended with nothing in between
+ *   (so, the continuation newlines do not become newlines in the script), but
+ *   a {@code /} can appear between any two quoted strings to insert an
+ *   explicit newline in the script. In addition to whatever comment syntax is
+ *   allowed in the scripting language, RFC822 comments (marked by parentheses,
+ *   and nestable) are allowed outside of the quoted strings.
+ *  </DD>
+ * </DL>
+ *<H3>Extracting a jar</H3>
+ * The command <CODE>java -jar foo.jar</CODE> is all it takes
+ * to extract a jar.  The <CODE>Main-Class</CODE> entry in the manifest
+ * identifies the entry point of JarX so it does not need to be specified.
+ *<P>
+ * JarX
+ *<H3>Call to action</H3>
+ * At the moment, Sun's Jar File Specification contains a mistake in the
+ * description of a content type that could lead to implementations
+ * that reject valid content types.  Squash this bug before it bites:
+ * log on to the
+ *<A HREF="http://developer.java.sun.com/developer/">Java Developer
+ * Connection</A> (it's free) and cast one, two, or all three of your Bug Votes
+ * for
+ *<A HREF="http://developer.java.sun.com/developer/bugParade/bugs/4310708.html">
+ *Bug #4310708</A>.
+ *<H3>Miscellany</H3>
+ * This class is a little sloppy and relatively slow, especially the Build side
+ * when converting plain text files.  The idea for JarX is a natural outgrowth
+ * of the Java 1.3 manifest standard and I have suggested that the functionality
+ * of JarX be added into the widely available jar tools.  If Sun takes the
+ * suggestion then the functionality of JarX will soon be provided by nice
+ * fast optimized tools and it won't be necessary to spend a lot of time
+ * polishing JarX.
+ *<P>
+ * Error handling is roughly nonexistent.  JarX is careful to avoid silent
+ * corruption of data, even verifying that all character encoding calls are
+ * successful, but makes no attempt to be graceful about errors or surprises.
+ * If something doesn't work the likely result is a one line message and abrupt
+ * exit, or an uncaught exception and stack trace.
+ *<P>
+ * The coding style is a little contrived just to arrange it so JarX.class is
+ * the only file needed in the jar to make it self-extracting.  In particular
+ * the JarX class is also written to serve as the class of tokens returned by
+ * the structured-field-body lexer, to avoid introducing a second class.  Weird,
+ * perhaps, but harmless weird.
+ *@author <A HREF="mailto:chap@gjt.org">Chapman Flack</A>
+ *@version $Id$
+ */
+public class JarX {
+  /**How to treat the entry being processed: bytes, characters, lines.
+   * Used only in the JarX instance created by main(). Set by classify().
+   * Only the exact String instances BYTES, CHARACTERS, LINES are to be used.
+   */
+  protected String treatment;
+  protected static final String BYTES = "bytes";
+  protected static final String CHARACTERS = "characters";
+  protected static final String LINES = "lines";
+  /**Charset (in archive) of the entry being processed.
+   * Used only in the JarX instance created by main(). Set by classify().
+   */
+  protected Charset archiveCharset;
+  /**Charset when unpacked of the entry being processed.
+   * Used only in the JarX instance created by main(). Set by classify().
+   */
+  protected Charset unpackedCharset;
+
+  /**Read permission to be set on the file.
+   * Only the final Strings NONE, OWNER, or ALL are to be used, or null, in
+   * which case no explicit setting is made and the OS defaults apply.
+   */
+  protected String readPermission;
+  /**Write permission to be set on the file.
+   * Only the final Strings NONE, OWNER, or ALL are to be used, or null, in
+   * which case no explicit setting is made and the OS defaults apply.
+   */
+  protected String writePermission;
+  /**Execute permission to be set on the file.
+   * Only the final Strings NONE, OWNER, or ALL are to be used, or null, in
+   * which case no explicit setting is made and the OS defaults apply.
+   */
+  protected String executePermission;
+
+  protected static final String NONE = "none";
+  protected static final String OWNER = "owner";
+  protected static final String ALL = "all";
+
+  /**As for treatment, but set from main attributes (or BYTES if not present).*/
+  protected String defaultTreatment = BYTES;
+  /**As for archiveCharset, but set from main attributes (default UTF-8).*/
+  protected Charset defaultArchiveCharset = Charset.forName( "UTF-8");
+  /**As for unpackedCharset, but set from main attributes or platform default.*/
+  protected Charset defaultUnpackedCharset = Charset.defaultCharset();
+
+  /**As for readPermission but set from main attributes, null if not present.*/
+  protected String defaultReadPermission;
+  /**As for writePermission but set from main attributes, null if not present.*/
+  protected String defaultWritePermission;
+  /**As for executePermission but set from main attributes, null if not present.
+   */
+  protected String defaultExecutePermission;
+
+  /**Script engine to run the name resolver script, if any.*/
+  protected ScriptEngine resolverEngine;
+  /**The name resolver script, if any.*/
+  protected String resolverScript;
+
+  /**Attribute name for specifying the in-archive charset.
+   * The Java powers that be didn't go for
+   *<A HREF="http://developer.java.sun.com/developer/bugParade/bugs/4310708.html">
+   *Bug #4310708</A> so there needs to be a dedicated manifest key for this
+   * (though JarX will still honor ;charset= on the Content-Type too).
+   */
+  public final Attributes.Name ARCHIVE_CHARSET =
+    new Attributes.Name( "_JarX_CharsetInArchive");
+  /**Attribute name for specifying the when-unpacked charset.
+   * This was not in the original JarX; the platform default was always used,
+   * and still is if this attribute is not present.
+   */
+  public final Attributes.Name UNPACKED_CHARSET =
+    new Attributes.Name( "_JarX_CharsetWhenUnpacked");
+  /**Permissions (only as supported in java.io.File for SE 6)
+   * spec *(, spec) where spec is action=whom, action is read, write, or
+   * execute, and whom is none, owner, or all.
+   */
+  public final Attributes.Name PERMISSIONS =
+    new Attributes.Name( "_JarX_Permissions");
+  /** Main attribute to specify a JSR223 script to control extracted names. */
+  public final Attributes.Name PATHRESOLVER =
+    new Attributes.Name( "_JarX_PathResolver");
+
+  /**Main attributes saved from the manifest (which must be seen early).*/
+  protected Attributes mainAttributes;
+
+  /**Token type, when JarX objects are used to return content type tokens*/
+  public short type;
+  /**Token text when JarX objects are used to return content type tokens*/
+  public String value;
+  
+  /**Token types from the structured field body lexer defined in
+   *<A HREF="ftp://ftp.isi.edu/in-notes/rfc822.txt">RFC822</A>
+   * as modified in
+   *<A HREF="ftp://ftp.isi.edu/in-notes/rfc2045.txt">RFC2045</A>.
+   * Also state numbers for the automaton in
+   * {@link #structuredFieldBody(String,int) structuredFieldBody}.
+   */
+  public static final short ATOM = 5;
+  public static final short COMMENT = 4;
+  public static final short DOMAINLITERAL = 3;
+  public static final short QUOTEDSTRING = 2;
+  public static final short TSPECIAL = 1;
+  static final short START = 0;
+
+  /**True if this JarX object represents a token of one of the given types.
+   * @param type allowable types
+   * @return as titled
+   */
+  public boolean is( short... type) {
+    for ( short t : type )
+      if ( t == this.type )
+        return true;
+    return false;
+  }
+
+  /**True if this JarX object represents a token of one of the given types
+   * and its value equals the given string.
+   * @param value string value for comparison
+   * @param type allowable types
+   * @return as titled
+   */
+  public boolean holds( String value, short... type) {
+    return is( type) && value.equals( this.value);
+  }
+
+  /**True if this JarX object represents a token of one of the given types
+   * and its value equals the given string, case-insensitively.
+   * @param value string value for comparison
+   * @param type allowable types
+   * @return as titled
+   */
+  public boolean holdsIgnoreCase( String value, short... type) {
+    return is( type) && value.equalsIgnoreCase( this.value);
+  }
+
+  /**Name of the JarX class file as stored in the jar*/
+  public static final String me
+    = JarX.class.getName().replace('.', '/') + ".class";
+  /**Name of the manifest file as stored in the jar*/
+  public static final String manifestName = "META-INF/MANIFEST.MF";
+  /**The (fixed) encoding used for manifest content*/
+  public static final String manifestCode = "UTF-8";
+
+  /**The entry point for extracting.
+   *@param args argument list
+   *@throws Exception if anything doesn't work, punt
+   */
+  public static void main( String[] args) throws Exception {
+    JarX e = new JarX();
+    
+    if ( args.length > 0 ) {
+      System.err.println( "usage: java -jar filename.jar");
+      System.exit( 1);
+    }
+
+    e.extract();
+  }
+
+  /**Find the jar I was loaded from and extract all entries except my own
+   * class file.
+   *@throws Exception if anything doesn't work, punt
+   */
+  public void extract() throws Exception {
+    URL jarURL =
+      this.getClass().getProtectionDomain().getCodeSource().getLocation();
+
+    InputStream is = jarURL.openStream();
+    JarInputStream jis = new JarInputStream( is);
+    
+    Manifest mf = null;
+
+    for ( JarEntry je;; ) {
+      je = jis.getNextJarEntry();
+      if ( je == null )
+      	break;
+      if ( null == mf ) {
+        mf = jis.getManifest();
+	if ( null != mf )
+	  setDefaults( mf.getMainAttributes());
+      }
+      if ( ! je.getName().equals( me) )
+	extract( je, jis);
+      jis.closeEntry();
+    }
+    
+    jis.close();
+  }
+  
+  /**Examine the main attributes to set any defaults.
+   * Includes loading the required script engine if a name resolver script
+   * is given.
+   * @param mainAttributes as obtained from the manifest
+   */
+  public void setDefaults( Attributes mainAttributes) {
+    this.mainAttributes = mainAttributes;
+
+    classify( mainAttributes, false);
+
+    defaultTreatment = treatment;
+    defaultArchiveCharset = archiveCharset;
+    defaultUnpackedCharset = unpackedCharset;
+
+    defaultReadPermission = readPermission;
+    defaultWritePermission = writePermission;
+    defaultExecutePermission = executePermission;
+
+    if ( null == mainAttributes )
+      return;
+
+    String v = mainAttributes.getValue( PATHRESOLVER);
+    if ( null == v )
+      return;
+
+    JarX[] toks = structuredFieldBody( v, 0);
+    if ( toks.length < 4
+      || ! toks[0].is( ATOM)
+      || ! toks[1].holds("/", TSPECIAL)
+      || ! toks[2].is( ATOM)
+      || ! toks[3].is( QUOTEDSTRING) ) {
+      System.err.printf( "Malformed name resolver attribute: %s\n", v);
+      System.exit( 1);
+    }
+
+    String mimetype = toks[0].value + "/" + toks[2].value;
+    StringBuilder script = new StringBuilder( toks[3].value);
+    int i = 4;
+    while ( i < toks.length ) {
+      if ( toks[i].holds( "/", TSPECIAL) )
+        script.append( '\n');
+      else if ( toks[i].is( QUOTEDSTRING) )
+        script.append( toks[i].value);
+      else
+        break;
+      ++i;
+    }
+
+    if ( i < toks.length ) {
+      System.err.printf( "Malformed name resolver attribute: %s\n", v);
+      System.exit( 1);
+    }
+
+    ScriptEngineManager mgr = new ScriptEngineManager();
+    resolverEngine = mgr.getEngineByMimeType( mimetype);
+    if ( null == resolverEngine ) {
+      System.err.printf( "No script engine found for %s\n", mimetype);
+      System.exit( 1);
+    }
+    resolverEngine.put( "properties", System.getProperties());
+    resolverScript = script.toString();
+  }
+
+  /**Set instance variables for text/binary and permissions treatment
+   * according to the passed Attributes.
+   * @param atts Usually a per-entry attribute set, but {@code classify} is
+   * also called by {@code setDefaults} to parse the main attributes.
+   * @param lazy In the usual case, as soon as an entry is classified as
+   * non-text, {@code classify} can return without looking for charset
+   * information. When called by {@code setDefaults}, however, laziness is not
+   * appropriate.
+   */
+  public void classify( Attributes atts, boolean lazy) {
+    treatment = defaultTreatment;
+    archiveCharset = defaultArchiveCharset;
+    unpackedCharset = defaultUnpackedCharset;
+
+    readPermission = defaultReadPermission;
+    writePermission = defaultWritePermission;
+    executePermission = defaultExecutePermission;
+
+    if ( null == atts )
+      return;
+
+    String v = atts.getValue( PERMISSIONS);
+    if ( null != v ) {
+      String r = null;
+      String w = null;
+      String x = null;
+      JarX[] toks = structuredFieldBody( v, 0);
+      int i = 0;
+      while ( i + 2 < toks.length ) {
+	if ( ! toks[i].is( ATOM) || ! toks[i+1].holds( "=", TSPECIAL) )
+	  break;
+	if ( ! toks[i+2].is( ATOM) )
+	  break;
+	String p = toks[i].value;
+	String noa = toks[i+2].value;
+	if ( NONE.equalsIgnoreCase( noa) )
+	  noa = NONE;
+	else if ( OWNER.equalsIgnoreCase( noa) )
+	  noa = OWNER;
+	else if ( ALL.equalsIgnoreCase( noa) )
+	  noa = ALL;
+	else
+	  break;
+	if ( "read".equalsIgnoreCase( p) && null == r )
+	  r = noa;
+	else if ( "write".equalsIgnoreCase( p) && null == w )
+	  w = noa;
+	else if ( "execute".equalsIgnoreCase( p) && null == x )
+	  x = noa;
+	else
+	  break;
+	i += 3;
+	if ( i+3 < toks.length && toks[i].holds( ",", TSPECIAL) )
+	  ++i;
+      }
+
+      if ( i < toks.length ) {
+	System.err.printf( "Malformed permissions attribute: %s\n", v);
+	System.exit( 1);
+      }
+
+      if ( null != r )
+        readPermission = r;
+      if ( null != w )
+        writePermission = w;
+      if ( null != x )
+        executePermission = x;
+    }
+
+    boolean archiveCharsetFound = false;
+
+    v = atts.getValue( Attributes.Name.CONTENT_TYPE);
+    if ( null != v ) {
+      JarX[] type = structuredFieldBody( v, 0);
+      if ( type[0].holdsIgnoreCase( "text", ATOM)
+        && type[1].holds( "/", TSPECIAL) ) {
+        treatment = type[2].holdsIgnoreCase( "plain", ATOM)? LINES : CHARACTERS;
+        archiveCharsetFound = archiveCharsetFromType( type);
+      }
+    }
+
+    if ( BYTES == treatment && lazy )
+      return;
+
+    if ( ! archiveCharsetFound ) {
+      v = atts.getValue( ARCHIVE_CHARSET);
+      if ( null != v )
+        archiveCharset = Charset.forName( v);
+    }
+
+    v = atts.getValue( UNPACKED_CHARSET);
+    if ( null != v )
+      unpackedCharset = Charset.forName( v);
+  }
+
+  /**Parse a Content-Type for any {@code charset} parameter.
+   * @param type tokenized Content-Type value
+   * @return true if the Content-Type specified a charset
+   */
+  protected boolean archiveCharsetFromType( JarX[] type) {
+    String charset = null;
+    int i = 3;
+
+    while ( i < type.length ) {
+      if ( ! type[i].holds( ";", TSPECIAL) )
+      	break;
+      if ( type[++i].holdsIgnoreCase( "charset", ATOM) ) {
+	if ( ! type[++i].holds( "=", TSPECIAL) )
+	  break;
+	if ( ! type[++i].is( ATOM, QUOTEDSTRING) )
+	  break;
+	charset = type[i].value;
+	break;
+      }
+      if ( ! type[++i].holds( "=", TSPECIAL) )
+	break;
+      if ( ! type[++i].is( ATOM, QUOTEDSTRING) )
+	break;
+      ++i;
+    }
+
+    if ( null != charset ) {
+      archiveCharset = Charset.forName( charset);
+      return true;
+    }
+
+    if ( i < type.length ) {
+      System.err.println( "Malformed Content-Type specification!");
+      System.exit( 1);
+    }
+
+    return false;
+  }
+
+  /**Extract a single entry, performing any appropriate conversion
+   *@param je JarEntry for the current entry
+   *@param is InputStream with the current entry content
+   *@throws IOException for any problem involving I/O
+   *@throws ScriptException for any problem involving the script engine
+   */
+  public void extract( JarEntry je, InputStream is)
+  throws IOException, ScriptException {
+    classify( je.getAttributes(), true);
+
+    String orig = je.getName();
+    String s = orig;
+    
+    if ( File.separatorChar != '/' )
+      s = s.replace( '/', File.separatorChar);
+
+    if ( null != resolverScript ) {
+      resolverEngine.put( "storedPath", orig);
+      resolverEngine.put( "platformPath", s);
+      resolverEngine.put( "computedPath", s);
+      resolverEngine.eval( resolverScript);
+      s = (String)resolverEngine.get( "computedPath");
+    }
+
+    System.err.print( s + " ");
+    
+    File f = new File( s);
+    
+    if ( je.isDirectory() ) {
+      if ( f.isDirectory()  ||  f.mkdirs() )
+      	System.err.println();
+      else
+      	System.err.println( "FAILED!");
+      return;
+    }
+      
+    OutputStream os;
+    
+    File tmpf;
+    File d = f.getParentFile();
+    if ( null == d )
+      d = new File( System.getProperty( "user.dir"));
+    try {
+      tmpf = File.createTempFile( f.getName(), ".tmp", d);
+    }
+    catch ( IOException e ) {
+      if ( ! d.mkdirs() )
+      	throw e;
+      tmpf = File.createTempFile( f.getName(), ".tmp", d);
+    }
+
+    os = new FileOutputStream( tmpf);
+
+    if ( null != readPermission ) {
+      if ( ALL == readPermission )
+        tmpf.setReadable( true, false);
+      else {
+        tmpf.setReadable( false, false);
+	if ( OWNER == readPermission )
+	  tmpf.setReadable( true, true);
+      }
+    }
+
+    if ( null != writePermission ) {
+      if ( ALL == writePermission )
+        tmpf.setWritable( true, false);
+      else {
+        tmpf.setWritable( false, false);
+	tmpf.setWritable( true, true); /* will when done writing */
+      }
+    }
+    
+    shovel( is, os);
+    
+    os.close();
+
+    if ( NONE == writePermission )
+      tmpf.setWritable( false, false);
+
+    if ( null != executePermission ) {
+      if ( ALL == executePermission )
+        tmpf.setExecutable( true, false);
+      else {
+        tmpf.setExecutable( false, false);
+	if ( OWNER == executePermission )
+	  tmpf.setExecutable( true, true);
+      }
+    }
+
+    tmpf.renameTo( f);
+  }
+
+  /**Copy content from an input to an output stream until end.
+   * Whether the content is shoveled as bytes, characters, or lines will be
+   * determined by instance variables that have been set by calling
+   * {@link #classify(Attributes,boolean) classify} before calling this method.
+   *@param is source of input
+   *@param os destination for output
+   *@throws IOException for any problem involving I/O
+   */
+  public void shovel( InputStream is, OutputStream os) throws IOException {
+    if ( BYTES == treatment )
+      shovelBytes( is, os);
+    else
+      shovelText( is, os);
+  }
+  
+  /**Copy <EM>bytes</EM> from an input to an output stream until end.
+   * No character encoding or newline conversion applies.
+   *@param is source of input
+   *@param os destination for output
+   *@throws IOException for any problem involving I/O
+   */
+  public static void shovelBytes( InputStream is, OutputStream os)
+  throws IOException {
+    byte[] buf = new byte [ 1024 ];
+    int got;
+    
+    for ( ;; ) {
+      got = is.read( buf, 0, buf.length);
+      if ( got == -1 )
+      	break;
+      os.write( buf, 0, got);
+    }
+    System.err.println( "as bytes");
+  }
+
+  /**Copy <EM>text</EM> from an input to an output stream until end.
+   * Determines the encoding transformation to use (based on the
+   * <CODE>charset</CODE> content-type parameter) and whether to copy as
+   * lines (with newline conversion) or unmolested characters.
+   * <CODE>text/plain</CODE> is copied as lines, all other text subtypes
+   * as characters.
+   *@param is source of input
+   *@param os destination of output
+   *@throws IOException for any problem involving I/O
+   */
+  public void
+  shovelText( InputStream is, OutputStream os)
+  throws IOException {
+    if ( LINES == treatment )
+      shovelLines( is, os);
+    else
+      shovelChars( is, os);
+  }
+
+  /**Copy <EM>lines</EM> of text from an input from an output stream, applying
+   * the specified character encoding and translating newlines.
+   * This method handles the extracting case, where the named encoding is
+   * associated with the input stream (jar) and the platform default encoding
+   * with the output (local file), and the local line.separator is used to
+   * separate lines on the output.
+   * Overridden in
+   * {@link JarX.Build#shovelLines(InputStream,OutputStream) build} to do
+   * the reverse when building a jar.
+   * To avoid silent corruption of data, this method verifies that all
+   * characters from the jar are successfully converted to the local platform's
+   * encoding.
+   *@param is the source of input
+   *@param os destination for output
+   *@throws IOException for any problem involving I/O
+   */
+  public void
+  shovelLines( InputStream is, OutputStream os)
+  throws IOException {
+    InputStreamReader isr =
+      new InputStreamReader( is, archiveCharset.newDecoder());
+    BufferedReader br = new BufferedReader( isr);
+    OutputStreamWriter osw =
+      new OutputStreamWriter( os, unpackedCharset.newEncoder());
+    BufferedWriter bw = new BufferedWriter( osw);
+    
+    String s;
+    
+    for ( ;; ) {
+      s = br.readLine();
+      if ( s == null )
+      	break;
+      bw.write( s);
+      bw.newLine();
+    }
+    bw.flush();
+    osw.flush();
+    
+    System.err.printf( "as lines (%s)\n", describeTranscoding(isr, osw));
+  }
+  
+  /**Copy <EM>characters</EM> of text from an input from an output stream,
+   * applying the specified character encoding but not translating newlines.
+   * This method handles the extracting case, where the named encoding is
+   * associated with the input stream (jar) and the platform default encoding
+   * with the output (local file).
+   * Overridden in
+   * {@link Build#shovelChars(InputStream,OutputStream) build} to do
+   * the reverse when building a jar.
+   * To avoid silent corruption of data, this method verifies that all
+   * characters from the jar are successfully converted to the local platform's
+   * encoding.
+   *@param is the source of input
+   *@param os destination for output
+   *@throws IOException for any problem involving I/O
+   */
+  public void
+  shovelChars( InputStream is, OutputStream os)
+  throws IOException {
+    InputStreamReader isr =
+      new InputStreamReader( is, archiveCharset.newDecoder());
+    OutputStreamWriter osw =
+      new OutputStreamWriter( os, unpackedCharset.newEncoder());
+    char[] c = new char [ 1024 ];
+    int got;
+    
+    for ( ;; ) {
+      got = isr.read( c, 0, c.length);
+      if ( got == -1 )
+      	break;
+      osw.write( c, 0, got);
+    }
+    osw.flush();
+    System.err.printf( "as characters (%s)\n", describeTranscoding(isr, osw));
+  }
+
+  public String describeTranscoding(
+    InputStreamReader isr, OutputStreamWriter osw) {
+    String ie = isr.getEncoding();
+    String oe = osw.getEncoding();
+    if ( ie.equals( oe) )
+      return ie;
+    return ie + " -> " + oe;
+  }
+  
+  /**Public constructor for an application using JarX to unpack jars.*/
+  public JarX() { }
+  /**Constructor for JarX objects used as tokens returned by the lexer.
+   *@param t the type of this token
+   *@param v the corresponding text (with delimiters removed and backslashes
+   * resolved for quoted strings, domain text, and comments)
+   */
+  protected JarX( short t, String v) { type = t; value = v; }
+
+  /**Lexical analyzer for structured field bodies as described in
+   *<A HREF="ftp://ftp.isi.edu/in-notes/rfc822.txt">RFC822</A>
+   * and modified in
+   *<A HREF="ftp://ftp.isi.edu/in-notes/rfc2045.txt">RFC2045</A>.
+   * Comments are processed and stored in tokens that are, at the last
+   * minute, excluded from the returned token list; only two lines would need
+   * to be changed to use this lexer in an application that wanted comments
+   * returned.
+   *@param field a header field
+   *@param off offset to the start of the structured field body
+   * (skip the field name and colon)
+   *@return An array of {@link #JarX(short,String) tokens} with any
+   * COMMENT tokens (for JarX purposes) excluded
+   */
+  public static JarX[] structuredFieldBody( String field, int off) {
+    char[] buf = new char [ field.length() - off ];
+    field.getChars( off, off + buf.length, buf, 0);
+    int beg = 0, end = -1, la;
+    int commentDepth = 0;
+    short state = START;
+    short lastState = state;
+    boolean bashed = false;
+    ArrayList<JarX> v = new ArrayList<JarX>();
+    
+    dfa: for ( la = 0; la < buf.length; ) {
+      
+      if ( end >= beg ) {
+      	if ( lastState != COMMENT )
+	  v.add(new JarX( lastState, new String( buf, beg, end-beg)));
+	end = -1;
+      }
+      lastState = state;
+      
+      switch ( state ) {
+      	case START:
+	  switch ( buf[la] ) {
+	    case '"': beg = ++la; state = QUOTEDSTRING; continue dfa;
+	    case '[': beg = ++la; state = DOMAINLITERAL; continue dfa;
+	    case '(': beg = ++la; state = COMMENT; continue dfa;
+	    case '/': case '?': case '=': case ')': case '<': case '>':
+	    case '@': case ',': case ';': case ':': case '\\':  case ']':
+	      state = TSPECIAL; continue dfa;
+	    case ' ': case '\u0009': ++la; continue dfa;
+	    default: beg = la++; state = ATOM; continue dfa;
+	  }
+	case TSPECIAL:
+	  beg = la;
+	  end = ++la;
+	  state = START;
+	  continue dfa;
+	case QUOTEDSTRING:
+	  for ( end = beg; la < buf.length; ++la ) {
+	    if ( bashed )
+	      bashed = false;
+	    else if ( buf [ la ] == '\\' ) {
+	      bashed = true;
+	      continue;
+	    }
+	    else if ( buf [ la ] == '"' ) {
+	      ++la;
+	      state = START;
+	      continue dfa;
+	    }
+	    buf [ end++ ] = buf [ la ];
+	  }
+	  break dfa;
+	case DOMAINLITERAL:
+	  for ( end = beg; la < buf.length; ++la ) {
+	    if ( bashed )
+	      bashed = false;
+	    else if ( buf [ la ] == '\\' ) {
+	      bashed = true;
+	      continue;
+	    }
+	    else if ( buf [ la ] == ']' ) {
+	      ++la;
+	      state = START;
+	      continue dfa;
+	    }
+	    buf [ end++ ] = buf [ la ];
+	  }
+	  break dfa;
+	case COMMENT:
+	  ++commentDepth;
+	  for ( end = beg; la < buf.length; ++la ) {
+	    if ( bashed )
+	      bashed = false;
+	    else if ( buf [ la ] == '\\' ) {
+	      bashed = true;
+	      continue;
+	    }
+	    else if ( buf [ la ] == ')' && 0 == --commentDepth ) {
+	      ++la;
+	      state = START;
+	      continue dfa;
+	    }
+	    else if ( buf [ la ] == '(' )
+	      ++commentDepth;
+	    buf [ end++ ] = buf [ la ];
+	  }
+	  break dfa;
+	case ATOM:
+	  for ( end = la; la < buf.length; ++la ) {
+	    if ( buf [ la ] <= ' ' ) {
+	      state = START;
+	      continue dfa;
+	    }
+	    switch ( buf [ la ] ) {
+	      case '/': case '?': case '=':
+	      case '(': case ')': case  '<': case '>': case '@':
+	      case ',': case ';': case '\\': case '"':
+	      case '[': case ']': state = START; continue dfa;
+	      default: ++end;
+	    }
+	  }
+	  state = START;
+	  break dfa;
+      }
+    }
+    if ( state != START )
+      System.err.println( "Warning: incomplete qstring, dtext, or comment");
+    if ( end >= beg )
+      if ( lastState != COMMENT )
+	v.add(new JarX( lastState, new String( buf, beg, end-beg)));
+    return v.toArray( new JarX [ v.size() ]);
+  }
+
+  /**Subclass of JarX containing the code needed to build jars.  This class
+   * is not needed for extracting and this class
+   * file does not need to be included in a self-extracting jar.
+   */
+  public static class Build extends JarX {
+    
+    /**Entry point for building a jar.
+     * Names of all files to be put in the jar (except the manifest itself)
+     * are taken from the manifest.
+     *@param args two command line arguments: 1) the name of the jar file
+     * to create; 2) the name of the manifest file.
+     *@throws Exception if anything goes wrong, punt
+     */
+    public static void main( String[] args) throws Exception {
+      if ( args.length != 2 ) {
+      	System.err.println( "usage: JarX.Build jarfile manifest");
+	System.exit( 1);
+      }
+      new Build().build( args[0], args[1]);
+    }
+    
+    /**Names of files to include, in order of appearance in the manifest*/
+    ArrayList<String> names = new ArrayList<String>();
+    /**Attribute sections of those files, null if not specified*/
+    ArrayList<Attributes> sections = new ArrayList<Attributes>();
+    
+    /**Method to be used by an application using this class to build a jar.
+     *@param jarFile name of jar file to be created
+     *@param manif name of an existing manifest file containing the names
+     * of files to include in the jar. File names in the manifest obey zip
+     * conventions with the forward slash / as the path operator, which may
+     * differ from the local platform convention.
+     *@throws Exception if anything doesn't work, punt
+     */
+    public void build( String jarFile, String manif) throws Exception {
+      FileOutputStream fos = new FileOutputStream( jarFile);
+      ZipOutputStream zos = new ZipOutputStream( fos);
+      FileInputStream is = new FileInputStream( manif);
+      ZipEntry ze;
+      File f;
+      
+      this.manifest( is);
+      is.close();
+      
+      System.err.print( manifestName + " ");
+      is = new FileInputStream( manif);
+      ze = new ZipEntry( manifestName);
+      zos.putNextEntry( ze);
+      classify( null, true);
+      archiveCharset = Charset.forName( manifestCode);
+      this.shovelLines( is, zos);
+      is.close();
+      zos.closeEntry();
+      
+      String[] n = new String [ names.size() ];
+      Attributes[] t = new Attributes[ sections.size() ];
+      
+      names.toArray( n);
+      sections.toArray( t);
+      
+      for ( int i = 0; i < n.length; ++i ) {
+      	if ( n[i].equals( manifestName) )
+	  continue;
+	System.err.print( n[i] + " ");
+	ze = new ZipEntry( n[i]);
+	f = new File( File.separatorChar == '/' ? n[i] :
+	              n[i].replace( '/', File.separatorChar));
+	ze.setTime( f.lastModified());
+	zos.putNextEntry( ze);
+	if ( ze.isDirectory() ) {
+	  System.err.println();
+	}
+	else if ( f.isDirectory() ) {
+	  System.err.println( "DIRECTORY! add / in manifest.");
+	  System.exit( 1);
+	}
+	else {
+	  is = new FileInputStream( f);
+	  classify( t[i], true);
+	  if ( BYTES == treatment )
+	    this.shovelBytes( is, zos);
+	  else
+	    this.shovelText( is, zos);
+	  is.close();
+	}
+	zos.closeEntry();
+      }
+      
+      zos.close();
+    }
+
+    /**Overridden to
+     * save name-to-type mappings in Lists instead of the Map, to
+     * preserve the order of names in the manifest.
+     */
+    void store( String name, Attributes atts) {
+      names.add( name);
+      sections.add( atts);
+    }
+
+    /**Overridden to apply the archive encoding to the output stream (jar
+     * entry), the unpacked encoding to the input stream (local file), and use
+     * the RFC2046-required CRLF line separator on the output.
+     *@param is source of input (local file)
+     *@param os destination of output (jar entry)
+     */
+    public void
+    shovelLines( InputStream is, OutputStream os)
+    throws IOException {
+      InputStreamReader isr =
+        new InputStreamReader( is, unpackedCharset.newDecoder());
+      BufferedReader br = new BufferedReader( isr);
+      OutputStreamWriter osw =
+        new OutputStreamWriter( os, archiveCharset.newEncoder());
+      BufferedWriter bw = new BufferedWriter( osw);
+
+      String crlf = "\r\n";
+
+      String s;
+ 
+      for ( ;; ) {
+    	s = br.readLine();
+    	if ( s == null )
+    	  break;
+	bw.write( s);
+	bw.write( crlf);
+      }
+      bw.flush();
+      osw.flush();
+ 
+      System.err.printf( "as lines (%s)\n", describeTranscoding(isr, osw));
+    }
+  
+    /**Overridden to apply the archive encoding to the output stream (jar entry)
+     * and the unpacked encoding to the input stream (local file).
+     *@param is source of input (local file)
+     *@param os destination of output (jar entry)
+     */
+    public void
+    shovelChars( InputStream is, OutputStream os)
+    throws IOException {
+      InputStreamReader isr =
+        new InputStreamReader( is, unpackedCharset.newDecoder());
+      OutputStreamWriter osw =
+        new OutputStreamWriter( os, archiveCharset.newEncoder());
+      char[] c = new char [ 1024 ];
+      int got;
+
+      for ( ;; ) {
+	got = isr.read( c, 0, c.length);
+	if ( got == -1 )
+      	  break;
+	osw.write( c, 0, got);
+      }
+      osw.flush();
+
+      System.err.printf( "as characters (%s)\n", describeTranscoding(isr, osw));
+    }
+
+    /**Read the manifest and build lists of file names and Attributes objects.
+     * This was originally here because JarX wanted to support Java 1.1, which
+     * lacked java.util.jar. The reason it is still here (in Build only) is that
+     * the java.util.jar.Manifest implementation doesn't preserve the order of
+     * manifest sections, while it is nice to build the jar in the specified
+     * order.
+     *@param is an input stream already open on the manifest
+     *@throws IOException if unable to read the manifest
+     */
+    public void manifest( InputStream is)
+    throws IOException {
+      InputStreamReader isr;
+      Charset enc = Charset.forName(manifestCode);
+      isr = new InputStreamReader( is, enc.newDecoder());
+      BufferedReader br = new BufferedReader( isr);
+
+      while ( section( br) ); /* */
+    }
+
+    /**Process one manifest section, adding a dictionary entry if the section
+     * contains both a <CODE>Name:</CODE> and a <CODE>Content-Type</CODE>
+     * attribute.
+     *@param r BufferedReader already open on the manifest
+     *@return true if there is another section to read, false if the end of the
+     * manifest has been reached
+     *@throws IOException if the manifest can't be read
+     */
+    public boolean section( BufferedReader r)
+    throws IOException {
+      String field;
+      String front;
+      String name = null;
+      Attributes atts = new Attributes();
+      boolean gotany = false;
+
+      for ( ;; ) {
+        field = header( r);
+        if ( field == null  ||  0 == field.length() )
+          break;
+        gotany = true;
+	int i = field.indexOf( ": ");
+	if ( i < 1 ) {
+	  System.err.printf( "Malformed line in manifest: %s\n", field);
+	  System.exit( 1);
+	}
+	front = field.substring(0, i);
+	field = field.substring(i+2);
+        if ( front.equalsIgnoreCase( "Name") ) {
+          if ( name == null )
+            name = field;
+          else
+            System.err.println(
+              "Warning: name attribute repeated within a section, ignored.");
+          continue;
+	}
+	atts.putValue( front, field);
+      }
+
+      if ( ! gotany )
+        return null != field;
+
+      if ( null == name ) {
+        if ( null != mainAttributes ) {
+	  System.err.println(
+	    "Main attributes followed by another nameless section");
+	  System.exit( 1);
+	}
+	setDefaults( atts);
+      }
+      else
+        store( name, atts);
+
+      return null != field;
+    }
+
+    /**Buffer used between calls to {@link #header(BufferedReader) header}.*/
+    String nextManifestLine = null;
+
+    /**Return one header line (complete after RFC822 continuation unfolding).
+     * <strong>Note:</strong> The Jar specification says it is "inspired by"
+     * RFC822, but the folding rule <strong>differs</strong>. RFC822 allows
+     * "linear whitespace" (i.e. space or tab) to start the continuation line,
+     * and the LWSP <em>remains in the line</em> (RFC822 lines are only supposed
+     * to be folded at places LWSP can appear). A jar manifest line continuation
+     * can only begin with a space, and the space is <em>eaten</em>; Java's
+     * manifest writer can arbitrarily fold in the middle of anything.
+     *@param r BufferedReader to read from
+     *@return the line read, or null at end of input
+     *@throws IOException if the input cannot be read
+     */
+    public String header( BufferedReader r) throws IOException {
+      if ( nextManifestLine == null )
+        nextManifestLine = r.readLine();
+
+      String line = nextManifestLine;
+
+      for  ( ;; ) {
+        nextManifestLine = r.readLine();
+        if ( nextManifestLine == null
+          || ! nextManifestLine.startsWith( " ") )
+          break;
+        line += nextManifestLine.substring(1);
+      }
+
+      return line;
+    }
+  }
+}

--- a/pljava-packaging/src/main/resources/pljava--unpackaged.sql
+++ b/pljava-packaging/src/main/resources/pljava--unpackaged.sql
@@ -1,0 +1,68 @@
+\echo Use "CREATE EXTENSION pljava FROM UNPACKAGED" to load this file. \quit
+
+/*
+ This script can "update" from any unpackaged PL/Java version supported by
+ the automigration code within PL/Java itself. The schema migration is first
+ touched off by the LOAD command, and then the ALTER EXTENSION commands gather
+ up the member objects according to the current schema version.
+ */
+
+DROP TABLE IF EXISTS @extschema@.loadpath;
+CREATE TABLE @extschema@.loadpath(s) AS SELECT CAST('MODULE_PATHNAME' AS text);
+LOAD 'MODULE_PATHNAME';
+DROP TABLE @extschema@.loadpath;
+
+/*
+ Why the DROP / ADD?  When faced with a LOAD command, PostgreSQL only does it
+ if the library has not been loaded already in the session (as could have
+ happened if, for example, a PL/Java function has already been called). If the
+ LOAD was skipped, there could still be an old-layout schema, because the
+ migration only happens in an actual LOAD.  To avoid confusion later, it's
+ helpful to fail fast in that case. DROPping the call handlers accomplishes
+ that, because the LOAD action always CREATE-OR-REPLACEs them (to be sure they
+ refer to the latest native library), which means they will already be gathered
+ into the extension, provided the LOAD actions actually ran. If not, the DROPs
+ will fail.
+ 
+ The error messages will not shed much light on the real problem, but at least
+ will indicate that there is a problem. The solution is simply to exit the
+ session and repeat the CREATE EXTENSION in a new session where PL/Java has not
+ been loaded yet.
+ */
+
+ALTER EXTENSION pljava DROP FUNCTION sqlj.java_call_handler();
+ALTER EXTENSION pljava  ADD FUNCTION sqlj.java_call_handler();
+ALTER EXTENSION pljava DROP FUNCTION sqlj.javau_call_handler();
+ALTER EXTENSION pljava  ADD FUNCTION sqlj.javau_call_handler();
+
+ALTER EXTENSION pljava ADD LANGUAGE java;
+ALTER EXTENSION pljava ADD LANGUAGE javau;
+
+ALTER EXTENSION pljava ADD
+ FUNCTION sqlj.add_type_mapping(character varying,character varying);
+ALTER EXTENSION pljava ADD
+ FUNCTION sqlj.drop_type_mapping(character varying);
+ALTER EXTENSION pljava ADD
+ FUNCTION sqlj.get_classpath(character varying);
+ALTER EXTENSION pljava ADD
+ FUNCTION sqlj.install_jar(bytea,character varying,boolean);
+ALTER EXTENSION pljava ADD
+ FUNCTION sqlj.install_jar(character varying,character varying,boolean);
+ALTER EXTENSION pljava ADD
+ FUNCTION sqlj.remove_jar(character varying,boolean);
+ALTER EXTENSION pljava ADD
+ FUNCTION sqlj.replace_jar(bytea,character varying,boolean);
+ALTER EXTENSION pljava ADD
+ FUNCTION sqlj.replace_jar(character varying,character varying,boolean);
+ALTER EXTENSION pljava ADD
+ FUNCTION sqlj.set_classpath(character varying,character varying);
+
+ALTER EXTENSION pljava ADD TABLE sqlj.classpath_entry;
+ALTER EXTENSION pljava ADD TABLE sqlj.jar_descriptor;
+ALTER EXTENSION pljava ADD TABLE sqlj.jar_entry;
+ALTER EXTENSION pljava ADD TABLE sqlj.jar_repository;
+ALTER EXTENSION pljava ADD TABLE sqlj.typemap_entry;
+
+ALTER EXTENSION pljava ADD SEQUENCE sqlj.jar_entry_entryid_seq;
+ALTER EXTENSION pljava ADD SEQUENCE sqlj.jar_repository_jarid_seq;
+ALTER EXTENSION pljava ADD SEQUENCE sqlj.typemap_entry_mapid_seq;

--- a/pljava-packaging/src/main/resources/pljava--unpackaged.sql
+++ b/pljava-packaging/src/main/resources/pljava--unpackaged.sql
@@ -66,3 +66,9 @@ ALTER EXTENSION pljava ADD TABLE sqlj.typemap_entry;
 ALTER EXTENSION pljava ADD SEQUENCE sqlj.jar_entry_entryid_seq;
 ALTER EXTENSION pljava ADD SEQUENCE sqlj.jar_repository_jarid_seq;
 ALTER EXTENSION pljava ADD SEQUENCE sqlj.typemap_entry_mapid_seq;
+
+SELECT pg_catalog.pg_extension_config_dump('@extschema@.jar_repository', '');
+SELECT pg_catalog.pg_extension_config_dump('@extschema@.jar_entry', '');
+SELECT pg_catalog.pg_extension_config_dump('@extschema@.jar_descriptor', '');
+SELECT pg_catalog.pg_extension_config_dump('@extschema@.classpath_entry', '');
+SELECT pg_catalog.pg_extension_config_dump('@extschema@.typemap_entry', '');

--- a/pljava-packaging/src/main/resources/pljava--unpackaged.sql
+++ b/pljava-packaging/src/main/resources/pljava--unpackaged.sql
@@ -8,7 +8,8 @@
  */
 
 DROP TABLE IF EXISTS @extschema@.loadpath;
-CREATE TABLE @extschema@.loadpath(s) AS SELECT CAST('MODULE_PATHNAME' AS text);
+CREATE TABLE @extschema@.loadpath(path, exnihilo) AS
+SELECT CAST('MODULE_PATHNAME' AS text), false;
 LOAD 'MODULE_PATHNAME';
 DROP TABLE @extschema@.loadpath;
 

--- a/pljava-packaging/src/main/resources/pljava.control
+++ b/pljava-packaging/src/main/resources/pljava.control
@@ -1,0 +1,6 @@
+comment = 'PL/Java procedural language (https://tada.github.io/pljava/)'
+default_version = '${project.version}'
+encoding = UTF8
+directory = 'pljava'
+module_pathname = '${module.pathname}'
+schema = sqlj

--- a/pljava-packaging/src/main/resources/pljava.sql
+++ b/pljava-packaging/src/main/resources/pljava.sql
@@ -1,0 +1,58 @@
+\echo Use "CREATE EXTENSION pljava" to load this file. \quit
+
+/*
+ Note: most of the work of setting up PL/Java is done within PL/Java itself,
+ touched off by the LOAD command, making possible a decent installation
+ experience even on pre-9.1, pre-extension PostgreSQL versions. This script
+ simply wraps that.
+ 
+ However, in this case, the native library has no easy way to find the
+ pathname it has just been loaded from (it looks for the path given to its
+ LOAD command, but finds the CREATE EXTENSION command instead). So, temporarily
+ save the path in a table.
+
+ The table's existence also helps PL/Java distinguish the case where it is
+ being loaded as an extension itself (via this script), and the case where
+ it is simply being awakened during the creation of some other extension
+ (CREATE EXTENSION foo where foo is something implemented using PL/Java).
+ */
+
+DROP TABLE IF EXISTS @extschema@.loadpath;
+CREATE TABLE @extschema@.loadpath(s) AS SELECT CAST('MODULE_PATHNAME' AS text);
+LOAD 'MODULE_PATHNAME';
+DROP TABLE @extschema@.loadpath;
+
+/*
+ Ok, the LOAD succeeded, so everything happened ... unless ... the same
+ PL/Java library had already been loaded earlier in this same session.
+ That would be an unusual case, but confusing if it happened, because
+ PostgreSQL turns LOAD into a (successful) no-op in that case, meaning
+ CREATE EXTENSION might appear to succeed without really completing.
+ To fail fast in that case, execute some command that needs PL/Java to work.
+ It may still give a bewildering error message on failure ("function
+ sqlj.get_classpath(unknown) does not exist" hardly sheds any light on the
+ real problem, but at least it detects that there is a problem). The result
+ goes nowhere; CREATE EXTENSION sends any SELECT output from scripts to the
+ bit bucket.
+
+ The solution to a problem detected here is simply to close the session,
+ and be sure to execute 'CREATE EXTENSION pljava' in a new session (new
+ at least in the sense that Java hasn't been used in it yet).
+ */
+
+SELECT sqlj.get_classpath('public');
+
+/*
+ All of these tables in sqlj are created empty by PL/Java itself, and
+ the contents are things later loaded by the user, so configure them to
+ be dumped. XXX Future work: loaded jars could be extensions themselves,
+ so these tables should be extended to record when that's the case, and the
+ config_dump calls should have WHERE clauses to avoid dumping rows that
+ would be supplied naturally by recreating those extensions.
+ */
+
+SELECT pg_catalog.pg_extension_config_dump('@extschema@.jar_repository', '');
+SELECT pg_catalog.pg_extension_config_dump('@extschema@.jar_entry', '');
+SELECT pg_catalog.pg_extension_config_dump('@extschema@.jar_descriptor', '');
+SELECT pg_catalog.pg_extension_config_dump('@extschema@.classpath_entry', '');
+SELECT pg_catalog.pg_extension_config_dump('@extschema@.typemap_entry', '');

--- a/pljava-packaging/src/main/resources/pljava.sql
+++ b/pljava-packaging/src/main/resources/pljava.sql
@@ -18,7 +18,8 @@
  */
 
 DROP TABLE IF EXISTS @extschema@.loadpath;
-CREATE TABLE @extschema@.loadpath(s) AS SELECT CAST('MODULE_PATHNAME' AS text);
+CREATE TABLE @extschema@.loadpath(path, exnihilo) AS
+SELECT CAST('MODULE_PATHNAME' AS text), true;
 LOAD 'MODULE_PATHNAME';
 DROP TABLE @extschema@.loadpath;
 

--- a/pljava-so/src/main/c/Backend.c
+++ b/pljava-so/src/main/c/Backend.c
@@ -260,6 +260,8 @@ static void initsequencer(enum initstage is, bool tolerant);
 	CppConcat(assign_,name)(type newval, bool doit, GucSource source)
 #define ASSIGNRETURN(thing) return (thing)
 #define ASSIGNRETURNIFCHECK(thing) if (doit) ; else return (thing)
+#define ASSIGNRETURNIFNXACT(thing) \
+	if (pljavaViableXact()) ; else return (thing)
 #define ASSIGNSTRINGHOOK(name) \
 	static const char * \
 	CppConcat(assign_,name)(const char *newval, bool doit, GucSource source); \
@@ -273,6 +275,7 @@ static void initsequencer(enum initstage is, bool tolerant);
 	CppConcat(assign_,name)(type newval, void *extra)
 #define ASSIGNRETURN(thing)
 #define ASSIGNRETURNIFCHECK(thing)
+#define ASSIGNRETURNIFNXACT(thing) if (pljavaViableXact()) ; else return
 #define ASSIGNSTRINGHOOK(name) ASSIGNHOOK(name, const char *)
 #endif
 
@@ -283,6 +286,7 @@ ASSIGNSTRINGHOOK(libjvm_location)
 	if ( IS_FORMLESS_VOID < initstage && initstage < IS_CAND_JVMOPENED )
 	{
 		alteredSettingsWereNeeded = true;
+		ASSIGNRETURNIFNXACT(newval);
 		initsequencer( initstage, true);
 	}
 	ASSIGNRETURN(newval);
@@ -295,6 +299,7 @@ ASSIGNSTRINGHOOK(vmoptions)
 	if ( IS_FORMLESS_VOID < initstage && initstage < IS_JAVAVM_OPTLIST )
 	{
 		alteredSettingsWereNeeded = true;
+		ASSIGNRETURNIFNXACT(newval);
 		initsequencer( initstage, true);
 	}
 	ASSIGNRETURN(newval);
@@ -307,6 +312,7 @@ ASSIGNSTRINGHOOK(classpath)
 	if ( IS_FORMLESS_VOID < initstage && initstage < IS_JAVAVM_OPTLIST )
 	{
 		alteredSettingsWereNeeded = true;
+		ASSIGNRETURNIFNXACT(newval);
 		initsequencer( initstage, true);
 	}
 	ASSIGNRETURN(newval);
@@ -319,6 +325,7 @@ ASSIGNHOOK(enabled, bool)
 	if ( IS_FORMLESS_VOID < initstage && initstage < IS_PLJAVA_ENABLED )
 	{
 		alteredSettingsWereNeeded = true;
+		ASSIGNRETURNIFNXACT(true);
 		initsequencer( initstage, true);
 	}
 	ASSIGNRETURN(true);

--- a/pljava-so/src/main/c/Backend.c
+++ b/pljava-so/src/main/c/Backend.c
@@ -550,6 +550,7 @@ static void initsequencer(enum initstage is, bool tolerant)
 		initstage = IS_COMPLETE;
 
 	case IS_COMPLETE:
+		pljavaLoadingAsExtension = false;
 		if ( alteredSettingsWereNeeded )
 		{
 			/* Use this StringInfoData to conditionally construct part of the
@@ -717,7 +718,7 @@ void _PG_init()
 {
 	if ( IS_PLJAVA_FOUND == initstage )
 		return; /* creating handler functions will cause recursive call */
-	pljavaCheckExtension();
+	pljavaCheckExtension( NULL);
 	initsequencer( initstage, true);
 }
 
@@ -755,6 +756,11 @@ static void initPLJavaClasses(void)
 		"_clearFunctionCache",
 		"()V",
 		Java_org_postgresql_pljava_internal_Backend__1clearFunctionCache
+		},
+		{
+		"_isCreatingExtension",
+		"()Z",
+		Java_org_postgresql_pljava_internal_Backend__1isCreatingExtension
 		},
 		{ 0, 0, 0 }
 	};
@@ -1580,4 +1586,17 @@ Java_org_postgresql_pljava_internal_Backend__1clearFunctionCache(JNIEnv* env, jc
 	BEGIN_NATIVE_NO_ERRCHECK
 	Function_clearFunctionCache();
 	END_NATIVE
+}
+
+/*
+ * Class:     org_postgresql_pljava_internal_Backend
+ * Method:    _isCreatingExtension
+ * Signature: ()Z
+ */
+JNIEXPORT jboolean JNICALL
+Java_org_postgresql_pljava_internal_Backend__1isCreatingExtension(JNIEnv *env, jclass cls)
+{
+	bool inExtension = false;
+	pljavaCheckExtension( &inExtension);
+	return inExtension ? JNI_TRUE : JNI_FALSE;
 }

--- a/pljava-so/src/main/c/InstallHelper.c
+++ b/pljava-so/src/main/c/InstallHelper.c
@@ -15,6 +15,7 @@
 #else
 #include <access/htup.h>
 #endif
+#include <access/xact.h>
 #include <catalog/pg_language.h>
 #include <catalog/pg_proc.h>
 #if PG_VERSION_NUM >= 90100
@@ -83,6 +84,11 @@ bool pljavaLoadingAsExtension = false;
 Oid pljavaTrustedOid = InvalidOid;
 
 Oid pljavaUntrustedOid = InvalidOid;
+
+bool pljavaViableXact()
+{
+	return IsTransactionState() && 'E' != TransactionBlockStatusCode();
+}
 
 char *pljavaDbName()
 {

--- a/pljava-so/src/main/include/pljava/InstallHelper.h
+++ b/pljava-so/src/main/include/pljava/InstallHelper.h
@@ -19,15 +19,27 @@
  */
 
 /*
- * If a LoadStatement is what the current ActivePortal is executing, then save
- * a copy of the pathname being loaded (pstrdup'd in TopMemoryContext) in
- * pljavaLoadPath, otherwise leave that variable unchanged/NULL. Nothing like
- * this would be necessary if PostgreSQL called _PG_init functions with the
- * path of the library being loaded.
+ * The path from which this library is being loaded, which is surprisingly
+ * tricky to find (and wouldn't be, if PostgreSQL called _PG_init functions
+ * with the path of the library being loaded!). Set by pljavaCheckExtension().
  */
-extern void pljavaCheckLoadPath();
-
 extern char const *pljavaLoadPath;
+
+/*
+ * If an extension is being created, try to determine pljavaLoadPath from a
+ * temporary table in the sqlj schema; if it's there, created by PL/Java's
+ * extension script, then the extension being created is PL/Java itself, so
+ * set pljavaLoadingAsExtension and pljavaLoadPath accordingly. Otherwise
+ * PL/Java is just being mentioned while creating some other extension, so set
+ * pljavaInExtension. If an extension is not being created, just check for a
+ * LOAD command and set pljavaLoadPath accordingly.
+ *
+ * Only called from _PG_init, which only calls once.
+ */
+extern void pljavaCheckExtension();
+
+extern bool pljavaLoadingAsExtension;
+extern bool pljavaInExtension;
 
 /*
  * Another way of getting the library path: if invoked by the fmgr before

--- a/pljava-so/src/main/include/pljava/InstallHelper.h
+++ b/pljava-so/src/main/include/pljava/InstallHelper.h
@@ -30,16 +30,23 @@ extern char const *pljavaLoadPath;
  * temporary table in the sqlj schema; if it's there, created by PL/Java's
  * extension script, then the extension being created is PL/Java itself, so
  * set pljavaLoadingAsExtension and pljavaLoadPath accordingly. Otherwise
- * PL/Java is just being mentioned while creating some other extension, so set
- * pljavaInExtension. If an extension is not being created, just check for a
- * LOAD command and set pljavaLoadPath accordingly.
+ * PL/Java is just being mentioned while creating some other extension.
+ * If an extension is not being created, just check for a LOAD command and
+ * set pljavaLoadPath accordingly.
  *
- * Only called from _PG_init, which only calls once.
+ * When called from _PG_init, which only calls once, the argument is null,
+ * indicating that the static result variables should be set. If the address of
+ * a boolean is provided, the static variables are not set, and the supplied
+ * boolean is set true if an extension is being created. (It is not touched if
+ * an extension is not being created.) That serves the case
+ * where PL/Java is already loaded, sqlj.install_jar has been called, and needs
+ * to know if the jar is being installed as part of an(other) extension. Such
+ * PL/Java-managed extensions aren't supported yet, but the case has to be
+ * recognized, even if only to say "you can't do that yet."
  */
-extern void pljavaCheckExtension();
+extern void pljavaCheckExtension(bool*);
 
 extern bool pljavaLoadingAsExtension;
-extern bool pljavaInExtension;
 
 /*
  * Another way of getting the library path: if invoked by the fmgr before

--- a/pljava/src/main/java/org/postgresql/pljava/internal/Backend.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/Backend.java
@@ -242,6 +242,14 @@ public class Backend
 		}
 	}
 
+	public static boolean isCreatingExtension()
+	{
+		synchronized(THREADLOCK)
+		{
+			return _isCreatingExtension();
+		}
+	}
+
 	/**
 	 * Called when the JVM is first booted and then everytime a switch
 	 * is made between calling a trusted function versus an untrusted
@@ -282,4 +290,5 @@ public class Backend
 	private native static int  _getStatementCacheSize();
 	private native static void _log(int logLevel, String str);
 	private native static void _clearFunctionCache();
+	private native static boolean _isCreatingExtension();
 }

--- a/pljava/src/main/java/org/postgresql/pljava/internal/InstallHelper.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/InstallHelper.java
@@ -61,7 +61,7 @@ public class InstallHelper
 		setPropertyIfNull( "org.postgresql.datadir", datadir);
 		setPropertyIfNull( "org.postgresql.libdir", libdir);
 		setPropertyIfNull( "org.postgresql.sharedir", sharedir);
-		setPropertyIfNull( "org.postgresql.etcdir", etcdir);
+		setPropertyIfNull( "org.postgresql.sysconfdir", etcdir);
 		setPropertyIfNull( "org.postgresql.pljava.version", implVersion);
 		setPropertyIfNull( "org.postgresql.pljava.native.version", nativeVer);
 		setPropertyIfNull( "org.postgresql.version",

--- a/pljava/src/main/java/org/postgresql/pljava/management/Commands.java
+++ b/pljava/src/main/java/org/postgresql/pljava/management/Commands.java
@@ -25,6 +25,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLData;
 import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
 import java.sql.SQLNonTransientException;
 import java.sql.SQLSyntaxErrorException;
 import java.sql.Statement;
@@ -1112,6 +1113,11 @@ public class Commands
 	private static void installJar(String urlString, String jarName,
 		boolean deploy, byte[] image) throws SQLException
 	{
+		if ( Backend.isCreatingExtension() )
+			throw new SQLFeatureNotSupportedException(
+				"A jar cannot (yet) be installed as an extension in its " +
+				"own right.", "0A000");
+
 		assertJarName(jarName);
 
 		if(getJarId(jarName, null) >= 0)

--- a/src/site/markdown/install/install.md.vm
+++ b/src/site/markdown/install/install.md.vm
@@ -8,35 +8,163 @@
 #set($h2 = '##')
 #set($h3 = '###')
 
-The PL/Java [build process][bld] using `mvn clean install` produces files
-needed to install the language in PostgreSQL, but does not place those
-files in their final locations or configure PostgreSQL to use them.
-Once the build is done, these instructions cover how to make PL/Java available
-in your database. 
+$h2 For the impatient
+
+After completing the [build][bld]:
+
+    java -jar pljava-packaging/target/pljava-pgX.Y-arch-os-link.jar
+    psql
+    CREATE EXTENSION pljava;
+
+where *pgX.Y* represents the PostgreSQL version, and *arch*, *os*, and
+*link* are ... wait, you're impatient, just look in the directory, you'll
+see the jar file there.
+
+*Not running PostgreSQL 9.1 or higher? Use
+`LOAD 'libpljava-so-${project.version}';` instead of the `CREATE EXTENSION`
+command. (It works in later versions too, if you prefer it to
+`CREATE EXTENSION`.) Using a Mac? Be sure to add `.bundle` at the end of the file name
+in the `LOAD` command. Windows? Remove `lib` from the front. Something else?
+Keep reading.*
+
+You may get a message that some configuration variable must be set.
+If so, keep reading.
+
+$h3 What the above will do
+
+The jar file produced in `pljava-packaging/target` at the end of the build
+contains all the files needed to install PL/Java, and it is self-extracting
+when simply run with `java -jar`. It does not contain any complicated,
+black-box installer, and if you prefer, it is just as easy to extract
+normally with the `jar` command or any `zip` tool, in which case you will
+see that it contains files at symbolic paths such as
+
+    pljava/pkglibdir/...
+    pljava/sharedir/...
+
+which you can move to wherever you like. Those names are based on
+the options you would pass to `pg_config` to find
+the right locations for your PostgreSQL setup, and that is exactly
+what the self-extractor does. Assuming it is run with the permissions needed
+to write there, it will put the PL/Java files into the expected locations,
+so that `CREATE EXTENSION` will find it without much configuration needed.
+
+Because that is done by the extractor, you can take the built jar file to
+other PostgreSQL installations, even with other filesystem layouts, and
+it will put the files in the right places there too.
+
+It has to be able to find `pg_config`, and if you have more than one
+installation of PostgreSQL on the machine, it has to find the *right*
+`pg_config`. You can either arrange the path in your environment so
+the right `pg_config` comes first, or specify it with `-Dpgconfig=` on
+the command line:
+
+    java -Dpgconfig=/local/pgsql/bin/pg_config -jar pljava-packaging/...
+
+All of the standard install locations can also be changed with `-D`
+options:
+
+    java -Dpgconfig.sharedir=/local/foo -jar pljava-packaging/...
+
+would cause all the files that would normally go in the configured
+share directory to be placed in `/local/foo` instead. You can therefore
+install PL/Java in many situations where you might not have write access
+to the standard locations, or might have other reasons to prefer
+giving the files another location.
+
+If you change locations, you will probably have to adjust some of PL/Java's
+configuration variables to match, before installation will succeed. For that,
+you will have to become patient, and read the rest of this page.
+
+**You will most probably have to set `pljava.libjvm_location`.** See the
+next section.
+
+*One last small thing the extractor does, that won't automatically happen if
+you extract with other tools, is make sure the text files have the right
+line-ending style for your system. Everything will still work, and there
+are easy fixes if you open them in an editor and they look funny. As long
+as you just extract with `java -jar` the self-extractor takes care of it
+for you.*
+
+$h2 PL/Java configuration variables
+
+PL/Java has configuration variables for most important file locations.
+One that you will *almost always have to set* is `pljava.libjvm_location`
+because the PL/Java installer doesn't control where different platforms
+and packagers put the Java files. *(If it did, things would be a lot
+more organized, have no doubt.)*
+
+You can set these variables within a database session, before issuing
+the `LOAD` or `CREATE EXTENSION` command. (In case you don't always get
+things right on the first try, you might set them after, too.) For example:
+
+    SET pljava.libjvm_location TO '/usr/lib/jvm/java-1.8.0/lib/...';
+
+`pljava.libjvm_location`
+: You are looking for a file named `libjvm` with extension `.so`, `.dll`,
+    or `.dylib` typically, buried a few directories/folders down in the
+    location where Java is installed. If more than one Java version is
+    installed, be sure to find the library from the version you want
+    PL/Java to use. See [locating libjvm][jvmloc] for help finding it.
+    Then set this variable to the full pathname, including the filename
+    and extension.
+
+`pljava.classpath`
+: There is probably no need to set this variable unless installation locations
+    were changed, in which case, it should be set to the final installed full
+    pathname of the file that is called
+    `pljava/sharedir/pljava/pljava-${project.version}.jar` in the installer jar.
+    Note: this variable isn't meant to point to the code you develop and
+    use in PL/Java--that's what the [`sqlj.install_jar function`][sqjij]
+    is for.
+
+[sqjij]: https://github.com/tada/pljava/wiki/SQL-functions
+
+Those two are not the only PL/Java configuration variables there are,
+but it is unlikely you would have to change any others before installation
+succeeds. For the rest, there is a [configuration variable reference][varref]
+page.
 
 [bld]: ../build/build.html
 
-The successful build will have produced two important files:
-
-* The PL/Java `jar` file, which contains Java classes, so it is
-    architecture-independent.
-
-* The PL/Java native library, which is architecture-specific. Its filename
-    extension can depend on the operating system: `.so` on many systems,
-    `.dll` on Windows, `.bundle` on Mac OS X / Darwin.
-
-For a final installation, you will want to copy these files from the build tree
-to more permanent locations, though a quick test that PL/Java works can be made
-with the files right where they are. See [locating the built files][locate] for
-how to find their exact names in your build tree.
-
-A third path name you will need to know is the one to your Java Runtime
-Environment's `libjvm` shared object (`.so`, `.dll`, etc.), usually a few
-levels deep under the directory where Java is installed on your platform.
-See [locating libjvm][jvmloc] for help finding it.
+One thing you can do with the configuration settings is quickly test that
+you have built a working PL/Java before installing the files in any permanent
+location. As long as the database server has access to the files in the
+build tree, you can start a session and set the variables to point to them,
+for a quick simple test. See [locating the built files][locate] for
+how to find their exact names in your build tree. After testing, you would
+probably put the files in more permanent locations and discard the temporary
+variable settings.
 
 [locate]: locate.html
 [jvmloc]: locatejvm.html
+
+$h2 Making the configuration settings persistent
+
+If you have loaded PL/Java successfully after making necessary changes to
+some `pljava.*` variables, and the files are in the final locations where
+you want them, you will want your variable settings to stick. The simplest
+way is to reissue the same `SET` commands as
+`ALTER DATABASE ` *databasename* ` SET ` *variablename* ` FROM CURRENT`
+commands, which will preserve the current settings and make them effective
+when any user connects to the same database.
+
+Another approach is to save them to the server's configuration file.
+If you wish PL/Java to be available for all databases in a cluster, it may
+be more convenient to put the settings in the file than to issue
+`ALTER DATABASE` for several databases, but `pg_ctl reload` will be needed
+to make changed settings effective. Starting with PostgreSQL 9.4,
+`ALTER SYSTEM` may be used as an alternative to editing the file.
+
+If you have several databases in the cluster and you favor the
+`CREATE EXTENSION` way of installing PL/Java, setting the variables
+with `ALTER SYSTEM` or the cluster-wide configuration file will make
+sure that `CREATE EXTENSION` just works, in any database where PL/Java
+is wanted. Different per-database settings can still be made if one
+database needs them.
+
+For PostgreSQL releases [earlier than 9.2][pre92], the configuration file is
+the _only_ way to make your settings persistent.
 
 $h2 Special topics
 
@@ -50,13 +178,19 @@ Be sure to read these additional sections if:
 [selinux]: selinux.html
 [osx]: ../build/macosx.html
 
-$h2 Install, configure, check
+$h2 More background and special considerations
+
+These last sections cover a little more of what happens under the hood.
+`CREATE EXTENSION` wraps these details up nicely, but they may still be
+of interest for particular needs.
+
+$h3 Install, configure, check
 
 Because PL/Java, by design, runs entirely in the backend process created
 for each connection to PostgreSQL, to configure it does not require any
 cluster-wide actions such as stopping or restarting the server, or editing
 the configuration file; any necessary settings can be made in SQL over
-an ordinary connection.
+an ordinary connection (in PostgreSQL 9.2 and later, anyway).
 
 _Caution: if you are installing a new, little-tested PL/Java build, be aware
 that in the unexpected case of a crash, the `postmaster` will kick other
@@ -159,21 +293,3 @@ $h3 PostgreSQL superuser, OS user distinct from the user running postgres
 In this case, simply place the files in any location where you can make them
 readable by the user running `postgres`, and set the `pljava.*` variables
 accordingly.
-
-$h2 Making the configuration settings persistent
-
-If you have loaded PL/Java successfully after making necessary changes to
-some `pljava.*` variables, you will want those settings to stick. The simplest
-way is to reissue the same `SET` commands as
-`ALTER DATABASE ` *databasename* ` SET ...` commands, which will be effective
-when any user connects to the same database.
-
-Another approach is to save them to the server's configuration file.
-If you wish PL/Java to be available for all databases in a cluster, it may
-be more convenient to put the settings in the file than to issue
-`ALTER DATABASE` for several databases, but `pg_ctl reload` will be needed
-to make changed settings effective. Starting with PostgreSQL 9.4,
-`ALTER SYSTEM` may be used as an alternative to editing the file.
-
-For PostgreSQL releases [earlier than 9.2][pre92], the configuration file is
-the _only_ way to make your settings persistent.

--- a/src/site/markdown/install/install.md.vm
+++ b/src/site/markdown/install/install.md.vm
@@ -1,5 +1,13 @@
 # Installing PL/Java
 
+## This is a comment, according to Apache Velocity, which is why you'll see
+## extraordinary measures taken below to make ## or lower level headings....
+## Also, if you do not know all the ins and outs of the Velocity template
+## language and would like to spend less time than I did to find the docs:
+## http://velocity.apache.org/engine/devel/user-guide.html
+#set($h2 = '##')
+#set($h3 = '###')
+
 The PL/Java [build process][bld] using `mvn clean install` produces files
 needed to install the language in PostgreSQL, but does not place those
 files in their final locations or configure PostgreSQL to use them.
@@ -30,7 +38,7 @@ See [locating libjvm][jvmloc] for help finding it.
 [locate]: locate.html
 [jvmloc]: locatejvm.html
 
-## Special topics
+$h2 Special topics
 
 Be sure to read these additional sections if:
 
@@ -42,7 +50,7 @@ Be sure to read these additional sections if:
 [selinux]: selinux.html
 [osx]: ../build/macosx.html
 
-## Install, configure, check
+$h2 Install, configure, check
 
 Because PL/Java, by design, runs entirely in the backend process created
 for each connection to PostgreSQL, to configure it does not require any
@@ -82,7 +90,7 @@ if you need it.
 
 [varref]: ../use/variables.html
 
-### Choosing where to place the files
+$h3 Choosing where to place the files
 
 Exactly where you place the files, and what pathnames you use in the
 above commands, can depend on your situation:
@@ -99,7 +107,7 @@ above commands, can depend on your situation:
 
 The rest of this page will cover those cases. First, the quick check.
 
-### A quick install check
+$h3 A quick install check
 
 For a quick sanity test, there is no need to move the built files to more
 permanent locations, as long as the build tree location and permissions are
@@ -109,7 +117,7 @@ pathnames directly in the `SET` and `LOAD` commands.
 For the lowest-impact quick test, begin a transaction first, load PL/Java
 and run [any tests you like][examples], then roll the transaction back.
 
-### OS superuser or distribution maintainer
+$h3 OS superuser or distribution maintainer
 
 If you fall in this category, you can minimize configuration within
 PostgreSQL by placing the built files into standard locations,
@@ -120,7 +128,7 @@ given just the basename of the file instead of a full path. Or, if
 `dynamic_library_path` is already set, the file can be placed in any
 directory on that list for the same effect.
 
-If the `pljava-${project.version}.jar` file is placed in the default location
+If the `pljava-\${project.version}.jar` file is placed in the default location
 (typically a `pljava` subdirectory of the PostgreSQL "share" directory), then
 `pljava.classpath` will not need to be set.
 
@@ -133,7 +141,7 @@ PL/Java variables, and with the built files in those locations.
 
 _Todo: add maven build options usable by distro spinners to set those defaults._
 
-### PostgreSQL superuser with access as user running postgres
+$h3 PostgreSQL superuser with access as user running postgres
 
 If you are not a superuser on the OS, you may not be able to place the
 PL/Java files in the default locations PostgreSQL was built with.
@@ -146,13 +154,13 @@ include its location, and give only the basename to `LOAD`.
 If you would rather ensure that the user running `postgres`, if compromised,
 could not modify these files, then the next case will be more appropriate.
 
-### PostgreSQL superuser, OS user distinct from the user running postgres
+$h3 PostgreSQL superuser, OS user distinct from the user running postgres
 
 In this case, simply place the files in any location where you can make them
 readable by the user running `postgres`, and set the `pljava.*` variables
 accordingly.
 
-## Making the configuration settings persistent
+$h2 Making the configuration settings persistent
 
 If you have loaded PL/Java successfully after making necessary changes to
 some `pljava.*` variables, you will want those settings to stick. The simplest

--- a/src/site/markdown/install/locate.md.vm
+++ b/src/site/markdown/install/locate.md.vm
@@ -20,41 +20,47 @@ may help in finding them.
 [bld]: ../build/build.html
 [inst]: install.html
 
-$h2 The packaged tar or zip file
+$h2 The packaged jar file
 
-The `pljava-packaging` subproject builds a single `.tar.gz` or `.zip` file
-(depending on the platform where the build is done). Relative to the
-root of the build tree, it is found at
+The `pljava-packaging` subproject builds a single `.jar` file.
+At one time, it was in the business of trying to decide whether Windows,
+Unix, or Mac users would like `.zip` or `.tar.gz` files better, but if you
+are planning to use PL/Java then you certainly have Java around, and can
+work with a `.jar` file no matter what.
 
-`pljava-packaging/target/pljava-${pgversion}-${naraol}.tar.gz` (or `.zip`)
+Relative to the root of the build tree, the jar file is found at
+
+`pljava-packaging/target/pljava-${pgversion}-${naraol}.jar`
 
 where `${pgversion}` resembles `pg9.4` and `${naraol}` is an
 *architecture-os-linker* triple, for example `amd64-Linux-gpp`
 or `amd64-Windows-msvc`. It contains these things:
 
-`pljava/pljava.jar`
+`pljava/pkglibdir/libpljava-\${project.version}.so` (or `.dll`, etc.)
+: The architecture-dependent, native library portion of the PL/Java
+    implementation (more below). The name might end in `.so` or `.dll`
+    or `.bundle` or something else, and might or might not start with `lib`.
+
+`pljava/sharedir/pljava/pljava-\${project.version}.jar`
 : The architecture-independent, Java portion of the PL/Java implementation
     (more below).
 
-`pljava/pljava.so` (or `.dll`, etc.)
-: The architecture-dependent, native library portion of the PL/Java
-    implementation (more below).
-
-`pljava/examples.jar`
+`pljava/sharedir/pljava/pljava-examples-\${project.version}.jar`
 : A set of [examples demonstrating PL/Java usage][examples], usable also
     as rudimentary tests.
 
-`pljava/docs.tar`
-: A collection of historical-interest and design documents from the origins
-    of PL/Java.
+`pljava/sharedir/extension/pljava.control`
+: The file that tells `CREATE EXTENSION` what's what.
 
-`pljava/install.sql`, `pljava/uninstall.sql`
-: _Deprecated_ In normal circumstances, these are no longer needed to install
-    or uninstall PL/Java.
+`pljava/sharedir/pljava/pljava--*.sql`
+: Various files scripting what `CREATE EXTENSION` or
+    `ALTER EXTENSION ... UPDATE` really do.
 
-`pljava/deploy.jar`
-: _Deprecated_ In normal circumstances, this tool is no longer needed to install
-    or uninstall PL/Java.
+It could happen that future versions add more files in the jar before
+updating this page. Also, every jar file has a `MANIFEST.MF`, and this
+file also contains a `JarX.class` to make it self-extracting; these are
+not otherwise important to PL/Java. See the [installation page][inst]
+for how to control the self-extraction.
 
 [examples]: ../examples/examples.html
 
@@ -63,7 +69,7 @@ locations, then complete the [installation][inst].
 
 $h2 Naming the built files directly
 
-When the only purpose is to quickly check the built PL/Java, it is faster
+When the only purpose is to quickly check the built PL/Java, it may be faster
 not to extract files from the packaged archive into some other location,
 but simply to `SET` the `pljava.*` variables to point to the files right
 where they were generated in the build tree.


### PR DESCRIPTION
The 'installhelp' branch gave PL/Java a more automated installation across all versions of PostgreSQL it supports, but did not provide integration into the CREATE EXTENSION machinery of PostgreSQL 9.1+. This branch does.

As most of the needed installation actions now happen when touched off by a single LOAD, supporting CREATE EXTENSION is largely a matter of supplying extension scripts that wrap a LOAD command. However, some internal behavior changes are needed that require PL/Java to notice when it is being loaded as an extension. It must also notice the different case where install_jar is being called from a CREATE EXTENSION script; that is not yet supported (the only response will be an SQLFeatureNotSupportedException), but looking ahead, it will be natural for the developer of some PL/Java-based functionality to want to package that jar as an extension, so it should be on the future-work list for PL/Java to handle that situation.

To make CREATE EXTENSION work absolutely requires getting a `pljava.control` file installed into the proper configured place, which all comes back to issue #6 and providing an easy way to get the built files installed in the expected places.

To do that, this branch simplifies the pljava-packaging subproject to produce only one form of final artifact (instead of a `.tar.gz` or `.zip` depending on the platform). Everybody intending to use PL/Java is going to have Java, so can certainly handle a jar/zip file, and a jar file can be made self-extracting simply by putting a small class in it and appointing it the Main-Class in the manifest.

I've revived a small class I wrote to do exactly that 16 years ago, and since Java had javax.script added in the last 16 years, it can now call a script to rewrite path names while extracting. The jar is built with ~30 lines of JavaScript to call `pg_config` at the time of extraction and put the files in the appropriate places (any of the places can also be overridden on the command line). It is not necessary to rely on the self-extraction, the jar can also be unpacked with any `jar` or `zip` tool, and the files are laid out in sensible "virtual" directory paths like `pljava/pkglibdir`, `pljava/sharedir`, etc.

So I believe this also closes #6.