### PR TITLE
Changes to accommodate PostgreSQL 10.

### DIFF
--- a/pljava-so/build.xml
+++ b/pljava-so/build.xml
@@ -63,7 +63,7 @@
 					<replaceregex pattern="devel.*|alpha.*|beta.*|rc.*$"
 						replace="\.99" flags="si" />
 					<containsregex
-						pattern="^[^\d]*+(\d++)\.(\d++)\.(\d++).*$"
+						pattern="^[^\d]*+(\d++)\.(\d++)(?:\.(\d++))?.*$"
 						replace="pg\1.\2" />
 				</tokenfilter>
 			</filterchain>

--- a/pljava-so/src/main/c/Backend.c
+++ b/pljava-so/src/main/c/Backend.c
@@ -106,7 +106,10 @@ static bool  pljavaEnabled;
 static bool  s_currentTrust;
 static int   s_javaLogLevel;
 
+#if PG_VERSION_NUM < 100000
 bool integerDateTimes = false;
+static void checkIntTimeType(void);
+#endif
 
 extern void Invocation_initialize(void);
 extern void Exception_initialize(void);
@@ -138,7 +141,6 @@ static void JVMOptList_delete(JVMOptList*);
 static void JVMOptList_add(JVMOptList*, const char*, void*, bool);
 static void JVMOptList_addVisualVMName(JVMOptList*);
 static void addUserJVMOptions(JVMOptList*);
-static void checkIntTimeType(void);
 static char* getClassPath(const char*);
 static jint JNICALL my_vfprintf(FILE*, const char*, va_list);
 static void _destroyJavaVM(int, Datum);
@@ -478,7 +480,9 @@ static void initsequencer(enum initstage is, bool tolerant)
 
 	case IS_CREATEVM_SYM_FOUND:
 		s_javaLogLevel = INFO;
+#if PG_VERSION_NUM < 100000
 		checkIntTimeType();
+#endif
 		HashMap_initialize(); /* creates things in TopMemoryContext */
 #ifdef PLJAVA_DEBUG
 		/* Hard setting for debug. Don't forget to recompile...
@@ -1264,6 +1268,7 @@ static void initJavaSession(void)
 	}
 }
 
+#if PG_VERSION_NUM < 100000
 static void checkIntTimeType(void)
 {
 	const char* idt = PG_GETCONFIGOPTION("integer_datetimes");
@@ -1271,6 +1276,7 @@ static void checkIntTimeType(void)
 	integerDateTimes = (strcmp(idt, "on") == 0);
 	elog(DEBUG2, integerDateTimes ? "Using integer_datetimes" : "Not using integer_datetimes");
 }
+#endif
 
 static jint initializeJavaVM(JVMOptList *optList)
 {

--- a/pljava-so/src/main/c/Function.c
+++ b/pljava-so/src/main/c/Function.c
@@ -838,11 +838,15 @@ Datum Function_invokeTrigger(Function self, PG_FUNCTION_ARGS)
 	jvalue arg;
 	Datum  ret;
 
-	arg.l = TriggerData_create((TriggerData*)fcinfo->context);
+	TriggerData *td = (TriggerData*)fcinfo->context;
+	arg.l = TriggerData_create(td);
 	if(arg.l == 0)
 		return 0;
 
 	currentInvocation->function = self;
+#if PG_VERSION_NUM >= 100000
+	currentInvocation->triggerData = td;
+#endif
 	Type_invoke(self->func.nonudt.returnType, self->clazz, self->func.nonudt.method, &arg, fcinfo);
 
 	fcinfo->isnull = false;

--- a/pljava-so/src/main/include/pljava/Backend.h
+++ b/pljava-so/src/main/include/pljava/Backend.h
@@ -21,7 +21,9 @@ extern "C" {
  * 
  * @author Thomas Hallgren
  *****************************************************************/
+#if PG_VERSION_NUM < 100000
 extern bool integerDateTimes;
+#endif
 
 void Backend_setJavaSecurity(bool trusted);
 

--- a/pljava-so/src/main/include/pljava/Invocation.h
+++ b/pljava-so/src/main/include/pljava/Invocation.h
@@ -10,6 +10,9 @@
 #define __pljava_Invocation_h
 
 #include <postgres.h>
+#if PG_VERSION_NUM >= 100000
+#include <commands/trigger.h>
+#endif
 #include "pljava/pljava.h"
 
 #ifdef __cplusplus
@@ -68,6 +71,15 @@ struct Invocation_
 	 * during this invocation.
 	 */
 	CallLocal*    callLocals;
+
+#if PG_VERSION_NUM >= 100000
+	/**
+	 * TriggerData pointer, if the function is being called as a trigger,
+	 * so it can be passed to SPI_register_trigger_data if the function connects
+	 * to SPI.
+	 */
+	TriggerData*  triggerData;
+#endif
 
 	/**
 	 * The previous call context when nested function calls


### PR DESCRIPTION
These PostgreSQL 10 changes affect PL/Java. (This list may not be complete, but these are the ones addressed here.)

New version number format (requires change to a regexp in PL/Java's build process).

Demise of non-integer datetimes (renders some PL/Java code dead, with warnings).

Transition tables (new trigger feature, now supported and with SQL generation).