### PR TITLE
Accomodate upstream SPI_push/pop API changes (issue #134)

### DIFF
--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/Triggers.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/Triggers.java
@@ -63,6 +63,15 @@ import static org.postgresql.pljava.example.LoggerTest.logMessage;
 		requires = { "transition triggers", "foobar2_42" },
 		install = "UPDATE javatest.foobar_2 SET value = 43 WHERE value = 42"
 	)
+	/*
+	 * Note for another day: this would seem an excellent place to add a
+	 * regression test for github issue #134 (make sure invocations of a
+	 * trigger do not fail with SPI_ERROR_UNCONNECTED). However, any test
+	 * here that runs from the deployment descriptor will be running when
+	 * SPI is already connected, so a regression would not be caught.
+	 * A proper test for it will have to wait for a proper testing harness
+	 * invoking tests from outside PL/Java itself.
+	 */
 })
 public class Triggers
 {

--- a/pljava-so/src/main/c/Invocation.c
+++ b/pljava-so/src/main/c/Invocation.c
@@ -88,13 +88,15 @@ void Invocation_assertConnect(void)
 	{
 		rslt = SPI_connect();
 		if ( SPI_OK_CONNECT != rslt )
-			elog(ERROR, "SPI_register_trigger_data returned %d", rslt);
+			elog(ERROR, "SPI_register_trigger_data returned %s",
+						SPI_result_code_string(rslt));
 #if PG_VERSION_NUM >= 100000
 		if ( NULL != currentInvocation->triggerData )
 		{
 			rslt = SPI_register_trigger_data(currentInvocation->triggerData);
 			if ( SPI_OK_TD_REGISTER != rslt )
-				elog(WARNING, "SPI_register_trigger_data returned %d", rslt);
+				elog(WARNING, "SPI_register_trigger_data returned %s",
+							  SPI_result_code_string(rslt));
 		}
 #endif
 		currentInvocation->hasConnected = true;

--- a/pljava-so/src/main/c/type/Relation.c
+++ b/pljava-so/src/main/c/type/Relation.c
@@ -168,6 +168,16 @@ Java_org_postgresql_pljava_internal_Relation__1getTupleDesc(JNIEnv* env, jclass 
  * Class:     org_postgresql_pljava_internal_Relation
  * Method:    _modifyTuple
  * Signature: (JJ[I[Ljava/lang/Object;)Lorg/postgresql/internal/pljava/Tuple;
+ *
+ * Note: starting with PostgreSQL 10, SPI_modifytuple must be run with SPI
+ * 'connected'. However, the caller likely wants a result living in a memory
+ * context longer-lived than SPI's. (At present, the only calls of this method
+ * originate in Function_invokeTrigger, which does switchToUpperContext() just
+ * for that reason.) Blindly adding Invocation_assertConnect() here would alter
+ * the behavior of subsequent palloc()s (not just in SPI_modifytuple, but also
+ * in, e.g., Tuple_create). So, given there's only one caller, let it be the
+ * caller's responsibility to ensure SPI is connected AND that a suitable
+ * memory context is selected for the result the caller wants.
  */
 JNIEXPORT jobject JNICALL
 Java_org_postgresql_pljava_internal_Relation__1modifyTuple(JNIEnv* env, jclass clazz, jlong _this, jlong _tuple, jintArray _indexes, jobjectArray _values)

--- a/pljava-so/src/main/include/pljava/type/TriggerData.h
+++ b/pljava-so/src/main/include/pljava/type/TriggerData.h
@@ -31,6 +31,9 @@ extern jobject TriggerData_create(TriggerData* triggerData);
 
 /*
  * Obtains the returned Tuple after trigger has been processed.
+ * Note: starting with PG 10, it is the caller's responsibility to ensure SPI
+ * is connected (and that a longer-lived memory context than SPI's is selected,
+ * if the caller wants the result to survive SPI_finish).
  */
 extern HeapTuple TriggerData_getTriggerReturnTuple(jobject jtd, bool* wasNull);
 

--- a/pljava/src/main/java/org/postgresql/pljava/internal/Relation.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/Relation.java
@@ -67,9 +67,16 @@ public class Relation extends JavaWrapper
 	}
 
 	/**
-	 * Creates a new <code>Tuple</code> by substituting new values for selected columns
-	 * copying the columns of the original <code>Tuple</code> at other positions. The
-	 * original <code>Tuple</code> is not modified.<br>
+	 * Creates a new {@code Tuple} by substituting new values for selected
+	 * columns copying the columns of the original {@code Tuple} at other
+	 * positions. The original {@code Tuple} is not modified.
+	 *<p>
+	 * Note: starting with PostgreSQL 10, this method can fail if SPI is not
+	 * connected; it is the <em>caller's</em> responsibility in PG 10 and up
+	 * to ensure that SPI is connected <em>and</em> that a longer-lived memory
+	 * context than SPI's has been selected, if the caller wants the result of
+	 * this call to survive {@code SPI_finish}.
+	 *
 	 * @param original The tuple that serves as the source.
 	 * @param fieldNumbers An array of one based indexes denoting the positions that
 	 * are to receive modified values.

--- a/pljava/src/main/java/org/postgresql/pljava/internal/TriggerData.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/TriggerData.java
@@ -90,6 +90,12 @@ public class TriggerData extends JavaWrapper implements org.postgresql.pljava.Tr
 	 * <code>new</code> and returns the native pointer of new tuple. This
 	 * method is called automatically by the trigger handler and should not
 	 * be called in any other way.
+	 *<p>
+	 * Note: starting with PostgreSQL 10, this method can fail if SPI is not
+	 * connected; it is the <em>caller's</em> responsibility in PG 10 and up
+	 * to ensure that SPI is connected <em>and</em> that a longer-lived memory
+	 * context than SPI's has been selected, if the caller wants the result of
+	 * this call to survive {@code SPI_finish}.
 	 * 
 	 * @return The modified tuple, or if no modifications have been made, the
 	 *         original tuple.


### PR DESCRIPTION
For PostgreSQL 10, SPI [changes][] so that `SPI_push`/`SPI_pop` are no longer used. For now, they are still defined (as no-ops), so there is no need yet to remove them throughout PL/Java. That can be done in the future when PL/Java no longer supports PG releases earlier than 10.

However, the change also affected the semantics of several other SPI functions, `SPI_modifytuple` being the only one PL/Java uses. It will now return `SPI_ERROR_UNCONNECTED` if called when SPI has not yet been connected, so now the caller must be sure a connection exists. (This is made the caller's responsibility so that the caller can also adjust the memory context, if the one imposed by `SPI_connect` won't do.) The change is made in `Function_invokeTrigger`, which is on the only call path, and is where the needed memory context is chosen.

[changes]: https://git.postgresql.org/gitweb/?p=postgresql.git;a=commit;h=1833f1a1c3b0e12b3ea40d49bf11898eedae5248