### PR TITLE
Make DEBUG1 quieter.

### DIFF
--- a/pljava-so/src/main/c/Backend.c
+++ b/pljava-so/src/main/c/Backend.c
@@ -485,7 +485,7 @@ static void initsequencer(enum initstage is, bool tolerant)
 			goto check_tolerant;
 		}
 		jvmStartedAtLeastOnce = true;
-		elog(DEBUG1, "successfully created Java virtual machine");
+		elog(DEBUG2, "successfully created Java virtual machine");
 		initstage = IS_JAVAVM_STARTED;
 
 	case IS_JAVAVM_STARTED:
@@ -774,10 +774,10 @@ static void initPLJavaClasses(void)
 
 	Exception_initialize();
 
-	elog(DEBUG1, "checking for a PL/Java Backend class on the given classpath");
+	elog(DEBUG2, "checking for a PL/Java Backend class on the given classpath");
 	s_Backend_class = PgObject_getJavaClass(
 		"org/postgresql/pljava/internal/Backend");
-	elog(DEBUG1, "successfully loaded Backend class");
+	elog(DEBUG2, "successfully loaded Backend class");
 	PgObject_registerNatives2(s_Backend_class, backendMethods);
 
 	tlField = PgObject_getStaticJavaField(s_Backend_class, "THREADLOCK", "Ljava/lang/Object;");
@@ -1031,7 +1031,7 @@ static void _destroyJavaVM(int status, Datum dummy)
 		Invocation_pushInvocation(&ctx, false);
 		if(sigsetjmp(recoverBuf, 1) != 0)
 		{
-			elog(DEBUG1,
+			elog(DEBUG2,
 				"needed to forcibly shut down the Java virtual machine");
 			s_javaVM = 0;
 			return;
@@ -1045,7 +1045,7 @@ static void _destroyJavaVM(int status, Datum dummy)
 		enable_sig_alarm(5000, false);
 #endif
 
-		elog(DEBUG1, "shutting down the Java virtual machine");
+		elog(DEBUG2, "shutting down the Java virtual machine");
 		JNI_destroyVM(s_javaVM);
 
 #if PG_VERSION_NUM >= 90300
@@ -1057,10 +1057,10 @@ static void _destroyJavaVM(int status, Datum dummy)
 
 #else
 		Invocation_pushInvocation(&ctx, false);
-		elog(DEBUG1, "shutting down the Java virtual machine");
+		elog(DEBUG2, "shutting down the Java virtual machine");
 		JNI_destroyVM(s_javaVM);
 #endif
-		elog(DEBUG1, "done shutting down the Java virtual machine");
+		elog(DEBUG2, "done shutting down the Java virtual machine");
 		s_javaVM = 0;
 		currentInvocation = 0;
 	}
@@ -1110,7 +1110,7 @@ static void JVMOptList_add(JVMOptList* jol, const char* optString, void* extraIn
 	if ( 0 == strncmp(optString, visualVMprefix, sizeof visualVMprefix - 1) )
 		seenVisualVMName = true;
 
-	elog(DEBUG1, "Added JVM option string \"%s\"", optString);		
+	elog(DEBUG2, "Added JVM option string \"%s\"", optString);
 }
 
 static void JVMOptList_addVisualVMName(JVMOptList* jol)
@@ -1222,7 +1222,7 @@ static void checkIntTimeType(void)
 	const char* idt = PG_GETCONFIGOPTION("integer_datetimes");
 
 	integerDateTimes = (strcmp(idt, "on") == 0);
-	elog(DEBUG1, integerDateTimes ? "Using integer_datetimes" : "Not using integer_datetimes");
+	elog(DEBUG2, integerDateTimes ? "Using integer_datetimes" : "Not using integer_datetimes");
 }
 
 static jint initializeJavaVM(JVMOptList *optList)
@@ -1242,7 +1242,7 @@ static jint initializeJavaVM(JVMOptList *optList)
 	vm_args.version  = JNI_VERSION_1_4;
 	vm_args.ignoreUnrecognized = JNI_FALSE;
 
-	elog(DEBUG1, "creating Java virtual machine");
+	elog(DEBUG2, "creating Java virtual machine");
 
 	jstat = JNI_createVM(&s_javaVM, &vm_args);
 

--- a/pljava-so/src/main/c/Exception.c
+++ b/pljava-so/src/main/c/Exception.c
@@ -159,7 +159,7 @@ void Exception_throw_ERROR(const char* funcName)
 		ex = JNI_newObject(ServerException_class, ServerException_init, ed);
 		currentInvocation->errorOccured = true;
 
-		elog(DEBUG1, "Exception in function %s", funcName);
+		elog(DEBUG2, "Exception in function %s", funcName);
 
 		JNI_deleteLocalRef(ed);
 		JNI_throw(ex);

--- a/pljava-so/src/main/c/Function.c
+++ b/pljava-so/src/main/c/Function.c
@@ -562,7 +562,7 @@ static void Function_init(Function self, ParseResult info, Form_pg_proc procStru
 	loader = JNI_callStaticObjectMethod(s_Loader_class, s_Loader_getSchemaLoader, schemaName);
 	JNI_deleteLocalRef(schemaName);
 
-	elog(DEBUG1, "Loading class %s", info->className);
+	elog(DEBUG2, "Loading class %s", info->className);
 	className = String_createJavaStringFromNTS(info->className);
 
 	tmp = JNI_callObjectMethod(loader, s_ClassLoader_loadClass, className);
@@ -592,7 +592,7 @@ static void Function_init(Function self, ParseResult info, Form_pg_proc procStru
 	initStringInfo(&sign);
 	buildSignature(self, &sign, self->func.nonudt.returnType, false);
 
-	elog(DEBUG1, "Obtaining method %s.%s %s", info->className, info->methodName, sign.data);
+	elog(DEBUG2, "Obtaining method %s.%s %s", info->className, info->methodName, sign.data);
 	self->func.nonudt.method = JNI_getStaticMethodIDOrNull(self->clazz, info->methodName, sign.data);
 
 	if(self->func.nonudt.method == 0)
@@ -601,7 +601,7 @@ static void Function_init(Function self, ParseResult info, Form_pg_proc procStru
 		Type altType = 0;
 		Type realRetType = self->func.nonudt.returnType;
 
-		elog(DEBUG1, "Method %s.%s %s not found", info->className, info->methodName, origSign);
+		elog(DEBUG2, "Method %s.%s %s not found", info->className, info->methodName, origSign);
 
 		if(Type_isPrimitive(self->func.nonudt.returnType))
 		{
@@ -631,7 +631,7 @@ static void Function_init(Function self, ParseResult info, Form_pg_proc procStru
 			initStringInfo(&sign);
 			buildSignature(self, &sign, altType, true);
 
-			elog(DEBUG1, "Obtaining method %s.%s %s", info->className, info->methodName, sign.data);
+			elog(DEBUG2, "Obtaining method %s.%s %s", info->className, info->methodName, sign.data);
 			self->func.nonudt.method = JNI_getStaticMethodIDOrNull(self->clazz, info->methodName, sign.data);
 	
 			if(self->func.nonudt.method != 0)

--- a/pljava-so/src/main/c/InstallHelper.c
+++ b/pljava-so/src/main/c/InstallHelper.c
@@ -140,11 +140,11 @@ static void checkLoadPath( bool *livecheck)
 	if ( NULL == l )
 		return;
 	if ( 1 < list_length( l) )
-		elog(DEBUG1, "ActivePortal lists %d statements", list_length( l));
+		elog(DEBUG2, "ActivePortal lists %d statements", list_length( l));
 	ut = (Node *)linitial(l);
 	if ( NULL == ut )
 	{
-		elog(DEBUG1, "got null for first statement from ActivePortal");
+		elog(DEBUG2, "got null for first statement from ActivePortal");
 		return;
 	}
 	if ( T_LoadStmt != nodeTag(ut) )
@@ -167,7 +167,7 @@ static void checkLoadPath( bool *livecheck)
 	ls = (LoadStmt *)ut;
 	if ( NULL == ls->filename )
 	{
-		elog(DEBUG1, "got null for a LOAD statement's filename");
+		elog(DEBUG2, "got null for a LOAD statement's filename");
 		return;
 	}
 	pljavaLoadPath =

--- a/pljava-so/src/main/include/pljava/pljava.h
+++ b/pljava-so/src/main/include/pljava/pljava.h
@@ -121,7 +121,7 @@ char* stack_base_ptr;
 		_STACK_BASE_SET; \
 		saveMainThreadId = mainThreadId; \
 		mainThreadId = threadId; \
-		elog(DEBUG1, "Set stack base for thread %lx", mainThreadId); \
+		elog(DEBUG2, "Set stack base for thread %lx", mainThreadId); \
 	}
 
 #define STACK_BASE_POP() \
@@ -129,7 +129,7 @@ char* stack_base_ptr;
 	{ \
 		_STACK_BASE_RESTORE; \
 		mainThreadId = saveMainThreadId; \
-		elog(DEBUG1, "Restored stack base for thread %lx", mainThreadId); \
+		elog(DEBUG2, "Restored stack base for thread %lx", mainThreadId); \
 	}
 
 /* NOTE!


### PR DESCRIPTION
Move a bunch of DEBUG1s to DEBUG2, leaving DEBUG1 for the
initial load message that identifies PL/Java and JVM versions.
(This is NOTICE if PL/Java is explicitly LOADed, so it's seen
by default, but in other cases you can now see it by enabling
DEBUG1, and not mixed in with a lot of other stuff.)