### PR TITLE
Honor client_min_messages too at PL/Java startup.

### DIFF
--- a/pljava/src/main/java/org/postgresql/pljava/internal/ELogHandler.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/ELogHandler.java
@@ -149,11 +149,15 @@ public class ELogHandler extends Handler
 		// during JVM initialization and before the native method is
 		// registered).
 		//
-		String pgLevel = Backend.getConfigOption("log_min_messages");
-		Level level = Level.ALL;
-		if(pgLevel != null)
+		String[] options = { "log_min_messages", "client_min_messages" };
+		Level finestLevel = null;
+		for ( String option : options )
 		{	
+			String pgLevel = Backend.getConfigOption(option);
+			if ( null == pgLevel )
+				continue;
 			pgLevel = pgLevel.toLowerCase().trim();
+			Level level = null;
 			if(pgLevel.equals("panic") || pgLevel.equals("fatal"))
 				level = Level.OFF;
 			else if(pgLevel.equals("error"))
@@ -170,8 +174,15 @@ public class ELogHandler extends Handler
 				level = Level.FINER;
 			else if(pgLevel.equals("debug3") || pgLevel.equals("debug4") || pgLevel.equals("debug5"))
 				level = Level.FINEST;
+			if ( null == level )
+				continue;
+			if ( null == finestLevel
+				|| finestLevel.intValue() > level.intValue() )
+				finestLevel = level;
 		}
-		return level;
+		if ( null == finestLevel )
+			finestLevel = Level.ALL;
+		return finestLevel;
 	}
 
 	// Private method to configure an ELogHandler

--- a/src/site/markdown/examples/examples.md.vm
+++ b/src/site/markdown/examples/examples.md.vm
@@ -58,7 +58,7 @@ descriptor goes farther, and calls several functions provided as test cases,
 so this use of `install_jar` may take a few extra seconds and produce some
 test-related output. (To see _successful_ test-related output, be sure to
 set `client_min_messages` to a level at least as detailed as `INFO` before
-invoking `install_jar`.)
+the session's first use of PL/Java.)
 
 $h2 Trying the examples
 

--- a/src/site/markdown/releasenotes.md.vm
+++ b/src/site/markdown/releasenotes.md.vm
@@ -88,6 +88,16 @@ a demonstration.
 
 [extrig]: $project.scm.url/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/Triggers.java
 
+$h4 Logging from Java
+
+The way the Java logging system has historically been plumbed to PostgreSQL's,
+as described in [issue 125](${ghbug}125), can be perplexing both because it
+is unaffected by later changes to the PostgreSQL settings after PL/Java is
+loaded in the session, and because it has honored only `log_min_messages`
+and ignored `client_min_messages`. The second part is easy to fix, so in
+1.5.1 the threshold where Java discards messages on the fast path is
+determined by the finer of `log_min_messages` and `client_min_messages`.
+
 $h4 Conveniences for downstream package maintainers
 
 The `mvn` command to build PL/Java will now accept an option to provide
@@ -110,6 +120,7 @@ $h3 Bugs fixed
 * [Add support for PostgreSQL 9.6](${ghbug}108)
 * [Clarify documentation of ResultSetProvider](${ghbug}115)
 * [`pg_upgrade` (upgrade failure from 9.5 to 9.6)](${ghbug}117)
+* [Java logging should honor `client_min_messages` too](${ghbug}125)
 
 $h3 Updated PostgreSQL APIs tracked
 


### PR DESCRIPTION
Fix the easier complaint in issue #125; if Java will be summarily
discarding log messages finer than a level derived from PostgreSQL's
settings just once at PL/Java startup, at least derive the level
from the finer of `log_min_messages` and `client_min_messages`, rather
than from `log_min_messages` alone.