### PR TITLE
Handle SETOF RECORD better in ResultSetHandle

### DIFF
--- a/pljava-api/src/main/java/org/postgresql/pljava/ResultSetHandle.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/ResultSetHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2015 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2018 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -21,11 +21,24 @@ import java.sql.SQLException;
  * of a {@link java.sql.ResultSet}. The primary motivation for this interface is
  * that an implementation that returns a ResultSet must be able to close the
  * connection and statement when no more rows are requested.
- *
+ *<p>
  * A function returning a <code>SET OF</code> a complex type generated on the
  * fly (rather than obtained from a query) would return
  * {@link ResultSetProvider} instead. One returning a <code>SET OF</code> a
  * simple type should simply return an {@link java.util.Iterator}.
+ *<p>
+ * In the case of a function declared to return {@code SETOF RECORD} rather than
+ * of a complex type known in advance, SQL requires any query using the function
+ * to include a column definition list. If the number of those columns does not
+ * match the number in the {@code ResultSet} returned here, only as many as the
+ * caller expects (in index order starting with 1) will be used; an exception is
+ * thrown if this result set has too few columns. If the types expected by the
+ * caller differ, values are converted as if retrieved one by one from this
+ * {@code ResultSet} and stored into the caller's with
+ * {@link ResultSet#updateObject(int, Object) updateObject}.
+ *<p>
+ * A function that needs to know the names or types of the caller's expected
+ * columns should implement {@link ResultSetProvider}.
  * @author Thomas Hallgren
  */
 public interface ResultSetHandle

--- a/pljava-api/src/main/java/org/postgresql/pljava/ResultSetProvider.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/ResultSetProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2017 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2018 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -23,6 +23,11 @@ import java.sql.SQLException;
  * it should just return {@link ResultSetHandle} instead. Functions that
  * return <code>SET OF</code> a simple type should simply return an
  * {@link java.util.Iterator Iterator}.
+ *<p>
+ * For a function declared to return {@code SETOF RECORD} rather than a specific
+ * complex type known in advance, the {@code receiver} argument to
+ * {@link #assignRowValues(ResultSet,int) assignRowValues} can be queried to
+ * learn the number, names, and types of columns expected by the caller.
  * @author Thomas Hallgren
  */
 public interface ResultSetProvider
@@ -31,11 +36,19 @@ public interface ResultSetProvider
 	 * This method is called once for each row that should be returned from
 	 * a procedure that returns a set of rows. The receiver
 	 * is a {@code SingleRowWriter}
-	 * writer instance that is used for capturing the data for the row.
+	 * instance that is used for capturing the data for the row.
+	 *<p>
+	 * If the return type is {@code RECORD} rather than a specific complex type,
+	 * SQL requires a column definition list to follow any use of the function
+	 * in a query. The {@link ResultSet#getMetaData() ResultSetMetaData}
+	 * of {@code receiver} can be used here to learn the number, names,
+	 * and types of the columns expected by the caller. (It can also be used in
+	 * the case of a specific complex type, but in that case the names and types
+	 * are probably already known.)
 	 * @param receiver Receiver of values for the given row.
 	 * @param currentRow Row number, zero on the first call, incremented by one
 	 * on each subsequent call.
-	 * @return <code>true</code> if a new row was provided, <code>false</code>
+	 * @return {@code true} if a new row was provided, {@code false}
 	 * if not (end of data).
 	 * @throws SQLException
 	 */

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/SetOfRecordTest.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/SetOfRecordTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2013 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2018 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -8,8 +8,9 @@
  *
  * Contributors:
  *   Tada AB
+ *   Chapman Flack
  */
-package org.postgresql.pljava.example;
+package org.postgresql.pljava.example.annotation;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -18,13 +19,33 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 
 import org.postgresql.pljava.ResultSetHandle;
+import org.postgresql.pljava.annotation.Function;
+import org.postgresql.pljava.annotation.SQLAction;
 
 /**
  * Example implementing the {@code ResultSetHandle} interface, to return
  * the {@link ResultSet} from any SQL {@code SELECT} query passed as a string
  * to the {@link #executeSelect executeSelect} function.
  */
+@SQLAction(requires="selecttorecords fn", install=
+" SELECT " +
+"  CASE WHEN r IS DISTINCT FROM ROW('Foo'::varchar, 1::integer, 1.5::float, " +
+"       23.67::decimal(8,2), '2005-06-01'::date, '20:56'::time, " +
+"       '2006-02-04 23:55:10'::timestamp) " +
+"  THEN javatest.logmessage('WARNING', 'SetOfRecordTest not ok') " +
+"  ELSE javatest.logmessage('INFO', 'SetOfRecordTest ok') " +
+"  END " +
+" FROM " +
+"  javatest.executeselecttorecords( " +
+"   'select ''Foo'',  1,  1.5,  23.67,  ''2005-06-01'',  ''20:56''::time, " +
+"           ''2006-02-04 23:55:10''') " +
+"  AS r(t_varchar varchar, t_integer integer, t_float float, " +
+"      t_decimal decimal(8,2), t_date date, t_time time, t_timestamp timestamp)"
+)
 public class SetOfRecordTest implements ResultSetHandle {
+
+	@Function(schema="javatest", name="executeselecttorecords",
+	          provides="selecttorecords fn")
 	public static ResultSetHandle executeSelect(String selectSQL)
 			throws SQLException {
 		return new SetOfRecordTest(selectSQL);

--- a/pljava-examples/src/main/resources/deployment/examples.ddr
+++ b/pljava-examples/src/main/resources/deployment/examples.ddr
@@ -343,11 +343,6 @@ SQLActions[ ] = {
 			AS 'org.postgresql.pljava.example.ResultSetTest.executeSelect'
 			LANGUAGE java;
 
-		CREATE FUNCTION javatest.executeSelectToRecords(varchar)
-			RETURNS SETOF RECORD
-			AS 'org.postgresql.pljava.example.SetOfRecordTest.executeSelect'
-			LANGUAGE java;
-
 		CREATE FUNCTION javatest.countNulls(record)
 			RETURNS int
 			AS 'org.postgresql.pljava.example.Parameters.countNulls'

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/SingleRowWriter.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/SingleRowWriter.java
@@ -1,10 +1,15 @@
 /*
- * Copyright (c) 2004, 2005, 2006 TADA AB - Taby Sweden
+ * Copyright (c) 2004-2018 Tada AB and other contributors, as listed below.
  * Copyright (c) 2010, 2011 PostgreSQL Global Development Group
  *
- * Distributed under the terms shown in the file COPYRIGHT
- * found in the root folder of this project or at
- * http://wiki.tada.se/index.php?title=PLJava_License
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Tada AB
+ *   Chapman Flack
  */
 package org.postgresql.pljava.jdbc;
 
@@ -106,8 +111,8 @@ public class SingleRowWriter extends SingleRowResultSet
 	throws SQLException
 	{
 		int top = m_values.length;
-		for(int idx = 0; idx < top; ++idx)
-			m_values[idx] = rs.getObject(idx+1);
+		for(int idx = 1; idx <= top; ++idx)
+			updateObject(idx, rs.getObject(idx));
 	}
 
 	/**

--- a/src/java/test/org/postgresql/pljava/test/Tester.java
+++ b/src/java/test/org/postgresql/pljava/test/Tester.java
@@ -861,44 +861,4 @@ public class Tester
 			}
 		}
 	}
-
-	public void testResultSet() throws SQLException
-	{
-		String sql;
-		Statement stmt = m_connection.createStatement();
-		ResultSet rs = null;
-
-		try
-		{
-			System.out.println("*** ResultSet test:");
-			sql = "SELECT * FROM javatest.executeSelect("
-				+ "'select ''Foo'' as t_varchar, 1::integer as t_integer, "
-				+ "1.5::float as t_float, 23.67::decimal(8,2) as t_decimal, "
-				+ "''2005-06-01''::date as t_date, ''20:56''::time as t_time, "
-				+ "''2006-02-04 23:55:10''::timestamp as t_timestamp')";
-
-			rs = stmt.executeQuery(sql);
-			System.out.println("SQL = " + sql);
-			System.out.println("results:");
-			while(rs.next())
-			{
-				System.out.println(rs.getString(1));
-			}
-			rs.close();
-		}
-		finally
-		{
-			if(rs != null)
-			{
-				try
-				{
-					rs.close();
-				}
-				catch(SQLException e)
-				{
-				}
-				rs = null;
-			}
-		}
-	}
 }


### PR DESCRIPTION
Cast types as expected if the types in the supplied `ResultSet` differ from those in the calling query's column definition list. Addresses issue #146. Adds a test and expanded API documentation.