### PR TITLE
Cluster name as property and in jps title.

### DIFF
--- a/pljava-so/src/main/c/Backend.c
+++ b/pljava-so/src/main/c/Backend.c
@@ -1115,10 +1115,15 @@ static void JVMOptList_add(JVMOptList* jol, const char* optString, void* extraIn
 
 static void JVMOptList_addVisualVMName(JVMOptList* jol)
 {
+	char const *clustername = pljavaClusterName();
 	StringInfoData buf;
 	initStringInfo(&buf);
-	appendStringInfo(&buf, "%sPL/Java:%d:%s",
-		visualVMprefix, MyProcPid, pljavaDbName());
+	if ( '\0' == *clustername )
+		appendStringInfo(&buf, "%sPL/Java:%d:%s",
+			visualVMprefix, MyProcPid, pljavaDbName());
+	else
+		appendStringInfo(&buf, "%sPL/Java:%s:%d:%s",
+			visualVMprefix, clustername, MyProcPid, pljavaDbName());
 	JVMOptList_add(jol, buf.data, 0, false);
 }
 
@@ -1285,7 +1290,7 @@ static void registerGUCOptions(void)
 		NULL, /* extended description */
 		&vmoptions,
 		#if PG_VERSION_NUM >= 80400
-			"-XX:+DisableAttachMechanism", /* boot value */
+			NULL, /* boot value */
 		#endif
 		PGC_SUSET,
 		#if PG_VERSION_NUM >= 80400

--- a/pljava-so/src/main/c/InstallHelper.c
+++ b/pljava-so/src/main/c/InstallHelper.c
@@ -332,6 +332,8 @@ char *InstallHelper_hello()
 	JNI_deleteLocalRef(nativeVer);
 	JNI_deleteLocalRef(user);
 	JNI_deleteLocalRef(dbname);
+	if ( NULL != clustername )
+		JNI_deleteLocalRef(clustername);
 	JNI_deleteLocalRef(ddir);
 	JNI_deleteLocalRef(ldir);
 	JNI_deleteLocalRef(sdir);

--- a/pljava-so/src/main/include/pljava/InstallHelper.h
+++ b/pljava-so/src/main/include/pljava/InstallHelper.h
@@ -63,6 +63,12 @@ extern Oid pljavaTrustedOid, pljavaUntrustedOid;
 extern char *pljavaDbName();
 
 /*
+ * Return the name of the cluster if it has been set (only possible in 9.5+),
+ * or an empty string, never NULL.
+ */
+extern char const *pljavaClusterName();
+
+/*
  * Construct a default for pljava.classpath ($sharedir/pljava/pljava-$VER.jar)
  * in pathbuf (which must have length at least MAXPGPATH), and return pathbuf,
  * or NULL if the constructed path would not fit.

--- a/pljava/src/main/java/org/postgresql/pljava/internal/InstallHelper.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/InstallHelper.java
@@ -44,7 +44,7 @@ public class InstallHelper
 	}
 
 	public static String hello(
-		String nativeVer, String user, String dbname,
+		String nativeVer, String user, String dbname, String clustername,
 		String datadir, String libdir, String sharedir, String etcdir)
 	{
 		String implVersion =
@@ -58,6 +58,8 @@ public class InstallHelper
 		System.setProperty( "user.name", user);
 		setPropertyIfNull( "java.awt.headless", "true");
 		setPropertyIfNull( "org.postgresql.database", dbname);
+		if ( null != clustername )
+			setPropertyIfNull( "org.postgresql.cluster", clustername);
 		setPropertyIfNull( "org.postgresql.datadir", datadir);
 		setPropertyIfNull( "org.postgresql.libdir", libdir);
 		setPropertyIfNull( "org.postgresql.sharedir", sharedir);

--- a/src/site/markdown/use/variables.md
+++ b/src/site/markdown/use/variables.md
@@ -76,21 +76,19 @@ These PostgreSQL configuration variables can influence PL/Java's operation:
     `pljava.vmoptions`. The exact quoting and encoding rules for this variable
     may be adjusted in a future PL/Java version.
 
-    The default value for this variable is `-XX:+DisableAttachMechanism`
-    so that [Java Management Extensions][jmx] tools such as
-    [`jvisualvm`][jvvm] are prevented by default from attaching to the
-    process. If you set any explicit value for `pljava.vmoptions`, you should
-    include `-XX:+DisableAttachMechanism` if you wish to prevent such tools
-    from attaching. If you intend to use the advanced features of such tools
-    (such as code profiling in VisualVM), then simply set any value for
-    `pljava.vmoptions` that does not contain `-XX:+DisableAttachMechanism`.
-    You may also need to do so if you are using a non-Oracle Java runtime
-    and it rejects that option as unknown.
+    You can include `-XX:+DisableAttachMechanism` among the options if you
+    prefer to prevent [Java Management Extensions][jmx] tools such as
+    [`jvisualvm`][jvvm] from attaching to the process even from the server host
+    itself (by default, such tools can connect if running on the server host as
+    a superuser, or the operating system user running the postmaster). That
+    will, of course, prevent you from using the advanced features of such tools,
+    such as code profiling in VisualVM.
 
     Even with attachment disabled, a tool such as VisualVM can display some
-    basic information about PL/Java processes (as long as it runs as the same
-    operating system user as the `postmaster`), including the arguments,
-    system properties, class and thread counts, and overall heap usage.
+    basic information about PL/Java processes (as long as it runs on the server
+    host, as a superuser or the same operating system user as the `postmaster`),
+    including the arguments, system properties, class and thread counts, and
+    overall heap usage.
 
 [pre92]: ../install/prepg92.html
 [depdesc]: https://github.com/tada/pljava/wiki/Sql-deployment-descriptor


### PR DESCRIPTION
Make the cluster name easily available if it is set (to a
nonempty string, in PostgreSQL versions where it is available),
as a java system property and in the title visible to jps
and jvisualvm.

In passing, lose the default vmoption to lock out jvisualvm local
connections. Noah Misch persuades me that PostgreSQL itself doesn't
make special efforts to prevent things that already require access
as the postgres user on the server host, and it would be unpostgresy
to do so here. Instead, simply document how to disable attachment,
if the admin so desires.