### PR TITLE
Api/master/annokwds

### DIFF
--- a/pljava-api/src/main/java/org/postgresql/pljava/annotation/Function.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/annotation/Function.java
@@ -53,22 +53,25 @@ public @interface Function
 	 * The <a href=
 'http://www.postgresql.org/docs/current/static/xfunc-volatility.html'>volatility
 category</a>
-	 * of the function.
+	 * describing the presence or absence of side-effects constraining what
+	 * the optimizer can safely do with the function.
 	 */
-	enum Type { IMMUTABLE, STABLE, VOLATILE };
+	enum Effects { IMMUTABLE, STABLE, VOLATILE };
 
 	/**
-	 * Whether the function only needs restricted capabilities and can
-	 * run in the "trusted" language instance, or requires an unrestricted
-	 * environment and has to run in an "untrusted" language instance.
+	 * Whether the function only needs limited capabilities and can
+	 * run in the "trusted" language sandbox, or has to be unsandboxed
+	 * and run in an "untrusted" language instance.
 	 */
-	enum Trust { RESTRICTED, UNRESTRICTED };
+	enum Trust { SANDBOXED, UNSANDBOXED };
 
 	/**
 	 * The element type in case the annotated function returns a
-	 * {@link org.postgresql.pljava.ResultSetProvider ResultSetProvider}.
+	 * {@link org.postgresql.pljava.ResultSetProvider ResultSetProvider},
+	 * or can be used to specify the return type of any function if the
+	 * compiler hasn't inferred it correctly.
 	 */
-	String complexType() default "";
+	String type() default "";
 
 	/**
 	 * The name of the function. This is optional. The default is
@@ -117,9 +120,7 @@ category</a>
 	Security security() default Security.INVOKER;
 	
 	/**
-	 * What the query optimizer is allowed to assume about this function
-	 * (this element has nothing to do with the data type returned by the
-	 * function; see complexType for that).
+	 * What the query optimizer is allowed to assume about this function.
 	 *
 	 * IMMUTABLE describes a pure function whose return will always be the same
 	 * for the same parameter values, with no side effects and no dependency on
@@ -129,14 +130,14 @@ category</a>
 	 * a function with side effects or about whose result the optimizer cannot
 	 * make any safe assumptions.
 	 */
-	Type type() default Type.VOLATILE;
+	Effects effects() default Effects.VOLATILE;
 	
 	/**
-	 * Whether the function will run in the RESTRICTED ("trusted") version
-	 * of the language, or requires UNRESTRICTED access and must be defined
+	 * Whether the function will run in the SANDBOXED ("trusted") version
+	 * of the language, or requires UNSANDBOXED access and must be defined
 	 * in the "untrusted" language instance.
 	 */
-	Trust trust() default Trust.RESTRICTED;
+	Trust trust() default Trust.SANDBOXED;
 	
 	/**
 	 * Whether the function can be safely pushed inside the evaluation of views

--- a/pljava-api/src/main/java/org/postgresql/pljava/annotation/Trigger.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/annotation/Trigger.java
@@ -27,7 +27,7 @@ public @interface Trigger
 	/**
 	 * Whether the trigger is invoked before or after the specified event.
 	 */
-	enum When { BEFORE, AFTER };
+	enum Called { BEFORE, AFTER, INSTEAD_OF };
 
 	/**
 	 * Types of event that can occasion a trigger.
@@ -73,8 +73,22 @@ public @interface Trigger
 	Scope scope() default Scope.STATEMENT;
 	
 	/**
-	 * Denotes if the trigger is fired before or after its
+	 * Denotes if the trigger is fired before, after, or instead of its
 	 * scope (row or statement)
 	 */
-	When when();
+	Called called();
+
+	/**
+	 * A boolean condition limiting when the trigger can be fired.
+	 * This text is injected verbatim into the generated SQL, after
+	 * the keyword {@code WHEN}.
+	 */
+	String when() default "";
+
+	/**
+	 * A list of columns (only meaningful for an UPDATE trigger). The trigger
+	 * will only fire for update if at least one of the columns is mentioned
+	 * as a target of the update command.
+	 */
+	String[] columns() default {};
 }

--- a/pljava-api/src/main/java/org/postgresql/pljava/sqlgen/TriggerNamer.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/sqlgen/TriggerNamer.java
@@ -29,7 +29,12 @@ class TriggerNamer
 	{
 		StringBuilder bld = new StringBuilder();
 		bld.append("trg_");
-		bld.append((t.when() == Trigger.When.BEFORE) ? 'b' : 'a');
+		switch ( t.called() )
+		{
+			case     BEFORE: bld.append( 'b'); break;
+			case      AFTER: bld.append( 'a'); break;
+			case INSTEAD_OF: bld.append( 'i'); break;
+		}
 		bld.append((t.scope() == Trigger.Scope.ROW) ? 'r' : 's');
 
 		// Fixed order regardless of order in list.
@@ -64,8 +69,6 @@ class TriggerNamer
 			bld.append('u');
 		if(atTruncate)
 			bld.append('t');
-		bld.append('_');
-		bld.append(t.table());
 		return bld.toString();
 	}
 }

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/ComplexScalar.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/ComplexScalar.java
@@ -25,7 +25,7 @@ import org.postgresql.pljava.annotation.Function;
 import org.postgresql.pljava.annotation.SQLType;
 import org.postgresql.pljava.annotation.BaseUDT;
 
-import static org.postgresql.pljava.annotation.Function.Type.IMMUTABLE;
+import static org.postgresql.pljava.annotation.Function.Effects.IMMUTABLE;
 import static
 	org.postgresql.pljava.annotation.Function.OnNullInput.RETURNS_NULL;
 
@@ -34,8 +34,8 @@ import static
 public class ComplexScalar implements SQLData {
 	private static Logger s_logger = Logger.getAnonymousLogger();
 
-	@Function(requires="scalar complex type", complexType="javatest.complex",
-		schema="javatest", name="logcomplex", type=IMMUTABLE,
+	@Function(requires="scalar complex type", type="javatest.complex",
+		schema="javatest", name="logcomplex", effects=IMMUTABLE,
 		onNullInput=RETURNS_NULL)
 	public static ComplexScalar logAndReturn(
 		@SQLType("javatest.complex") ComplexScalar cpl) {
@@ -43,7 +43,7 @@ public class ComplexScalar implements SQLData {
 		return cpl;
 	}
 
-	@Function(type=IMMUTABLE, onNullInput=RETURNS_NULL)
+	@Function(effects=IMMUTABLE, onNullInput=RETURNS_NULL)
 	public static ComplexScalar parse(String input, String typeName)
 			throws SQLException {
 		try {
@@ -87,7 +87,7 @@ public class ComplexScalar implements SQLData {
 		return m_typeName;
 	}
 
-	@Function(type=IMMUTABLE, onNullInput=RETURNS_NULL)
+	@Function(effects=IMMUTABLE, onNullInput=RETURNS_NULL)
 	@Override
 	public void readSQL(SQLInput stream, String typeName) throws SQLException {
 		s_logger.info(typeName + " from SQLInput");
@@ -96,7 +96,7 @@ public class ComplexScalar implements SQLData {
 		m_typeName = typeName;
 	}
 
-	@Function(type=IMMUTABLE, onNullInput=RETURNS_NULL)
+	@Function(effects=IMMUTABLE, onNullInput=RETURNS_NULL)
 	@Override
 	public String toString() {
 		s_logger.info(m_typeName + " toString");
@@ -109,7 +109,7 @@ public class ComplexScalar implements SQLData {
 		return sb.toString();
 	}
 
-	@Function(type=IMMUTABLE, onNullInput=RETURNS_NULL)
+	@Function(effects=IMMUTABLE, onNullInput=RETURNS_NULL)
 	@Override
 	public void writeSQL(SQLOutput stream) throws SQLException {
 		s_logger.info(m_typeName + " to SQLOutput");

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/ComplexTuple.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/ComplexTuple.java
@@ -31,9 +31,9 @@ public class ComplexTuple implements SQLData {
 	private static Logger s_logger = Logger.getAnonymousLogger();
 
 	@Function(schema="javatest", name="logcomplex",
-		type=Function.Type.IMMUTABLE,
+		effects=Function.Effects.IMMUTABLE,
 		onNullInput=Function.OnNullInput.RETURNS_NULL,
-		complexType="javatest.complextuple", requires="complextuple type")
+		type="javatest.complextuple", requires="complextuple type")
 	public static ComplexTuple logAndReturn(
 		@SQLType("javatest.complextuple") ComplexTuple cpl) {
 		s_logger.info(cpl.getSQLTypeName() + "(" + cpl.m_x + ", " + cpl.m_y

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/Enumeration.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/Enumeration.java
@@ -40,7 +40,7 @@ import org.postgresql.pljava.annotation.Function;
 })
 public class Enumeration
 {
-	@Function(requires="mood type", provides="textToMood", complexType="mood")
+	@Function(requires="mood type", provides="textToMood", type="mood")
 	public static String textToMood(String s)
 	{
 		return s;
@@ -50,7 +50,7 @@ public class Enumeration
 	{
 		return s;
 	}
-	@Function(requires="mood type", provides="textsToMoods", complexType="mood")
+	@Function(requires="mood type", provides="textsToMoods", type="mood")
 	public static Iterator<String> textsToMoods(String[] ss)
 	{
 		return Arrays.asList(ss).iterator();

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/Point.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/Point.java
@@ -26,7 +26,7 @@ import org.postgresql.pljava.annotation.SQLType;
 public class Point implements SQLData {
 	private static Logger s_logger = Logger.getAnonymousLogger();
 
-	@Function(schema="javatest", complexType="point",
+	@Function(schema="javatest", type="point",
 		onNullInput=Function.OnNullInput.RETURNS_NULL)
 	public static Point logAndReturn(@SQLType("point") Point cpl) {
 		s_logger.info(cpl.getSQLTypeName() + cpl);

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/Triggers.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/Triggers.java
@@ -18,7 +18,7 @@ import org.postgresql.pljava.TriggerData;
 import org.postgresql.pljava.annotation.Function;
 import org.postgresql.pljava.annotation.SQLAction;
 import org.postgresql.pljava.annotation.Trigger;
-import static org.postgresql.pljava.annotation.Trigger.When.*;
+import static org.postgresql.pljava.annotation.Trigger.Called.*;
 import static org.postgresql.pljava.annotation.Trigger.Event.*;
 import static org.postgresql.pljava.annotation.Function.Security.*;
 
@@ -42,8 +42,8 @@ public class Triggers
 		schema = "javatest",
 		security = INVOKER,
 		triggers = {
-			@Trigger(when = BEFORE, table = "foobar_1", events = { INSERT } ),
-			@Trigger(when = BEFORE, table = "foobar_2", events = { INSERT } )
+			@Trigger(called = BEFORE, table = "foobar_1", events = { INSERT } ),
+			@Trigger(called = BEFORE, table = "foobar_2", events = { INSERT } )
 		})
 
 	public static void insertUsername(TriggerData td)

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/UnicodeRoundTripTest.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/UnicodeRoundTripTest.java
@@ -109,7 +109,7 @@ public class UnicodeRoundTripTest {
 	 * @param rs OUT (matched, cparray, s) as described above
 	 * @return true to indicate the OUT tuple is not null
 	 */
-	@Function(complexType="unicodetestrow",
+	@Function(type="unicodetestrow",
 		requires="unicodetestrow type", provides="unicodetest fn")
 	public static boolean unicodetest(String s, int[] ints, ResultSet rs)
 	throws SQLException {

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/UsingProperties.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/UsingProperties.java
@@ -68,7 +68,7 @@ public class UsingProperties implements ResultSetProvider
 		return true;
 	}
 
-	@Function( complexType = "javatest._properties")
+	@Function( type = "javatest._properties")
 	public static ResultSetProvider propertyExampleAnno()
 	throws SQLException
 	{

--- a/src/site/markdown/use/hello.md.vm
+++ b/src/site/markdown/use/hello.md.vm
@@ -432,13 +432,13 @@ package com.example.proj;
 
 import org.postgresql.pljava.annotation.Function;
 
-import static org.postgresql.pljava.annotation.Function.Type.IMMUTABLE;
+import static org.postgresql.pljava.annotation.Function.Effects.IMMUTABLE;
 import static
   org.postgresql.pljava.annotation.Function.OnNullInput.RETURNS_NULL;
 
 public class Hello {
 
-  @Function(onNullInput=RETURNS_NULL, type=IMMUTABLE)
+  @Function(onNullInput=RETURNS_NULL, effects=IMMUTABLE)
   public static String hello(String toWhom) {
     return "Hello, " + toWhom + "!";
   }


### PR DESCRIPTION
 Change annotation keywords discussed on -dev.

@Function(type=  ->  effects=
@Function(complexType= -> type=
@Function(trust=RESTRICTED|UNRESTRICTED -> SANDBOXED|UNSANDBOXED

@Trigger(when= -> called=
@Trigger(when="a boolean condition" new tracks PG9.0+

Also added called=INSTEAD_OF and columns={} to track PG.
That is, the SQL generator can recognize them and generate
the DDR; nothing is changed in PL/Java runtime yet.

Changed the generation of default trigger names to leave off the table name; trigger names are in per-table namespaces anyway.