### PR TITLE
Bug/rel1 5 stable/pg upgrade

### DIFF
--- a/pljava-so/src/main/c/InstallHelper.c
+++ b/pljava-so/src/main/c/InstallHelper.c
@@ -66,6 +66,16 @@
 #endif
 
 /*
+ * Before 9.1, there was no IsBinaryUpgrade. Before 9.5, it did not have
+ * PGDLLIMPORT and so was not visible in Windows. In either case, just define
+ * it to be false; Windows users may have trouble using pg_upgrade to versions
+ * earlier than 9.5, but with the current version being 9.6 that should be rare.
+ */
+#if PG_VERSION_NUM < 90100 || defined(_MSC_VER) && PG_VERSION_NUM < 90500
+#define IsBinaryUpgrade false
+#endif
+
+/*
  * Before 9.3, there was no IsBackgroundWorker. As of 9.6.1 it still does not
  * have PGDLLIMPORT, but MyBgworkerEntry != NULL can be used in MSVC instead.
  * However, until 9.3.3, even that did not have PGDLLIMPORT, and there's not
@@ -395,9 +405,9 @@ char *pljavaFnOidToLibPath(Oid fnOid)
 	return probinstring;
 }
 
-bool InstallHelper_inBackgroundWorker()
+bool InstallHelper_shouldDeferInit()
 {
-	return IsBackgroundWorker;
+	return IsBackgroundWorker || IsBinaryUpgrade;
 }
 
 bool InstallHelper_isPLJavaFunction(Oid fn)

--- a/pljava-so/src/main/include/pljava/InstallHelper.h
+++ b/pljava-so/src/main/include/pljava/InstallHelper.h
@@ -107,12 +107,13 @@ extern bool pljavaViableXact();
 
 /*
  * Backend's initsequencer needs to know whether it's being called in a 9.3+
- * background worker process (the init sequence has to change). That should be
- * a simple test of IsBackgroundWorker except (wouldn't you know) for more
+ * background worker process, or during a pg_upgrade (in either case, the
+ * init sequence needs to be lazier). Those should both be simple tests of
+ * IsBackgroundWorker or IsBinaryUpgrade, except (wouldn't you know) for more
  * version-specific Windows visibility issues, so the ugly details are in
  * InstallHelper, and Backend just asks this nice function.
  */
-extern bool InstallHelper_inBackgroundWorker();
+extern bool InstallHelper_shouldDeferInit();
 
 extern char *InstallHelper_hello();
 

--- a/src/site/markdown/install/install.md.vm
+++ b/src/site/markdown/install/install.md.vm
@@ -143,7 +143,7 @@ things right on the first try, you might set them after, too.) For example:
 
 [sqjij]: https://github.com/tada/pljava/wiki/SQL-functions
 
-Those two are not the only PL/Java configuration variables there are,
+Those three are not the only PL/Java configuration variables there are,
 but it is unlikely you would have to change any others before installation
 succeeds. For the rest, there is a [configuration variable reference][varref]
 page.
@@ -195,42 +195,10 @@ PL/Java performs an upgrade installation if there is already an `sqlj` schema
 with tables that match a known PL/Java schema from version 1.3.0 or later. It
 will convert, preserving data, to the current schema if necessary.
 
-*Remember that PL/Java runs independently
-in each database session where it is in use. Older PL/Java versions active in
-other sessions can be disrupted by the schema change.*
+A database cluster using PL/Java can be binary-upgraded using `pg_upgrade`
+when certain requirements are met.
 
-A trial installation of a PL/Java update can be done in a transaction, and
-rolled back if desired, leaving the schema as it was. Any concurrent sessions
-with active older PL/Java versions will not be disrupted by the altered schema
-as long as the transaction remains open, *but they may block for the duration,
-so whatever testing will be done within the transaction should be done quickly
-if that could be an issue*.
-
-$h3 Upgrading, outside the extension framework
-
-On PostgreSQL pre-9.1, or whenever PL/Java has not been installed
-with `CREATE EXTENSION`, it can be updated with a `LOAD` command just
-as in a fresh installation. This must be done in a fresh session (in
-which nothing has caused PL/Java to load since establishing the connection).
-
-$h3 Upgrading, within the extension framework
-
-On PostgreSQL 9.1 or later where PL/Java has been installed with
-`CREATE EXTENSION`, it can be updated with
-[`ALTER EXTENSION pljava UPDATE`][aeu], as long as
-`SELECT * FROM pg_extension_update_paths('pljava')` shows a one-step path
-from the version currently installed to the version desired.
-
-[aeu]: http://www.postgresql.org/docs/current/static/sql-alterextension.html
-
-As with the `LOAD` method, an `ALTER EXTENSION ... UPDATE` must be done
-in a fresh session, before anything has loaded PL/Java; this also precludes
-an update with a multi-step path in a single command, but the intent is to
-always provide a one-step path between _released_ versions.
-
-If you will be following development (`SNAPSHOT`) versions, the installation
-method using `LOAD` may be simpler, as updates between snapshots with the
-same version string make no sense to the extension framework.
+For more on both procedures, see [Upgrading](upgrade.html).
 
 $h2 Usage permission
 

--- a/src/site/markdown/install/upgrade.md
+++ b/src/site/markdown/install/upgrade.md
@@ -1,0 +1,95 @@
+# Upgrading
+
+## Upgrading the PL/Java version in a database
+
+PL/Java performs an upgrade installation if there is already an `sqlj` schema
+with tables that match a known PL/Java schema from version 1.3.0 or later. It
+will convert, preserving data, to the current schema if necessary.
+
+*Remember that PL/Java runs independently
+in each database session where it is in use. Older PL/Java versions active in
+other sessions can be disrupted by the schema change.*
+
+A trial installation of a PL/Java update can be done in a transaction, and
+rolled back if desired, leaving the schema as it was. Any concurrent sessions
+with active older PL/Java versions will not be disrupted by the altered schema
+as long as the transaction remains open, *but they may block for the duration,
+so whatever testing will be done within the transaction should be done quickly
+if that could be an issue*.
+
+### Upgrading, outside the extension framework
+
+On PostgreSQL pre-9.1, or whenever PL/Java has not been installed
+with `CREATE EXTENSION`, it can be updated with a `LOAD` command just
+as in a fresh installation. This must be done in a fresh session (in
+which nothing has caused PL/Java to load since establishing the connection).
+
+### Upgrading, within the extension framework
+
+On PostgreSQL 9.1 or later where PL/Java has been installed with
+`CREATE EXTENSION`, it can be updated with
+[`ALTER EXTENSION pljava UPDATE`][aeu], as long as
+`SELECT * FROM pg_extension_update_paths('pljava')` shows a one-step path
+from the version currently installed to the version desired.
+
+[aeu]: http://www.postgresql.org/docs/current/static/sql-alterextension.html
+
+As with the `LOAD` method, an `ALTER EXTENSION ... UPDATE` must be done
+in a fresh session, before anything has loaded PL/Java; this also precludes
+an update with a multi-step path in a single command, but the intent is to
+always provide a one-step path between _released_ versions.
+
+If you will be following development (`SNAPSHOT`) versions, the installation
+method using `LOAD` may be simpler, as updates between snapshots with the
+same version string make no sense to the extension framework.
+
+## Upgrading the PostgreSQL major version with PL/Java in use
+
+### Binary upgrading with `pg_upgrade`
+
+Using the [`pg_upgrade`][pgu] tool [contributed to PostgreSQL in 9.0][pguc],
+an entire PostgreSQL cluster can be upgraded to a later major version in a
+more direct process than the dump to SQL and reload formerly required.
+The binary upgrade is possible as long as the cluster and databases meet
+certain requirements, which should be studied in the
+[`pg_upgrade` manual page][pgu] version for the PostgreSQL release being
+upgraded *to*.
+
+PL/Java adds a few additional considerations:
+
+* `pg_upgrade` will check in advance that every loadable module used in
+    the old cluster can be loaded in the new cluster, but the schema and
+    data will be copied over by `pg_upgrade` itself. That means that a
+    PL/Java build for the new PostgreSQL version must be *installed in
+    the directory structure* for the new cluster before running `pg_upgrade`,
+    but *not* installed into any databases (the new cluster should not have
+    had any non-system objects created yet).
+
+* In the steps of [Installing PL/Java](install.html), that means that the
+    self-extracting `java -jar ...` command must have been run (or the
+    equivalent package-installation command, if you are getting PL/Java
+    through a packaging system for your OS), but no `CREATE EXTENSION` or
+    `LOAD` command should have been run to configure it in any database.  If
+    using the extracting jar, to be sure of installing it to the right cluster,
+    add `-Dpgconfig=`*pgconfigpath* at the end, where *pgconfigpath* is the
+    full path to the *new* cluster's `pg_config` executable.
+
+* PL/Java releases before 1.5.1 were not aware of `pg_upgrade` operation.
+    To avoid possible errors during the upgrade involving OID or object
+    clashes, the PL/Java release installed for the new cluster should be
+    1.5.1 or later.
+
+* When `pg_upgrade` tests that all needed modules are present, it expects
+    the names to match. The PL/Java module name includes the PL/Java version,
+    so the versions installed in the old and new clusters should be the same.
+    Given that 1.5.1 or later should be installed in the new cluster,
+    if any databases in the old cluster are using an older PL/Java version,
+    PL/Java should be upgraded in each (as described at the top of this page)
+    before running `pg_upgrade`. To be sure of installing a newer PL/Java
+    build into the old cluster, if using the extracting jar, add
+    `-Dpgconfig=`*oldpgconfigpath* at the end of the `java -jar ...` command
+    line, with *oldpgconfigpath* the full path to the old cluster's `pg_config`
+    executable.
+
+[pgu]: https://www.postgresql.org/docs/current/static/pgupgrade.html
+[pguc]: https://www.postgresql.org/docs/9.0/static/release-9-0.html#AEN103668

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -24,6 +24,8 @@
 			 href='build/build.html'/>
 			<item name='Installing into PostgreSQL'
 			 href='install/install.html'/>
+			<item name='Upgrading'
+			 href='install/upgrade.html'/>
 			<item name='User guide'
 			 href='use/use.html'/>
 			<item name='Developer notes'


### PR DESCRIPTION
As reported in #117, PL/Java's self-installing behavior steps on the toes of `pg_upgrade`. It is explicitly caught by a check Bruce Momjian added to `pg_upgrade` [for PG 9.5][upchk], but even if an earlier PG version doesn't catch it, it still could cause OID and duplicate-object clashes, and PL/Java should refrain from doing it when a `pg_upgrade` is in progress.

This is also a good opportunity to expand the doc of upgrade procedures to a whole page of its own.

Will take care of #117 when released.

[upchk]: https://git.postgresql.org/gitweb/?p=postgresql.git;a=blobdiff;f=src/backend/catalog/heap.c;h=c346edac93be55889e8fe18398579be551ce0f5f;hp=33eef9f1caffcfbcd178140047d1ef64abb5145c;hb=a7ae1dcf4939cf643c5abe8dd673e4b87a6efd42;hpb=73fe87503f23144a27f0bdecc55587deb5aa425f