### PR TITLE
Track PG9.5 change re compiler attributes.

### DIFF
--- a/pljava-so/src/main/include/pljava/Exception.h
+++ b/pljava-so/src/main/include/pljava/Exception.h
@@ -11,6 +11,14 @@
 
 #include "pljava/PgObject.h"
 
+#if PG_VERSION_NUM < 90500
+#ifdef __GNUC__
+#define pg_attribute_printf(f,a) __attribute__((format(printf, f, a)))
+#else
+#define pg_attribute_printf(f,a)
+#endif
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -38,7 +46,7 @@ extern void	Exception_featureNotSupported(const char* requestedFeature, const ch
 extern void Exception_throw(int errCode, const char* errMessage, ...)
 /* This extension allows gcc to check the format string for consistency with
    the supplied arguments. */
-__attribute__((format(printf, 2, 3)));
+pg_attribute_printf(2, 3);
 
 /*
  * Like ereport(ERROR, ...) but this method will raise a Java IllegalArgumentException and
@@ -49,7 +57,7 @@ __attribute__((format(printf, 2, 3)));
 extern void Exception_throwIllegalArgument(const char* errMessage, ...)
 /* This extension allows gcc to check the format string for consistency with
    the supplied arguments. */
-__attribute__((format(printf, 1, 2)));
+pg_attribute_printf(1, 2);
 
 /*
  * Like ereport(ERROR, ...) but this method will raise a Java SQLException and


### PR DESCRIPTION
In PG commit bbfd7eda, uses of compiler `__attribute__` marks were
replaced by new dedicated-purpose macros like `pg_attribute_printf`,
appearing in 9.5+. Adapt to the new style, in the one file where
the old style was used.

Caught by Ken Olson, on Windows MSVC, where it broke.