### PR TITLE
Fix #136 SPIConnection prepareStatement doesn't recognize all parameters

### DIFF
--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/SPIConnection.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/SPIConnection.java
@@ -422,7 +422,7 @@ public class SPIConnection implements Connection
 				//
 				if(inQuote == c)
 					inQuote = 0;
-				else
+				else if(inQuote == 0)
 					inQuote = c;
 				break;
 			


### PR DESCRIPTION
Fix #136 SPIConnection prepareStatement doesn't recognize all parameters when SQL combines single and double quotes