### PR TITLE
Bring PostgreSQL 9.6 compatibility.

### DIFF
--- a/pljava-api/src/main/java/org/postgresql/pljava/annotation/Function.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/annotation/Function.java
@@ -150,16 +150,17 @@ category</a>
 	/** 
 	 * Whether the function is UNSAFE to use in any parallel query plan at all
 	 * (the default), or avoids all disqualifying operations and so is SAFE to
-	 * execute anywhere in a parallel plan, or, by avoiding some such
+	 * execute anywhere in a parallel plan, or, by avoiding <em>some</em> such
 	 * operations, may appear in parallel plans but RESTRICTED to execute only
 	 * on the parallel group leader. The operations that must be considered are
 	 * set out in <a href=
 'https://www.postgresql.org/docs/current/static/parallel-safety.html#PARALLEL-LABELING'
 >Parallel Labeling for Functions and Aggregates</a> in the PostgreSQL docs.
-	 * PL/Java itself can perform such operations internally; a thorough code
-	 * audit would be needed to learn when, if ever, a PL/Java function could
-	 * appropriately be declared anything but the default UNSAFE.
-	 *
+	 *<p>
+	 * For much more on the practicalities of parallel query and PL/Java,
+	 * please see <a href=
+'../../../../../../use/parallel.html'>the users' guide</a>.
+	 *<p>
 	 * Appeared in 9.6.
 	 */
 	Parallel parallel() default Parallel.UNSAFE;

--- a/pljava-api/src/main/java/org/postgresql/pljava/annotation/Function.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/annotation/Function.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2013 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2016 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -64,6 +64,14 @@ category</a>
 	 * and run in an "untrusted" language instance.
 	 */
 	enum Trust { SANDBOXED, UNSANDBOXED };
+
+	/** 
+	 * Whether the function is unsafe to use in any parallel query plan at all,
+	 * or avoids certain operations and can appear in such a plan but must be
+	 * executed only in the parallel group leader, or avoids an even larger
+	 * set of operations and is safe to execute anywhere in a parallel plan.
+	 */
+	enum Parallel { UNSAFE, RESTRICTED, SAFE };
 
 	/**
 	 * The element type in case the annotated function returns a
@@ -138,6 +146,23 @@ category</a>
 	 * in the "untrusted" language instance.
 	 */
 	Trust trust() default Trust.SANDBOXED;
+
+	/** 
+	 * Whether the function is UNSAFE to use in any parallel query plan at all
+	 * (the default), or avoids all disqualifying operations and so is SAFE to
+	 * execute anywhere in a parallel plan, or, by avoiding some such
+	 * operations, may appear in parallel plans but RESTRICTED to execute only
+	 * on the parallel group leader. The operations that must be considered are
+	 * set out in <a href=
+'https://www.postgresql.org/docs/current/static/parallel-safety.html#PARALLEL-LABELING'
+>Parallel Labeling for Functions and Aggregates</a> in the PostgreSQL docs.
+	 * PL/Java itself can perform such operations internally; a thorough code
+	 * audit would be needed to learn when, if ever, a PL/Java function could
+	 * appropriately be declared anything but the default UNSAFE.
+	 *
+	 * Appeared in 9.6.
+	 */
+	Parallel parallel() default Parallel.UNSAFE;
 	
 	/**
 	 * Whether the function can be safely pushed inside the evaluation of views

--- a/pljava-api/src/main/java/org/postgresql/pljava/sqlgen/DDRProcessor.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/sqlgen/DDRProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2013 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2016 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -1226,6 +1226,7 @@ hunt:	for ( ExecutableElement ee : ees )
 		public Security       security() { return _security; }
 		public Effects         effects() { return _effects; }
 		public Trust             trust() { return _trust; }
+		public Parallel       parallel() { return _parallel; }
 		public boolean       leakproof() { return _leakproof; }
 		public int                cost() { return _cost; }
 		public int                rows() { return _rows; }
@@ -1243,6 +1244,7 @@ hunt:	for ( ExecutableElement ee : ees )
 		public Security    _security;
 		public Effects     _effects;
 		public Trust       _trust;
+		public Parallel    _parallel;
 		public Boolean     _leakproof;
 		int                _cost;
 		int                _rows;
@@ -1490,6 +1492,8 @@ hunt:	for ( ExecutableElement ee : ees )
 				sb.append( "\tRETURNS NULL ON NULL INPUT\n");
 			if ( Security.DEFINER.equals( security()) )
 				sb.append( "\tSECURITY DEFINER\n");
+			if ( ! Parallel.UNSAFE.equals( parallel()) )
+				sb.append( "\tPARALLEL ").append( parallel()).append( '\n');
 			if ( -1 != cost() )
 				sb.append( "\tCOST ").append( cost()).append( '\n');
 			if ( -1 != rows() )
@@ -1583,6 +1587,7 @@ hunt:	for ( ExecutableElement ee : ees )
 			_security = Security.INVOKER;
 			_effects = Effects.VOLATILE;
 			_trust = Trust.SANDBOXED;
+			_parallel = Parallel.UNSAFE;
 			_leakproof = false;
 			_settings = new String[0];
 			_triggers = new Trigger[0];

--- a/pljava-so/src/main/c/InstallHelper.c
+++ b/pljava-so/src/main/c/InstallHelper.c
@@ -65,6 +65,28 @@
 #endif
 #endif
 
+/*
+ * Before 9.3, there was no IsBackgroundWorker. As of 9.6.1 it still does not
+ * have PGDLLIMPORT, but MyBgworkerEntry != NULL can be used in MSVC instead.
+ * However, until 9.3.3, even that did not have PGDLLIMPORT, and there's not
+ * much to be done about it. BackgroundWorkerness won't be detected in MSVC
+ * for 9.3.0 through 9.3.2.
+ *
+ * One thing it's needed for is to avoid dereferencing MyProcPort in a
+ * background worker, where it's not set. Define BGW_HAS_NO_MYPROCPORT if that
+ * has to be (and can be) checked.
+ */
+#if PG_VERSION_NUM < 90300  ||  defined(_MSC_VER) && PG_VERSION_NUM < 90303
+#define IsBackgroundWorker false
+#else
+#define BGW_HAS_NO_MYPROCPORT
+#include <commands/dbcommands.h>
+#if defined(_MSC_VER)
+#include <postmaster/bgworker.h>
+#define IsBackgroundWorker (MyBgworkerEntry != NULL)
+#endif
+#endif
+
 #ifndef PLJAVA_SO_VERSION
 #error "PLJAVA_SO_VERSION needs to be defined to compile this file."
 #else
@@ -87,6 +109,7 @@ static bool extensionExNihilo = false;
 
 static void checkLoadPath( bool *livecheck);
 static void getExtensionLoadPath();
+static char *origUserName();
 
 char const *pljavaLoadPath = NULL;
 
@@ -103,7 +126,43 @@ bool pljavaViableXact()
 
 char *pljavaDbName()
 {
+#ifdef BGW_HAS_NO_MYPROCPORT
+	char *shortlived;
+	static char *longlived;
+	if ( IsBackgroundWorker )
+	{
+		if ( NULL == longlived )
+		{
+			shortlived = get_database_name(MyDatabaseId);
+			if ( NULL != shortlived )
+			{
+				longlived = MemoryContextStrdup(TopMemoryContext, shortlived);
+				pfree(shortlived);
+			}
+		}
+		return longlived;
+	}
+#endif
 	return MyProcPort->database_name;
+}
+
+static char *origUserName()
+{
+#ifdef BGW_HAS_NO_MYPROCPORT
+	char *shortlived;
+	static char *longlived;
+	if ( IsBackgroundWorker )
+	{
+		if ( NULL == longlived )
+		{
+			shortlived = GetUserNameFromId(GetAuthenticatedUserId(), false);
+			longlived = MemoryContextStrdup(TopMemoryContext, shortlived);
+			pfree(shortlived);
+		}
+		return longlived;
+	}
+#endif
+	return MyProcPort->user_name;
 }
 
 char const *pljavaClusterName()
@@ -327,6 +386,11 @@ char *pljavaFnOidToLibPath(Oid fnOid)
 	return probinstring;
 }
 
+bool InstallHelper_inBackgroundWorker()
+{
+	return IsBackgroundWorker;
+}
+
 bool InstallHelper_isPLJavaFunction(Oid fn)
 {
 	char *itsPath;
@@ -401,8 +465,8 @@ char *InstallHelper_hello()
 
 	Invocation_pushBootContext(&ctx);
 	nativeVer = String_createJavaStringFromNTS(SO_VERSION_STRING);
-	user = String_createJavaStringFromNTS(MyProcPort->user_name);
-	dbname = String_createJavaStringFromNTS(MyProcPort->database_name);
+	user = String_createJavaStringFromNTS(origUserName());
+	dbname = String_createJavaStringFromNTS(pljavaDbName());
 	if ( '\0' == *clusternameC )
 		clustername = NULL;
 	else

--- a/pljava-so/src/main/c/SPI.c
+++ b/pljava-so/src/main/c/SPI.c
@@ -1,10 +1,14 @@
 /*
- * Copyright (c) 2004, 2005, 2006 TADA AB - Taby Sweden
- * Distributed under the terms shown in the file COPYRIGHT
- * found in the root folder of this project or at
- * http://eng.tada.se/osprojects/COPYRIGHT.html
+ * Copyright (c) 2004-2016 Tada AB and other contributors, as listed below.
  *
- * @author Thomas Hallgren
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Tada AB
+ *   Chapman Flack
  */
 #include "org_postgresql_pljava_internal_SPI.h"
 #include "pljava/SPI.h"

--- a/pljava-so/src/main/c/SPI.c
+++ b/pljava-so/src/main/c/SPI.c
@@ -32,7 +32,7 @@ void SPI_initialize(void)
 		},
 		{
 		"_getProcessed",
-		"()I",
+		"()J",
 		Java_org_postgresql_pljava_internal_SPI__1getProcessed
 		},
 		{
@@ -97,12 +97,12 @@ Java_org_postgresql_pljava_internal_SPI__1exec(JNIEnv* env, jclass cls, jlong th
 /*
  * Class:     org_postgresql_pljava_internal_SPI
  * Method:    _getProcessed
- * Signature: ()I
+ * Signature: ()J
  */
-JNIEXPORT jint JNICALL
+JNIEXPORT jlong JNICALL
 Java_org_postgresql_pljava_internal_SPI__1getProcessed(JNIEnv* env, jclass cls)
 {
-	return (jint)SPI_processed;
+	return (jlong)SPI_processed;
 }
 
 /*

--- a/pljava-so/src/main/c/type/Composite.c
+++ b/pljava-so/src/main/c/type/Composite.c
@@ -133,15 +133,20 @@ static jobject _Composite_getSRFCollector(Type self, PG_FUNCTION_ARGS)
 	return tmp2;
 }
 
-static bool _Composite_hasNextSRF(Type self, jobject rowProducer, jobject rowCollector, jint callCounter)
+static bool _Composite_hasNextSRF(Type self, jobject rowProducer, jobject rowCollector, jlong callCounter)
 {
 	/* Obtain next row using the RowCollector as a parameter to the
 	 * ResultSetProvider.assignRowValues method.
 	 */
+	if ( callCounter > PG_INT32_MAX )
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("the ResultSetProvider cannot return more than "
+					"INT32_MAX rows")));
 	return (JNI_callBooleanMethod(rowProducer,
 			s_ResultSetProvider_assignRowValues,
 			rowCollector,
-			callCounter) == JNI_TRUE);
+			(jint)callCounter) == JNI_TRUE);
 }
 
 static Datum _Composite_nextSRF(Type self, jobject rowProducer, jobject rowCollector)

--- a/pljava-so/src/main/c/type/Composite.c
+++ b/pljava-so/src/main/c/type/Composite.c
@@ -1,10 +1,14 @@
 /*
- * Copyright (c) 2004, 2005, 2006 TADA AB - Taby Sweden
- * Distributed under the terms shown in the file COPYRIGHT
- * found in the root folder of this project or at
- * http://eng.tada.se/osprojects/COPYRIGHT.html
+ * Copyright (c) 2004-2016 Tada AB and other contributors, as listed below.
  *
- * @author Thomas Hallgren
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Tada AB
+ *   Chapman Flack
  */
 #include <postgres.h>
 #include <funcapi.h>

--- a/pljava-so/src/main/c/type/Portal.c
+++ b/pljava-so/src/main/c/type/Portal.c
@@ -106,7 +106,7 @@ void Portal_initialize(void)
 		},
 		{
 		"_getPortalPos",
-	  	"(J)I",
+		"(J)J",
 	  	Java_org_postgresql_pljava_internal_Portal__1getPortalPos
 		},
 		{
@@ -135,11 +135,6 @@ void Portal_initialize(void)
 	  	Java_org_postgresql_pljava_internal_Portal__1isAtStart
 		},
 		{
-		"_isPosOverflow",
-	  	"(J)Z",
-	  	Java_org_postgresql_pljava_internal_Portal__1isPosOverflow
-		},
-		{
 		"_move",
 		"(JJZJ)J",
 	  	Java_org_postgresql_pljava_internal_Portal__1move
@@ -161,17 +156,17 @@ void Portal_initialize(void)
 /*
  * Class:     org_postgresql_pljava_internal_Portal
  * Method:    _getPortalPos
- * Signature: (J)I
+ * Signature: (J)J
  */
-JNIEXPORT jint JNICALL
+JNIEXPORT jlong JNICALL
 Java_org_postgresql_pljava_internal_Portal__1getPortalPos(JNIEnv* env, jclass clazz, jlong _this)
 {
-	jint result = 0;
+	jlong result = 0;
 	if(_this != 0)
 	{
 		Ptr2Long p2l;
 		p2l.longVal = _this;
-		result = (jint)((Portal)p2l.ptrVal)->portalPos;
+		result = (jlong)((Portal)p2l.ptrVal)->portalPos;
 	}
 	return result;
 }
@@ -319,24 +314,6 @@ Java_org_postgresql_pljava_internal_Portal__1isAtEnd(JNIEnv* env, jclass clazz, 
 		Ptr2Long p2l;
 		p2l.longVal = _this;
 		result = (jboolean)((Portal)p2l.ptrVal)->atEnd;
-	}
-	return result;
-}
-
-/*
- * Class:     org_postgresql_pljava_internal_Portal
- * Method:    _isPosOverflow
- * Signature: (J)Z
- */
-JNIEXPORT jboolean JNICALL
-Java_org_postgresql_pljava_internal_Portal__1isPosOverflow(JNIEnv* env, jclass clazz, jlong _this)
-{
-	jboolean result = JNI_FALSE;
-	if(_this != 0)
-	{
-		Ptr2Long p2l;
-		p2l.longVal = _this;
-		result = (jboolean)((Portal)p2l.ptrVal)->posOverflow;
 	}
 	return result;
 }

--- a/pljava-so/src/main/c/type/Portal.c
+++ b/pljava-so/src/main/c/type/Portal.c
@@ -116,7 +116,7 @@ void Portal_initialize(void)
 		},
 		{
 		"_fetch",
-	  	"(JJZI)I",
+		"(JJZJ)J",
 	  	Java_org_postgresql_pljava_internal_Portal__1fetch
 		},
 		{
@@ -141,7 +141,7 @@ void Portal_initialize(void)
 		},
 		{
 		"_move",
-	  	"(JJZI)I",
+		"(JJZJ)J",
 	  	Java_org_postgresql_pljava_internal_Portal__1move
 		},
 		{ 0, 0, 0 }
@@ -179,12 +179,12 @@ Java_org_postgresql_pljava_internal_Portal__1getPortalPos(JNIEnv* env, jclass cl
 /*
  * Class:     org_postgresql_pljava_internal_Portal
  * Method:    _fetch
- * Signature: (JJZI)I
+ * Signature: (JJZJ)J
  */
-JNIEXPORT jint JNICALL
-Java_org_postgresql_pljava_internal_Portal__1fetch(JNIEnv* env, jclass clazz, jlong _this, jlong threadId, jboolean forward, jint count)
+JNIEXPORT jlong JNICALL
+Java_org_postgresql_pljava_internal_Portal__1fetch(JNIEnv* env, jclass clazz, jlong _this, jlong threadId, jboolean forward, jlong count)
 {
-	jint result = 0;
+	jlong result = 0;
 	if(_this != 0)
 	{
 		BEGIN_NATIVE
@@ -195,8 +195,9 @@ Java_org_postgresql_pljava_internal_Portal__1fetch(JNIEnv* env, jclass clazz, jl
 		p2l.longVal = _this;
 		PG_TRY();
 		{
-			SPI_cursor_fetch((Portal)p2l.ptrVal, forward == JNI_TRUE, (int)count);
-			result = (jint)SPI_processed;
+			SPI_cursor_fetch((Portal)p2l.ptrVal, forward == JNI_TRUE,
+				(long)count);
+			result = (jlong)SPI_processed;
 		}
 		PG_CATCH();
 		{
@@ -343,12 +344,12 @@ Java_org_postgresql_pljava_internal_Portal__1isPosOverflow(JNIEnv* env, jclass c
 /*
  * Class:     org_postgresql_pljava_internal_Portal
  * Method:    _move
- * Signature: (JJZI)I
+ * Signature: (JJZJ)J
  */
-JNIEXPORT jint JNICALL
-Java_org_postgresql_pljava_internal_Portal__1move(JNIEnv* env, jclass clazz, jlong _this, jlong threadId, jboolean forward, jint count)
+JNIEXPORT jlong JNICALL
+Java_org_postgresql_pljava_internal_Portal__1move(JNIEnv* env, jclass clazz, jlong _this, jlong threadId, jboolean forward, jlong count)
 {
-	jint result = 0;
+	jlong result = 0;
 	if(_this != 0)
 	{
 		BEGIN_NATIVE
@@ -359,8 +360,8 @@ Java_org_postgresql_pljava_internal_Portal__1move(JNIEnv* env, jclass clazz, jlo
 		p2l.longVal = _this;
 		PG_TRY();
 		{
-			SPI_cursor_move((Portal)p2l.ptrVal, forward == JNI_TRUE, (int)count);
-			result = (jint)SPI_processed;
+			SPI_cursor_move((Portal)p2l.ptrVal, forward == JNI_TRUE, (long)count);
+			result = (jlong)SPI_processed;
 		}
 		PG_CATCH();
 		{

--- a/pljava-so/src/main/c/type/Portal.c
+++ b/pljava-so/src/main/c/type/Portal.c
@@ -1,12 +1,15 @@
 /*
- * Copyright (c) 2004, 2005, 2006 TADA AB - Taby Sweden
- * Copyright (c) 2008, 2010, 2011 PostgreSQL Global Development Group
+ * Copyright (c) 2004-2016 Tada AB and other contributors, as listed below.
  *
- * Distributed under the terms shown in the file COPYRIGHT
- * found in the root folder of this project or at
- * http://wiki.tada.se/index.php?title=PLJava_License
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
  *
- * @author Thomas Hallgren
+ * Contributors:
+ *   Tada AB
+ *   PostgreSQL Global Development Group
+ *   Chapman Flack
  */
 #include <postgres.h>
 #include <commands/portalcmds.h>

--- a/pljava-so/src/main/c/type/TupleDesc.c
+++ b/pljava-so/src/main/c/type/TupleDesc.c
@@ -218,11 +218,11 @@ Java_org_postgresql_pljava_internal_TupleDesc__1formTuple(JNIEnv* env, jclass cl
 		TupleDesc self = (TupleDesc)p2l.ptrVal;
 		int    count   = self->natts;
 		Datum* values  = (Datum*)palloc(count * sizeof(Datum));
-		char*  nulls   = palloc(count);
+		bool*  nulls   = palloc(count * sizeof(bool));
 		jobject typeMap = Invocation_getTypeMap();
 
 		memset(values, 0,  count * sizeof(Datum));
-		memset(nulls, 'n', count);	/* all values null initially */
+		memset(nulls, true, count * sizeof(bool));/*all values null initially*/
 	
 		for(idx = 0; idx < count; ++idx)
 		{
@@ -231,12 +231,12 @@ Java_org_postgresql_pljava_internal_TupleDesc__1formTuple(JNIEnv* env, jclass cl
 			{
 				Type type = Type_fromOid(SPI_gettypeid(self, idx + 1), typeMap);
 				values[idx] = Type_coerceObject(type, value);
-				nulls[idx] = ' ';
+				nulls[idx] = false;
 			}
 		}
 
 		curr = MemoryContextSwitchTo(JavaMemoryContext);
-		tuple = heap_formtuple(self, values, nulls);
+		tuple = heap_form_tuple(self, values, nulls);
 		result = Tuple_internalCreate(tuple, false);
 		MemoryContextSwitchTo(curr);
 		pfree(values);

--- a/pljava-so/src/main/c/type/TupleDesc.c
+++ b/pljava-so/src/main/c/type/TupleDesc.c
@@ -1,10 +1,14 @@
 /*
- * Copyright (c) 2004, 2005, 2006 TADA AB - Taby Sweden
- * Distributed under the terms shown in the file COPYRIGHT
- * found in the root folder of this project or at
- * http://eng.tada.se/osprojects/COPYRIGHT.html
+ * Copyright (c) 2004-2016 Tada AB and other contributors, as listed below.
  *
- * @author Thomas Hallgren
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Tada AB
+ *   Chapman Flack
  */
 #include <postgres.h>
 #include <executor/spi.h>

--- a/pljava-so/src/main/c/type/TupleTable.c
+++ b/pljava-so/src/main/c/type/TupleTable.c
@@ -1,10 +1,14 @@
 /*
- * Copyright (c) 2004, 2005, 2006 TADA AB - Taby Sweden
- * Distributed under the terms shown in the file COPYRIGHT
- * found in the root folder of this project or at
- * http://eng.tada.se/osprojects/COPYRIGHT.html
+ * Copyright (c) 2004-2016 Tada AB and other contributors, as listed below.
  *
- * @author Thomas Hallgren
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Tada AB
+ *   Chapman Flack
  */
 #include <postgres.h>
 #include <executor/spi.h>

--- a/pljava-so/src/main/c/type/Type.c
+++ b/pljava-so/src/main/c/type/Type.c
@@ -1,10 +1,14 @@
 /*
- * Copyright (c) 2004, 2005, 2006 TADA AB - Taby Sweden
- * Distributed under the terms shown in the file COPYRIGHT
- * found in the root folder of this project or at
- * http://eng.tada.se/osprojects/COPYRIGHT.html
+ * Copyright (c) 2004-2016 Tada AB and other contributors, as listed below.
  *
- * @author Thomas Hallgren
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Tada AB
+ *   Chapman Flack
  */
 #include <postgres.h>
 #include <fmgr.h>

--- a/pljava-so/src/main/c/type/Type.c
+++ b/pljava-so/src/main/c/type/Type.c
@@ -415,7 +415,8 @@ Datum Type_invokeSRF(Type self, jclass cls, jmethodID method, jvalue* args, PG_F
 	currentInvocation->hasConnected = ctxData->hasConnected;
 	currentInvocation->invocation   = ctxData->invocation;
 
-	hasRow = Type_hasNextSRF(self, ctxData->rowProducer, ctxData->rowCollector, (jint)context->call_cntr);
+	hasRow = Type_hasNextSRF(self, ctxData->rowProducer, ctxData->rowCollector,
+		(jlong)context->call_cntr);
 
 	ctxData->hasConnected = currentInvocation->hasConnected;
 	ctxData->invocation   = currentInvocation->invocation;
@@ -629,7 +630,7 @@ static jobject _Type_getSRFCollector(Type self, PG_FUNCTION_ARGS)
 	return 0;
 }
 
-static bool _Type_hasNextSRF(Type self, jobject rowProducer, jobject rowCollector, jint callCounter)
+static bool _Type_hasNextSRF(Type self, jobject rowProducer, jobject rowCollector, jlong callCounter)
 {
 	return (JNI_callBooleanMethod(rowProducer, s_Iterator_hasNext) == JNI_TRUE);
 }
@@ -656,7 +657,7 @@ jobject Type_getSRFCollector(Type self, PG_FUNCTION_ARGS)
 	return self->typeClass->getSRFCollector(self, fcinfo);
 }
 
-bool Type_hasNextSRF(Type self, jobject rowProducer, jobject rowCollector, jint callCounter)
+bool Type_hasNextSRF(Type self, jobject rowProducer, jobject rowCollector, jlong callCounter)
 {
 	return self->typeClass->hasNextSRF(self, rowProducer, rowCollector, callCounter);
 }

--- a/pljava-so/src/main/include/pljava/InstallHelper.h
+++ b/pljava-so/src/main/include/pljava/InstallHelper.h
@@ -64,6 +64,8 @@ extern bool InstallHelper_isPLJavaFunction(Oid fn);
 
 /*
  * Return the name of the current database, from MyProcPort ... don't free it.
+ * In a background worker, there's no MyProcPort, and the name is found another
+ * way and strdup'd in TopMemoryContext, it'll keep, don't bother freeing it.
  */
 extern char *pljavaDbName();
 
@@ -102,6 +104,15 @@ extern char const *InstallHelper_defaultClassPath(char *);
  * recognize the ABORT_PENDING cases.
  */
 extern bool pljavaViableXact();
+
+/*
+ * Backend's initsequencer needs to know whether it's being called in a 9.3+
+ * background worker process (the init sequence has to change). That should be
+ * a simple test of IsBackgroundWorker except (wouldn't you know) for more
+ * version-specific Windows visibility issues, so the ugly details are in
+ * InstallHelper, and Backend just asks this nice function.
+ */
+extern bool InstallHelper_inBackgroundWorker();
 
 extern char *InstallHelper_hello();
 

--- a/pljava-so/src/main/include/pljava/pljava.h
+++ b/pljava-so/src/main/include/pljava/pljava.h
@@ -54,6 +54,16 @@ extern int vsnprintf(char* buf, size_t count, const char* format, va_list arg);
 #include "access/htup_details.h"
 #endif
 
+/*
+ * PG_*_{MIN,MAX} macros (which happen, conveniently, to match Java's datatypes
+ * (the signed ones, anyway), appear in PG 9.5. Could test for them directly,
+ * but explicit version conditionals may be easier to find and prune when the
+ * back-compatibility horizon passes them. Here are only the ones being used.
+ */
+#if PG_VERSION_NUM < 90500
+#define PG_INT32_MAX    (0x7FFFFFFF)
+#endif
+
 
 /* The errorOccured will be set when a call from Java into one of the
  * backend functions results in a elog that causes a longjmp (Levels >= ERROR)

--- a/pljava-so/src/main/include/pljava/pljava.h
+++ b/pljava-so/src/main/include/pljava/pljava.h
@@ -1,10 +1,14 @@
 /*
- * Copyright (c) 2004, 2005, 2006 TADA AB - Taby Sweden
- * Distributed under the terms shown in the file COPYRIGHT
- * found in the root folder of this project or at
- * http://eng.tada.se/osprojects/COPYRIGHT.html
+ * Copyright (c) 2004-2016 Tada AB and other contributors, as listed below.
  *
- * @author Thomas Hallgren
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Tada AB
+ *   Chapman Flack
  */
 #ifndef __pljava_pljava_h
 #define __pljava_pljava_h

--- a/pljava-so/src/main/include/pljava/type/Type.h
+++ b/pljava-so/src/main/include/pljava/type/Type.h
@@ -1,10 +1,14 @@
 /*
- * Copyright (c) 2004, 2005, 2006 TADA AB - Taby Sweden
- * Distributed under the terms shown in the file COPYRIGHT
- * found in the root folder of this project or at
- * http://eng.tada.se/osprojects/COPYRIGHT.html
+ * Copyright (c) 2004-2016 Tada AB and other contributors, as listed below.
  *
- * @author Thomas Hallgren
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Tada AB
+ *   Chapman Flack
  */
 #ifndef __pljava_type_Type_h
 #define __pljava_type_Type_h

--- a/pljava-so/src/main/include/pljava/type/Type.h
+++ b/pljava-so/src/main/include/pljava/type/Type.h
@@ -215,7 +215,7 @@ extern jobject Type_getSRFCollector(Type self, PG_FUNCTION_ARGS);
 /*
  * Called to determine if the producer will produce another row.
  */
-extern bool Type_hasNextSRF(Type self, jobject producer, jobject collector, jint counter);
+extern bool Type_hasNextSRF(Type self, jobject producer, jobject collector, jlong counter);
 
 /*
  * Converts the next row into a Datum of the expected type.

--- a/pljava-so/src/main/include/pljava/type/Type_priv.h
+++ b/pljava-so/src/main/include/pljava/type/Type_priv.h
@@ -102,7 +102,7 @@ struct TypeClass_
 
 	jobject (*getSRFProducer)(Type self, jclass clazz, jmethodID method, jvalue* args);
 	jobject (*getSRFCollector)(Type self, PG_FUNCTION_ARGS);
-	bool (*hasNextSRF)(Type self, jobject producer, jobject collector, jint counter);
+	bool (*hasNextSRF)(Type self, jobject producer, jobject collector, jlong counter);
 	Datum (*nextSRF)(Type self, jobject producer, jobject collector);
 	void (*closeSRF)(Type self, jobject producer);
 	const char* (*getJNISignature)(Type self);

--- a/pljava-so/src/main/include/pljava/type/Type_priv.h
+++ b/pljava-so/src/main/include/pljava/type/Type_priv.h
@@ -1,10 +1,14 @@
 /*
- * Copyright (c) 2004, 2005, 2006 TADA AB - Taby Sweden
- * Distributed under the terms shown in the file COPYRIGHT
- * found in the root folder of this project or at
- * http://eng.tada.se/osprojects/COPYRIGHT.html
+ * Copyright (c) 2004-2016 Tada AB and other contributors, as listed below.
  *
- * @author Thomas Hallgren
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Tada AB
+ *   Chapman Flack
  */
 #ifndef __pljava_type_Type_priv_h
 #define __pljava_type_Type_priv_h

--- a/pljava/src/main/java/org/postgresql/pljava/internal/Portal.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/Portal.java
@@ -1,8 +1,14 @@
 /*
- * Copyright (c) 2004, 2005, 2006 TADA AB - Taby Sweden
- * Distributed under the terms shown in the file COPYRIGHT
- * found in the root folder of this project or at
- * http://eng.tada.se/osprojects/COPYRIGHT.html
+ * Copyright (c) 2004-2016 Tada AB and other contributors, as listed below.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Tada AB
+ *   Chapman Flack
  */
 package org.postgresql.pljava.internal;
 

--- a/pljava/src/main/java/org/postgresql/pljava/internal/Portal.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/Portal.java
@@ -83,12 +83,19 @@ public class Portal
 	 * @return The actual number of fetched rows.
 	 * @throws SQLException if the handle to the native structur is stale.
 	 */
-	public int fetch(boolean forward, int count)
+	public long fetch(boolean forward, long count)
 	throws SQLException
 	{
 		synchronized(Backend.THREADLOCK)
 		{
-			return _fetch(m_pointer, System.identityHashCode(Thread.currentThread()), forward, count);
+			long fetched =
+				_fetch(m_pointer,
+					System.identityHashCode(Thread.currentThread()),
+					forward, count);
+			if ( fetched < 0 )
+				throw new ArithmeticException(
+					"fetched too many rows to report in a Java signed long");
+			return fetched;
 		}
 	}
 
@@ -145,15 +152,21 @@ public class Portal
 	 * Performs an <code>SPI_cursor_move</code>.
 	 * @param forward Set to <code>true</code> for forward, <code>false</code> for backward.
 	 * @param count Maximum number of rows to fetch.
-	 * @return The value of the global variable <code>SPI_result</code>.
+	 * @return The actual number of rows moved.
 	 * @throws SQLException if the handle to the native structur is stale.
 	 */
-	public int move(boolean forward, int count)
+	public long move(boolean forward, long count)
 	throws SQLException
 	{
 		synchronized(Backend.THREADLOCK)
 		{
-			return _move(m_pointer, System.identityHashCode(Thread.currentThread()), forward, count);
+			long moved = _move(m_pointer,
+				System.identityHashCode(Thread.currentThread()),
+				forward, count);
+			if ( moved < 0 )
+				throw new ArithmeticException(
+					"moved too many rows to report in a Java signed long");
+			return moved;
 		}
 	}
 
@@ -166,7 +179,7 @@ public class Portal
 	private static native TupleDesc _getTupleDesc(long pointer)
 	throws SQLException;
 
-	private static native int _fetch(long pointer, long threadId, boolean forward, int count)
+	private static native long _fetch(long pointer, long threadId, boolean forward, long count)
 	throws SQLException;
 
 	private static native void _close(long pointer);
@@ -180,6 +193,6 @@ public class Portal
 	private static native boolean _isPosOverflow(long pointer)
 	throws SQLException;
 
-	private static native int _move(long pointer, long threadId, boolean forward, int count)
+	private static native long _move(long pointer, long threadId, boolean forward, long count)
 	throws SQLException;
 }

--- a/pljava/src/main/java/org/postgresql/pljava/internal/Portal.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/Portal.java
@@ -53,12 +53,17 @@ public class Portal
 	 * Returns the value of the <code>portalPos</code> attribute.
 	 * @throws SQLException if the handle to the native structur is stale.
 	 */
-	public int getPortalPos()
+	public long getPortalPos()
 	throws SQLException
 	{
 		synchronized(Backend.THREADLOCK)
 		{
-			return _getPortalPos(m_pointer);
+			long pos = _getPortalPos(m_pointer);
+			if ( pos < 0 )
+				throw new ArithmeticException(
+					"portal position too large to report " +
+					"in a Java signed long");
+			return pos;
 		}
 	}
 
@@ -126,19 +131,6 @@ public class Portal
 	}
 
 	/**
-	 * Returns the value of the <code>posOverflow</code> attribute.
-	 * @throws SQLException if the handle to the native structur is stale.
-	 */
-	public boolean isPosOverflow()
-	throws SQLException
-	{
-		synchronized(Backend.THREADLOCK)
-		{
-			return _isPosOverflow(m_pointer);
-		}
-	}
-
-	/**
 	 * Checks if the portal is still active. I can be closed either explicitly
 	 * using the {@link #close()} mehtod or implicitly due to a pop of invocation
 	 * context.
@@ -173,7 +165,7 @@ public class Portal
 	private static native String _getName(long pointer)
 	throws SQLException;
 
-	private static native int _getPortalPos(long pointer)
+	private static native long _getPortalPos(long pointer)
 	throws SQLException;
 
 	private static native TupleDesc _getTupleDesc(long pointer)
@@ -188,9 +180,6 @@ public class Portal
 	throws SQLException;
 
 	private static native boolean _isAtStart(long pointer)
-	throws SQLException;
-	
-	private static native boolean _isPosOverflow(long pointer)
 	throws SQLException;
 
 	private static native long _move(long pointer, long threadId, boolean forward, long count)

--- a/pljava/src/main/java/org/postgresql/pljava/internal/SPI.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/SPI.java
@@ -1,8 +1,14 @@
 /*
- * Copyright (c) 2004, 2005, 2006 TADA AB - Taby Sweden
- * Distributed under the terms shown in the file COPYRIGHT
- * found in the root folder of this project or at
- * http://eng.tada.se/osprojects/COPYRIGHT.html
+ * Copyright (c) 2004-2016 Tada AB and other contributors, as listed below.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Tada AB
+ *   Chapman Flack
  */
 package org.postgresql.pljava.internal;
 

--- a/pljava/src/main/java/org/postgresql/pljava/internal/SPI.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/SPI.java
@@ -64,11 +64,15 @@ public class SPI
 	/**
 	 * Returns the value of the global variable <code>SPI_processed</code>.
 	 */
-	public static int getProcessed()
+	public static long getProcessed()
 	{
 		synchronized(Backend.THREADLOCK)
 		{
-			return _getProcessed();
+			long count = _getProcessed();
+			if ( count < 0 )
+				throw new ArithmeticException(
+					"too many rows processed to count in a Java signed long");
+			return count;
 		}
 	}
 
@@ -172,7 +176,7 @@ public class SPI
 	}
 
 	private native static int _exec(long threadId, String command, int rowCount);
-	private native static int _getProcessed();
+	private native static long _getProcessed();
 	private native static int _getResult();
 	private native static void _freeTupTable();
 	private native static TupleTable _getTupTable(TupleDesc known);

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/SPIPreparedStatement.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/SPIPreparedStatement.java
@@ -389,10 +389,10 @@ public class SPIPreparedStatement extends SPIStatement implements PreparedStatem
 		return new SPIParameterMetaData(this.getSqlTypes());
 	}
 
-	protected int executeBatchEntry(Object batchEntry)
+	protected long executeBatchEntry(Object batchEntry)
 	throws SQLException
 	{
-		int ret = SUCCESS_NO_INFO;
+		long ret = SUCCESS_NO_INFO;
 		Object batchParams[] = (Object[])batchEntry;
 		Object batchValues = batchParams[0];
 		Object batchSqlTypes = batchParams[1];
@@ -422,7 +422,7 @@ public class SPIPreparedStatement extends SPIStatement implements PreparedStatem
 			this.getResultSet().close();
 		else
 		{
-			int updCount = this.getUpdateCount();
+			long updCount = this.getUpdateCount();
 			if(updCount >= 0)
 				ret = updCount;
 		}

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/SPIPreparedStatement.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/SPIPreparedStatement.java
@@ -1,10 +1,15 @@
 /*
- * Copyright (c) 2004, 2005, 2006 TADA AB - Taby Sweden
- * Copyright (c) 2007, 2010, 2011 PostgreSQL Global Development Group
+ * Copyright (c) 2004-2016 Tada AB and other contributors, as listed below.
  *
- * Distributed under the terms shown in the file COPYRIGHT
- * found in the root folder of this project or at
- * http://wiki.tada.se/index.php?title=PLJava_License
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Tada AB
+ *   PostgreSQL Global Development Group
+ *   Chapman Flack
  */
 package org.postgresql.pljava.jdbc;
 

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/SPIResultSet.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/SPIResultSet.java
@@ -1,8 +1,14 @@
 /*
- * Copyright (c) 2004, 2005, 2006 TADA AB - Taby Sweden
- * Distributed under the terms shown in the file COPYRIGHT
- * found in the root folder of this project or at
- * http://eng.tada.se/osprojects/COPYRIGHT.html
+ * Copyright (c) 2004-2016 Tada AB and other contributors, as listed below.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Tada AB
+ *   Chapman Flack
  */
 package org.postgresql.pljava.jdbc;
 

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/SPIResultSet.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/SPIResultSet.java
@@ -29,7 +29,7 @@ public class SPIResultSet extends ResultSetBase
 	private final SPIStatement m_statement;
 	private final Portal    m_portal;
 	private final TupleDesc m_tupleDesc;
-	private final int       m_maxRows;
+	private final long      m_maxRows;
 
 	private Tuple m_currentRow;
 	private Tuple m_nextRow;
@@ -37,7 +37,7 @@ public class SPIResultSet extends ResultSetBase
 	private TupleTable m_table;
 	private int m_tableRow;
 
-	SPIResultSet(SPIStatement statement, Portal portal, int maxRows)
+	SPIResultSet(SPIStatement statement, Portal portal, long maxRows)
 	throws SQLException
 	{
 		super(statement.getFetchSize());
@@ -119,7 +119,7 @@ public class SPIResultSet extends ResultSetBase
 			if(portal.isAtEnd())
 				return null;
 
-			int mx;
+			long mx;
 			int fetchSize = this.getFetchSize();
 			if(m_maxRows > 0)
 			{
@@ -134,7 +134,7 @@ public class SPIResultSet extends ResultSetBase
 
 			try
 			{
-				int result = portal.fetch(true, mx);
+				long result = portal.fetch(true, mx);
 				if(result > 0)
 					m_table = SPI.getTupTable(m_tupleDesc);
 				m_tableRow = -1;

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/SPIStatement.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/SPIStatement.java
@@ -35,7 +35,7 @@ public class SPIStatement implements Statement
 	private int       m_fetchSize      = 1000;
 	private int       m_maxRows        = 0;
 	private ResultSet m_resultSet      = null;
-	private int       m_updateCount    = 0;
+	private long      m_updateCount    = 0;
 	private ArrayList m_batch          = null;
 	private boolean   m_closed         = false;
 
@@ -179,7 +179,23 @@ public class SPIStatement implements Statement
 		int numBatches = (m_batch == null) ? 0 : m_batch.size();
 		int[] result = new int[numBatches];
 		for(int idx = 0; idx < numBatches; ++idx)
+		{
+			long count = this.executeBatchEntry(m_batch.get(idx));
+			result[idx] = (count > Integer.MAX_VALUE)
+				? SUCCESS_NO_INFO : (int)count;
+		}
+		return result;
+	}
+
+	public long[] executeLargeBatch()
+	throws SQLException
+	{
+		int numBatches = (m_batch == null) ? 0 : m_batch.size();
+		long[] result = new long[numBatches];
+		for(int idx = 0; idx < numBatches; ++idx)
+		{
 			result[idx] = this.executeBatchEntry(m_batch.get(idx));
+		}
 		return result;
 	}
 
@@ -314,6 +330,15 @@ public class SPIStatement implements Statement
 	public int getUpdateCount()
 	throws SQLException
 	{
+		if ( m_updateCount > Integer.MAX_VALUE )
+			throw new ArithmeticException(
+				"too many rows updated to report in a Java signed int");
+		return (int)m_updateCount;
+	}
+
+	public long getLargeUpdateCount()
+	throws SQLException
+	{
 		return m_updateCount;
 	}
 
@@ -384,10 +409,10 @@ public class SPIStatement implements Statement
 		m_batch.add(batch);
 	}
 
-	protected int executeBatchEntry(Object batchEntry)
+	protected long executeBatchEntry(Object batchEntry)
 	throws SQLException
 	{
-		int ret = SUCCESS_NO_INFO;
+		long ret = SUCCESS_NO_INFO;
 		if(this.execute(m_connection.nativeSQL((String)batchEntry)))
 			this.getResultSet().close();
 		else if(m_updateCount >= 0)

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/SPIStatement.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/SPIStatement.java
@@ -1,10 +1,15 @@
 /*
- * Copyright (c) 2004, 2005, 2006 TADA AB - Taby Sweden
- * Copyright (c) 2008, 2010, 2011 PostgreSQL Global Development Group
+ * Copyright (c) 2004-2016 Tada AB and other contributors, as listed below.
  *
- * Distributed under the terms shown in the file COPYRIGHT
- * found in the root folder of this project or at
- * http://wiki.tada.se/index.php?title=PLJava_License
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Tada AB
+ *   PostgreSQL Global Development Group
+ *   Chapman Flack
  */
 package org.postgresql.pljava.jdbc;
 

--- a/src/site/markdown/use/parallel.md
+++ b/src/site/markdown/use/parallel.md
@@ -1,8 +1,9 @@
 # PL/Java in parallel query or background worker
 
-PL/Java can be used in some [background worker processes][bgworker] as
-introduced in PostgreSQL 9.3, and in [parallel queries][parq], from
-PostgreSQL 9.6, with some restrictions.
+With some restrictions, PL/Java can be used in [parallel queries][parq], from
+PostgreSQL 9.6, and in some [background worker processes][bgworker] (as
+introduced in PostgreSQL 9.3, though 9.5 or later is needed for support
+in PL/Java).
 
 [bgworker]: https://www.postgresql.org/docs/current/static/bgworker.html
 [parq]: https://www.postgresql.org/docs/current/static/parallel-query.html

--- a/src/site/markdown/use/parallel.md
+++ b/src/site/markdown/use/parallel.md
@@ -1,0 +1,82 @@
+# PL/Java in parallel query or background worker
+
+PL/Java can be used in some [background worker processes][bgworker] as
+introduced in PostgreSQL 9.3, and in [parallel queries][parq], from
+PostgreSQL 9.6, with some restrictions.
+
+[bgworker]: https://www.postgresql.org/docs/current/static/bgworker.html
+[parq]: https://www.postgresql.org/docs/current/static/parallel-query.html
+
+## Background worker processes
+
+Because PL/Java requires access to a database containing the `sqlj` schema,
+PL/Java is only usable in a worker process that initializes a database
+connection, which must happen before the first use of any function that
+depends on PL/Java.
+
+## Parallel queries
+
+Like any user-defined function, a PL/Java function can be
+[annotated][paranno] with a level of "parallel safety", `UNSAFE` by default.
+
+When a function labeled `UNSAFE` is used in a query, the query cannot be
+parallelized at all. If a query contains a function labeled `RESTRICTED`, parts
+of the query may execute in parallel, but the part that calls the `RESTRICTED`
+function will be executed only in the lead process. A function labeled `SAFE`
+may be executed in every process participating in the query.
+
+[paranno]: ../pljava-api/apidocs/index.html?org/postgresql/pljava/annotation/Function.html#parallel()
+
+### Parallel setup cost
+
+PostgreSQL parallel query processing uses multiple operating-system processes,
+and these processes are new for each parallel query. If a PL/Java function is
+labeled `PARALLEL SAFE` and is pushed by the query planner to run in the
+parallel worker processes, each new process will start a Java virtual machine.
+The cost of doing so will reduce the expected advantage of parallel execution.
+
+To inform the query planner of this trade-off, the value of the PostgreSQL
+configuration variable [`parallel_setup_cost`][parsetcost] should be increased.
+The startup cost can be minimized with attention to the
+[PL/Java VM option recommendations][vmopt], including class data sharing.
+
+[parsetcost]: https://www.postgresql.org/docs/current/static/runtime-config-query.html#GUC-PARALLEL-SETUP-COST
+[vmopt]: ../install/vmoptions.html
+
+### Limits on `RESTRICTED`/`SAFE` function behavior
+
+There are stringent limits on what a function labeled `RESTRICTED` may do,
+and even more stringent limits on what may be done in a function labeled `SAFE`.
+The PostgreSQL manual describes the limits in the section
+[Parallel Labeling for Functions and Aggregates][parlab].
+
+[parlab]: https://www.postgresql.org/docs/current/static/parallel-safety.html#PARALLEL-LABELING
+
+While PostgreSQL does check for some inappropriate operations from a
+`PARALLEL SAFE` or `RESTRICTED` function, for the most part it relies on
+functions being labeled correctly. When in doubt, the conservative approach
+is to label a function `UNSAFE`, which can't go wrong. A function mistakenly
+labeled `RESTRICTED` or `SAFE` could produce unpredictable results.
+
+#### Internal workings of PL/Java
+
+While a given PL/Java function itself may clearly qualify as `RESTRICTED` or
+`SAFE` by inspection, there may still be cases where a forbidden operation
+results from the internal workings of PL/Java itself. This has not been seen
+in testing (simple parallel queries with `RESTRICTED` or `SAFE` PL/Java
+functions work fine), but to rule out the possibility would require a careful
+audit of PL/Java's code. Until then, it would be prudent for any application
+involving parallel query with `RESTRICTED` or `SAFE` PL/Java functions
+to be first tested in a non-production environment.
+
+### Further reading
+
+A [Parallel query and PL/Java][pqwiki] page on the PL/Java wiki is provided
+to collect experience and tips regarding this significant new capability
+that may be gathered in between updates to this documentation.
+
+[README.parallel][rmp] in the PostgreSQL source, for more detail on why parallel
+query works the way it does.
+
+[rmp]: https://git.postgresql.org/gitweb/?p=postgresql.git;a=blob;f=src/backend/access/transam/README.parallel
+[pqwiki]: https://github.com/tada/pljava/wiki/Parallel-query-and-PLJava

--- a/src/site/markdown/use/use.md
+++ b/src/site/markdown/use/use.md
@@ -35,6 +35,17 @@ internal PL/Java classes that may change from release to release.
 
 ## Special topics
 
+### Parallel query
+
+PostgreSQL 9.3 introduced [background worker processes][bgworker],
+and PostgreSQL 9.6 introduced [parallel query][parq].
+
+For details on PL/Java in a background worker or parallel query, see
+[PL/Java in parallel query](parallel.html).
+
+[bgworker]: https://www.postgresql.org/docs/current/static/bgworker.html
+[parq]: https://www.postgresql.org/docs/current/static/parallel-query.html
+
 ### Character-set encodings
 
 PL/Java will work most seamlessly when the server encoding in PostgreSQL is

--- a/src/site/markdown/use/use.md
+++ b/src/site/markdown/use/use.md
@@ -37,7 +37,8 @@ internal PL/Java classes that may change from release to release.
 
 ### Parallel query
 
-PostgreSQL 9.3 introduced [background worker processes][bgworker],
+PostgreSQL 9.3 introduced [background worker processes][bgworker]
+(though at least PostgreSQL 9.5 is needed for support in PL/Java),
 and PostgreSQL 9.6 introduced [parallel query][parq].
 
 For details on PL/Java in a background worker or parallel query, see


### PR DESCRIPTION
Catch up with various changes in PostgreSQL 9.6, including the widening to 64 bits of various things related to row counts, the consequent demise of `Portal`'s `posOverflow` flag, and the final removal of `heap_formtuple` (which was deprecated for a long time, with the preferred alternative already present back at least as far as 8.2).

PL/Java can now be used in PostgreSQL 9.6 parallel queries (and for other purposes in background worker processes, which were introduced in 9.3, but only supported from 9.5 on in PL/Java).

A [wiki page](https://github.com/tada/pljava/wiki/Parallel-query-and-PLJava) has been added about the parallel capabilities.

Should resolve #108.
