### PR TITLE
Use getSQLTypeName, one minor change suggested in issue #149

### DIFF
--- a/pljava/src/main/java/org/postgresql/pljava/internal/Oid.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/Oid.java
@@ -1,11 +1,18 @@
 /*
- * Copyright (c) 2004, 2005, 2006 TADA AB - Taby Sweden
- * Distributed under the terms shown in the file COPYRIGHT
- * found in the root folder of this project or at
- * http://eng.tada.se/osprojects/COPYRIGHT.html
+ * Copyright (c) 2004-2018 Tada AB and other contributors, as listed below.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Tada AB
+ *   Chapman Flack
  */
 package org.postgresql.pljava.internal;
 
+import java.sql.SQLData;
 import java.sql.SQLException;
 import java.util.HashMap;
 
@@ -37,13 +44,15 @@ public class Oid extends Number
 	}
 
 	/**
-	 * Finds the PostgreSQL well known Oid for the given class.
-	 * @param clazz The class.
+	 * Finds the PostgreSQL well known Oid for the given Java object.
+	 * @param obj The object.
 	 * @return The well known Oid or null if no such Oid could be found.
 	 */
-	public static Oid forJavaClass(Class clazz)
+	public static Oid forJavaObject(Object obj) throws SQLException
 	{
-		return (Oid)s_class2typeId.get(clazz);
+		if ( obj instanceof SQLData )
+			return forTypeName(((SQLData)obj).getSQLTypeName());
+		return (Oid)s_class2typeId.get(obj.getClass());
 	}
 
 	/**

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/SPIPreparedStatement.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/SPIPreparedStatement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2016 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2018 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -209,7 +209,7 @@ public class SPIPreparedStatement extends SPIStatement implements PreparedStatem
 			throw new SQLException("Illegal parameter index");
 
 		Oid id = (sqlType == Types.OTHER)
-			? Oid.forJavaClass(value.getClass())
+			? Oid.forJavaObject(value)
 			: Oid.forSqlType(sqlType);
 
 		// Default to String.


### PR DESCRIPTION
Provide one of the short-term solutions suggested in issue #149.

As the current PreparedStatement implementation does not get the
inferred parameter types from PostgreSQL (which became possible
with SPI only as recently as PostgreSQL 9.0), its setObject method
must make a best effort to map in the other direction, finding the
PostgreSQL type that corresponds to the Java parameter value. In
one case, this is easily made much more reliable: when the Java
parameter value is an SQLData instance (a UDT), and therefore has
a getSQLTypeName method, unused until now.

Add a test method (in the ComplexTuple UDT example) to confirm that
the type is properly mapped when passed as a parameter to a
PreparedStatement.