### PR TITLE
SQL comments on PL/Java's own DB objects, and user generated ones.

### DIFF
--- a/pljava-api/src/main/java/org/postgresql/pljava/annotation/BaseUDT.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/annotation/BaseUDT.java
@@ -125,6 +125,13 @@ public @interface BaseUDT
 	String implementor() default "";
 
 	/**
+	 * A comment to be associated with the type. If left to default,
+	 * and the Java class has a doc comment, its first sentence will be used.
+	 * If an empty string is explicitly given, no comment will be set.
+	 */
+	String comment() default "";
+
+	/**
 	 * Name, possibly schema-qualified, of a function to parse type-modifier
 	 * strings for this type. Such a function may be implemented in any language
 	 * as long as it can accept a single {@code cstring[]} parameter and return

--- a/pljava-api/src/main/java/org/postgresql/pljava/annotation/Function.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/annotation/Function.java
@@ -196,4 +196,11 @@ category</a>
 	 * emit code not wrapped in an {@code <implementor block>}.
 	 */
 	String implementor() default "";
+
+	/**
+	 * A comment to be associated with the SQL function. If left to default,
+	 * and the Java function has a doc comment, its first sentence will be used.
+	 * If an empty string is explicitly given, no comment will be set.
+	 */
+	String comment() default "";
 }

--- a/pljava-api/src/main/java/org/postgresql/pljava/annotation/MappedUDT.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/annotation/MappedUDT.java
@@ -100,4 +100,11 @@ public @interface MappedUDT
 	 * PostgreSQL type.
 	 */
 	String[] structure() default {};
+
+	/**
+	 * A comment to be associated with the type. If left to default,
+	 * and the Java class has a doc comment, its first sentence will be used.
+	 * If an empty string is explicitly given, no comment will be set.
+	 */
+	String comment() default "";
 }

--- a/pljava-api/src/main/java/org/postgresql/pljava/annotation/SQLType.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/annotation/SQLType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2013 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2016 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -24,7 +24,7 @@ import java.lang.annotation.Target;
  * automatically mapped type, and/or to supply an SQL default value.
  *
  * This annotation cannot be used to supply the SQL declaration's return type,
- * but {@link Function#complexType @Function(complexType=...)} can.
+ * but {@link Function#type @Function(type=...)} can.
  *
  * @author Thomas Hallgren - pre-Java6 version
  * @author Chapman Flack (Purdue Mathematics) - updated to Java6, added SQLType

--- a/pljava-api/src/main/java/org/postgresql/pljava/annotation/Trigger.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/annotation/Trigger.java
@@ -91,4 +91,11 @@ public @interface Trigger
 	 * as a target of the update command.
 	 */
 	String[] columns() default {};
+
+	/**
+	 * A comment to be associated with the trigger. If left to default,
+	 * and the Java function has a doc comment, its first sentence will be used.
+	 * If an empty string is explicitly given, no comment will be set.
+	 */
+	String comment() default "";
 }

--- a/pljava-api/src/main/java/org/postgresql/pljava/annotation/package-info.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/annotation/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2015-2016 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -52,12 +52,12 @@
  * in the top directory of the tree where the compiled class files are written.
  * <dt><code>ddr.name.trusted</code>
  * <dd>The language name that will be used to declare methods that are
- * annotated to have {@link org.postgresql.pljava.annotation.Function.Trust#RESTRICTED} behavior. If not
+ * annotated to have {@link org.postgresql.pljava.annotation.Function.Trust#SANDBOXED} behavior. If not
  * specified, the name <code>java</code> will be used. It must match the name
  * used for the "trusted" language declaration when PL/Java was installed.
  * <dt><code>ddr.name.untrusted</code>
  * <dd>The language name that will be used to declare methods that are
- * annotated to have {@link org.postgresql.pljava.annotation.Function.Trust#UNRESTRICTED} behavior. If not
+ * annotated to have {@link org.postgresql.pljava.annotation.Function.Trust#UNSANDBOXED} behavior. If not
  * specified, the name <code>javaU</code> will be used. It must match the name
  * used for the "untrusted" language declaration when PL/Java was installed.
  * <dt><code>ddr.implementor</code>

--- a/pljava/src/main/java/org/postgresql/pljava/internal/InstallHelper.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/InstallHelper.java
@@ -161,10 +161,19 @@ public class InstallHelper
 			" LANGUAGE C");
 		s.execute("REVOKE ALL PRIVILEGES" +
 			" ON FUNCTION sqlj.java_call_handler() FROM public");
-		s.execute(
-			"COMMENT ON FUNCTION sqlj.java_call_handler() IS '" +
-			"Function-call handler for PL/Java''s trusted/sandboxed " +
-			"language.'");
+		ResultSet rs = s.executeQuery(
+			"SELECT pg_catalog.obj_description(CAST(" +
+			"'sqlj.java_call_handler()' AS pg_catalog.regprocedure), " +
+			"'pg_proc')");
+		rs.next();
+		rs.getString(1);
+		boolean noComment = rs.wasNull();
+		rs.close();
+		if ( noComment )
+			s.execute(
+				"COMMENT ON FUNCTION sqlj.java_call_handler() IS '" +
+				"Function-call handler for PL/Java''s trusted/sandboxed " +
+				"language.'");
 
 		s.execute(
 			"CREATE OR REPLACE FUNCTION sqlj.javau_call_handler()" +
@@ -173,10 +182,19 @@ public class InstallHelper
 			" LANGUAGE C");
 		s.execute("REVOKE ALL PRIVILEGES" +
 			" ON FUNCTION sqlj.javau_call_handler() FROM public");
-		s.execute(
-			"COMMENT ON FUNCTION sqlj.javau_call_handler() IS '" +
-			"Function-call handler for PL/Java''s untrusted/unsandboxed " +
-			"language.'");
+		rs = s.executeQuery(
+			"SELECT pg_catalog.obj_description(CAST(" +
+			"'sqlj.javau_call_handler()' AS pg_catalog.regprocedure), " +
+			"'pg_proc')");
+		rs.next();
+		rs.getString(1);
+		noComment = rs.wasNull();
+		rs.close();
+		if ( noComment )
+			s.execute(
+				"COMMENT ON FUNCTION sqlj.javau_call_handler() IS '" +
+				"Function-call handler for PL/Java''s untrusted/unsandboxed " +
+				"language.'");
 	}
 
 	private static void languages( Connection c, Statement s)

--- a/pljava/src/main/java/org/postgresql/pljava/internal/InstallHelper.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/InstallHelper.java
@@ -136,6 +136,10 @@ public class InstallHelper
 		{
 			p = c.setSavepoint();
 			s.execute("CREATE SCHEMA sqlj");
+			s.execute("COMMENT ON SCHEMA sqlj IS '"+
+			"Schema for objects pertaining to PL/Java, as specified by " +
+			"\"SQL/JRT\" part 13 of the SQL standard, Java Routines and Types.'"
+			);
 			s.execute("GRANT USAGE ON SCHEMA sqlj TO public");
 			c.releaseSavepoint(p);
 		}
@@ -157,6 +161,10 @@ public class InstallHelper
 			" LANGUAGE C");
 		s.execute("REVOKE ALL PRIVILEGES" +
 			" ON FUNCTION sqlj.java_call_handler() FROM public");
+		s.execute(
+			"COMMENT ON FUNCTION sqlj.java_call_handler() IS '" +
+			"Function-call handler for PL/Java''s trusted/sandboxed " +
+			"language.'");
 
 		s.execute(
 			"CREATE OR REPLACE FUNCTION sqlj.javau_call_handler()" +
@@ -165,6 +173,10 @@ public class InstallHelper
 			" LANGUAGE C");
 		s.execute("REVOKE ALL PRIVILEGES" +
 			" ON FUNCTION sqlj.javau_call_handler() FROM public");
+		s.execute(
+			"COMMENT ON FUNCTION sqlj.javau_call_handler() IS '" +
+			"Function-call handler for PL/Java''s untrusted/unsandboxed " +
+			"language.'");
 	}
 
 	private static void languages( Connection c, Statement s)
@@ -176,6 +188,10 @@ public class InstallHelper
 			p = c.setSavepoint();
 			s.execute(
 				"CREATE TRUSTED LANGUAGE java HANDLER sqlj.java_call_handler");
+			s.execute(
+				"COMMENT ON LANGUAGE java IS '" +
+				"Trusted/sandboxed language for routines and types in " +
+				"Java; http://tada.github.io/pljava/'");
 			c.releaseSavepoint(p);
 		}
 		catch ( SQLException sqle )
@@ -184,11 +200,16 @@ public class InstallHelper
 			if ( ! "42710".equals(sqle.getSQLState()) )
 				throw sqle;
 		}
+
 		try
 		{
 			p = c.setSavepoint();
 			s.execute(
 				"CREATE LANGUAGE javaU HANDLER sqlj.javau_call_handler");
+			s.execute(
+				"COMMENT ON LANGUAGE javau IS '" +
+				"Untrusted/unsandboxed language for routines and types in " +
+				"Java; http://tada.github.io/pljava/'");
 			c.releaseSavepoint(p);
 		}
 		catch ( SQLException sqle )

--- a/pljava/src/main/java/org/postgresql/pljava/management/Commands.java
+++ b/pljava/src/main/java/org/postgresql/pljava/management/Commands.java
@@ -257,6 +257,8 @@ import static org.postgresql.pljava.annotation.Function.Security.DEFINER;
 "		jarOwner    NAME NOT NULL," +
 "		jarManifest TEXT" +
 "	)",
+"	COMMENT ON TABLE sqlj.jar_repository IS" +
+"	'Information on jars loaded by PL/Java, one row per jar.'",
 "	GRANT SELECT ON sqlj.jar_repository TO public",
 
 "	CREATE TABLE sqlj.jar_entry(" +
@@ -267,6 +269,8 @@ import static org.postgresql.pljava.annotation.Function.Security.DEFINER;
 "		entryImage  BYTEA NOT NULL," +
 "		UNIQUE(jarId, entryName)" +
 "	)",
+"	COMMENT ON TABLE sqlj.jar_entry IS" +
+"	'Name and content of each entry in every jar loaded by PL/Java.'",
 "	GRANT SELECT ON sqlj.jar_entry TO public",
 
 "	CREATE TABLE sqlj.jar_descriptor(" +
@@ -275,6 +279,10 @@ import static org.postgresql.pljava.annotation.Function.Security.DEFINER;
 "		PRIMARY KEY (jarId, ordinal)," +
 "		entryId     INT NOT NULL REFERENCES sqlj.jar_entry ON DELETE CASCADE" +
 "	)",
+"	COMMENT ON TABLE sqlj.jar_descriptor IS" +
+"	'Associates each jar with zero-or-more deployment descriptors (a row " +
+	"for each), with ordinal indicating their order of mention in the " +
+	"manifest.'",
 "	GRANT SELECT ON sqlj.jar_descriptor TO public",
 
 "	CREATE TABLE sqlj.classpath_entry(" +
@@ -284,6 +292,10 @@ import static org.postgresql.pljava.annotation.Function.Security.DEFINER;
 "					REFERENCES sqlj.jar_repository ON DELETE CASCADE," +
 "		PRIMARY KEY(schemaName, ordinal)" +
 "	)",
+"	COMMENT ON TABLE sqlj.classpath_entry IS" +
+"	'Associates each schema with zero-or-more jars (a row " +
+	"for each), with ordinal indicating their order of precedence in the " +
+	"classpath.'",
 "	GRANT SELECT ON sqlj.classpath_entry TO public",
 
 "	CREATE TABLE sqlj.typemap_entry(" +
@@ -291,6 +303,8 @@ import static org.postgresql.pljava.annotation.Function.Security.DEFINER;
 "		javaName    VARCHAR(200) NOT NULL," +
 "		sqlName     NAME NOT NULL" +
 "	)",
+"	COMMENT ON TABLE sqlj.typemap_entry IS" +
+"	'A row for each SQL type <-> Java type custom mapping.'",
 "	GRANT SELECT ON sqlj.typemap_entry TO public"
 }, remove={
 "	DROP TABLE sqlj.typemap_entry",

--- a/pljava/src/main/java/org/postgresql/pljava/management/Commands.java
+++ b/pljava/src/main/java/org/postgresql/pljava/management/Commands.java
@@ -490,7 +490,7 @@ public class Commands
 	 * @param sqlTypeName The name of the SQL type. The name can be
 	 *            qualified with a schema (namespace). If the schema is omitted,
 	 *            it will be resolved according to the current setting of the
-	 *            <code>search_path</code>.
+	 *            {@code search_path}.
 	 * @param javaClassName The name of the class. The class must be found in
 	 *            the classpath in effect for the current schema
 	 * @throws SQLException
@@ -535,7 +535,7 @@ public class Commands
 	 * @param sqlTypeName The name of the SQL type. The name can be
 	 *            qualified with a schema (namespace). If the schema is omitted,
 	 *            it will be resolved according to the current setting of the
-	 *            <code>search_path</code>.
+	 *            {@code search_path}.
 	 * @throws SQLException
 	 */
 	@Function(schema="sqlj", name="drop_type_mapping", security=DEFINER)
@@ -559,11 +559,11 @@ public class Commands
 
 	/**
 	 * Return the classpath that has been defined for the schema named
-	 * <code>schemaName</code> This method is exposed in SQL as
-	 * <code>sqlj.get_classpath(VARCHAR)</code>.
+	 * {@code schemaName}. This method is exposed in SQL as
+	 * {@code sqlj.get_classpath(VARCHAR)}.
 	 * 
 	 * @param schemaName Name of the schema for which this path is valid.
-	 * @return The defined classpath or <code>null</code> if this schema has
+	 * @return The defined classpath or {@code null} if this schema has
 	 *         no classpath.
 	 * @throws SQLException
 	 */
@@ -615,15 +615,15 @@ public class Commands
 
 	/**
 	 * Installs a new Jar in the database jar repository under name
-	 * <code>jarName</code>. Once installed classpaths can be defined that
+	 * {@code jarName}. Once installed classpaths can be defined that
 	 * refrences this jar. This method is exposed in SQL as
-	 * <code>sqlj.install_jar(BYTEA, VARCHAR, BOOLEAN)</code>.
+	 * {@code sqlj.install_jar(BYTEA, VARCHAR, BOOLEAN)}.
 	 * 
 	 * @param image The byte array that constitutes the jar content.
 	 * @param jarName The name by which the system will refer to this jar.
 	 * @param deploy If set, execute install commands found in the deployment
 	 *            descriptor.
-	 * @throws SQLException if the <code>jarName</code> contains characters
+	 * @throws SQLException if the {@code jarName} contains characters
 	 *             that are invalid or if the named jar already exists in the
 	 *             system.
 	 * @see #setClassPath
@@ -638,15 +638,15 @@ public class Commands
 
 	/**
 	 * Installs a new Jar in the database jar repository under name
-	 * <code>jarName</code>. Once installed classpaths can be defined that
+	 * {@code jarName}. Once installed classpaths can be defined that
 	 * refrences this jar. This method is exposed in SQL as
-	 * <code>sqlj.install_jar(VARCHAR, VARCHAR, BOOLEAN)</code>.
+	 * {@code sqlj.install_jar(VARCHAR, VARCHAR, BOOLEAN)}.
 	 * 
 	 * @param urlString The location of the jar that will be installed.
 	 * @param jarName The name by which the system will refer to this jar.
 	 * @param deploy If set, execute install commands found in the deployment
 	 *            descriptor.
-	 * @throws SQLException if the <code>jarName</code> contains characters
+	 * @throws SQLException if the {@code jarName} contains characters
 	 *             that are invalid or if the named jar already exists in the
 	 *             system.
 	 * @see #setClassPath
@@ -659,10 +659,10 @@ public class Commands
 	}
 
 	/**
-	 * Removes the jar named <code>jarName</code> from the database jar
+	 * Removes the jar named {@code jarName} from the database jar
 	 * repository. Class path entries that references this jar will also be
 	 * removed (just the entry, not the whole path). This method is exposed in
-	 * SQL as <code>sqlj.remove_jar(VARCHAR, BOOLEAN)</code>.
+	 * SQL as {@code sqlj.remove_jar(VARCHAR, BOOLEAN)}.
 	 * 
 	 * @param jarName The name by which the system referes this jar.
 	 * @param undeploy If set, execute remove commands found in the deployment
@@ -707,9 +707,9 @@ public class Commands
 	}
 
 	/**
-	 * Replaces the image of jar named <code>jarName</code> in the database
-	 * jar repository. This method is exposed in SQL as <code>
-	 * sqlj.replace_jar(BYTEA, VARCHAR, BOOLEAN)</code>.
+	 * Replaces the image of jar named {@code jarName} in the database
+	 * jar repository. This method is exposed in SQL as
+	 * {@code sqlj.replace_jar(BYTEA, VARCHAR, BOOLEAN)}.
 	 * 
 	 * @param jarImage The byte array that constitutes the jar content.
 	 * @param jarName The name by which the system referes this jar.
@@ -727,9 +727,9 @@ public class Commands
 	}
 
 	/**
-	 * Replaces the image of jar named <code>jarName</code> in the database
-	 * jar repository. This method is exposed in SQL as <code>
-	 * sqlj.replace_jar(VARCHAR, VARCHAR, BOOLEAN)</code>.
+	 * Replaces the image of jar named {@code jarName} in the database
+	 * jar repository. This method is exposed in SQL as
+	 * {@code sqlj.replace_jar(VARCHAR, VARCHAR, BOOLEAN)}.
 	 * 
 	 * @param urlString The location of the jar that will be installed.
 	 * @param jarName The name by which the system referes this jar.
@@ -747,9 +747,9 @@ public class Commands
 
 	/**
 	 * Define the class path to use for Java functions, triggers, and procedures
-	 * that are created in the schema named <code>schemaName</code> This
+	 * that are created in the schema named {@code schemaName}. This
 	 * method is exposed in SQL as
-	 * <code>sqlj.set_classpath(VARCHAR, VARCHAR)</code>.
+	 * {@code sqlj.set_classpath(VARCHAR, VARCHAR)}.
 	 * 
 	 * @param schemaName Name of the schema for which this path is valid.
 	 * @param path Colon separated list of names. Each name must denote the name


### PR DESCRIPTION
Bit of a luxury perhaps, but the last thing left on the list I sent around on December 18th.

Get the SQL generator producing SQL comments where possible from user code, and exploit that to get most comments on PL/Java's own objects too, with a few of the rest hand-coded.

There is no new thing under the sun; László Hornyák had PL-J making comments out of javadoc some time back in 2004 or '05.