### PR TITLE
Improve message in strange javac error case.

### DIFF
--- a/pljava-api/src/main/java/org/postgresql/pljava/sqlgen/DDRProcessor.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/sqlgen/DDRProcessor.java
@@ -866,7 +866,19 @@ hunt:	for ( ExecutableElement ee : ees )
 					if ( ! isExplicit  &&  null != f.get( inst) )
 						continue;
 					if ( fkl.isArray() )
-						f.set( inst, avToArray( v, fkl.getComponentType()));
+					{
+						try {
+							f.set( inst, avToArray( v, fkl.getComponentType()));
+						}
+						catch (AnnotationValueException ave)
+						{
+							msg( Kind.ERROR, e, am,
+							"unresolved value for an element of annotation" +
+							" member \"%s\" (check for missing/misspelled" +
+							" import, etc.)",
+							name);
+						}
+					}
 					else if ( fkl.isEnum() )
 						f.set( inst, Enum.valueOf( fkl.asSubclass( Enum.class),
 							((VariableElement)v).getSimpleName().toString()));


### PR DESCRIPTION
Earlier in the week I saw truly perplexing errors that stemmed
from a simple missing or misspelled import, but javac, instead
of reporting the error, would supply DDRProcessor with an instance
of an internal Error class where the unresolvable value should have
been. So now, at least recognize that Error class and produce a more
helpful message. Now, of course, I am unable to test the change,
because javac (same version! same machine!) is now doing the right
thing every time. At least with this change, if the right conditions
are ever hit again for javac to misbehave as it was earlier, the
message should be more helpful.