### PR TITLE
Let annotations give defaults to row-type parameters.

### DIFF
--- a/pljava-api/src/main/java/org/postgresql/pljava/annotation/SQLType.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/annotation/SQLType.java
@@ -41,13 +41,22 @@ public @interface SQLType
 	String value() default "";
 	
 	/**
-	 * Default value for the parameter. Parameters of array type can have
+	 * Default value for the parameter. Parameters of row or array type can have
 	 * defaults too, so this element accepts an array. For a scalar type,
 	 * just supply one value. Values given here go into the descriptor file
 	 * as properly-escaped string literals explicitly cast to the parameter
 	 * type, which covers the typical case of defaults that are simple
 	 * literals or can be computed as Java String-typed constant expressions
 	 * (e.g. ""+Math.PI) and ensures the parsability of the descriptor file.
+	 *<p>
+	 * For a row type of unknown structure (PostgreSQL type {@code RECORD}), the
+	 * only default that can be specified is {@code {}}, which can be useful for
+	 * functions that use a {@code RECORD} parameter to accept an arbitrary
+	 * sequence of named, typed parameters from the caller. For a named row type
+	 * (not {@code RECORD}), an array of nonzero length will be accepted. It
+	 * needs to match the number and order of components of the row type (which
+	 * cannot be checked at compile time, but will cause the deployment
+	 * descriptor code to fail at jar install time if it does not).
 	 */
 	String[] defaultValue() default {};
 	

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/RecordParameterDefaults.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/RecordParameterDefaults.java
@@ -42,13 +42,6 @@ import org.postgresql.pljava.annotation.SQLType;
 			"DROP TYPE javatest.paramtypeinfo"
 		}
 	),
-	@SQLAction(
-		requires = "foobar tables", // created in Triggers.java
-		install = {
-		},
-		remove = {
-		}
-	),
 })
 public class RecordParameterDefaults implements ResultSetProvider
 {

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/RecordParameterDefaults.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/RecordParameterDefaults.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2018- Tada AB and other contributors, as listed below.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Chapman Flack
+ */
+package org.postgresql.pljava.example.annotation;
+
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+
+import static java.util.Arrays.fill;
+
+import org.postgresql.pljava.ResultSetProvider;
+import org.postgresql.pljava.annotation.Function;
+import org.postgresql.pljava.annotation.SQLAction;
+import org.postgresql.pljava.annotation.SQLActions;
+import org.postgresql.pljava.annotation.SQLType;
+
+/**
+ * Example demonstrating the use of a {@code RECORD} parameter as a way to
+ * supply an arbitrary sequence of named, typed parameters to a PL/Java
+ * function.
+ *<p>
+ * Also tests the proper DDR generation of defaults for such parameters.
+ */
+@SQLActions({
+	@SQLAction(
+		provides = "paramtypeinfo type", // created in Triggers.java
+		install = {
+			"CREATE TYPE javatest.paramtypeinfo AS (" +
+			"name text, pgtypename text, javaclass text, tostring text" +
+			")"
+		},
+		remove = {
+			"DROP TYPE javatest.paramtypeinfo"
+		}
+	),
+	@SQLAction(
+		requires = "foobar tables", // created in Triggers.java
+		install = {
+		},
+		remove = {
+		}
+	),
+})
+public class RecordParameterDefaults implements ResultSetProvider
+{
+	/**
+	 * Return the names, types, and values of parameters supplied as a single
+	 * anonymous RECORD type; the parameter is given an empty-record default,
+	 * allowing it to be omitted in calls, or used with the named-parameter
+	 * call syntax.
+	 *<p>
+	 * For example, this function could be called as:
+	 *<pre>
+	 * SELECT (paramDefaultsRecord()).*;
+	 *</pre>
+	 * or as:
+	 *<pre>
+	 * SELECT (paramDefaultsRecord(params => s)).*
+	 * FROM (SELECT 42 AS a, '42' AS b, 42.0 AS c) AS s;
+	 *</pre>
+	 */
+	@Function(
+		requires = "paramtypeinfo type",
+		schema = "javatest",
+		type = "javatest.paramtypeinfo"
+		)
+	public static ResultSetProvider paramDefaultsRecord(
+		@SQLType(defaultValue={})ResultSet params)
+	throws SQLException
+	{
+		return new RecordParameterDefaults(params);
+	}
+
+	/**
+	 * Like paramDefaultsRecord but illustrating the use of a named row type
+	 * with known structure, and supplying a default for the function
+	 * parameter.
+	 *<p>
+	 *<pre>
+	 * SELECT paramDefaultsNamedRow();
+	 *
+	 * SELECT paramDefaultsNamedRow(userWithNum => ('fred', 3.14));
+	 *</pre>
+	 */
+	@Function(
+		requires = "foobar tables", // created in Triggers.java
+		schema = "javatest"
+		)
+	public static String paramDefaultsNamedRow(
+		@SQLType(value="javatest.foobar_2", defaultValue={"bob", "42"})
+		ResultSet userWithNum)
+	throws SQLException
+	{
+		return String.format("username is %s and value is %s",
+			userWithNum.getObject("username"), userWithNum.getObject("value"));
+	}
+
+
+
+	private final ResultSetMetaData m_paramrsmd;
+	private final Object[] m_values;
+	
+	RecordParameterDefaults(ResultSet paramrs) throws SQLException
+	{
+		m_paramrsmd = paramrs.getMetaData();
+		/*
+		 * Grab the values from the parameter SingleRowResultSet now; it isn't
+		 * guaranteed to stay valid for the life of the set-returning function.
+		 */
+		m_values = new Object [ m_paramrsmd.getColumnCount() ];
+		for ( int i = 0; i < m_values.length; ++ i )
+			m_values[i] = paramrs.getObject( 1 + i);
+	}
+
+	@Override
+	public boolean assignRowValues(ResultSet receiver, int currentRow)
+	throws SQLException
+	{
+		int col = 1 + currentRow;
+		if ( col > m_paramrsmd.getColumnCount() )
+			return false;
+		receiver.updateString("name", m_paramrsmd.getColumnLabel(col));
+		receiver.updateString("pgtypename", m_paramrsmd.getColumnTypeName(col));
+		Object o = m_values[col - 1];
+		receiver.updateString("javaclass", o.getClass().getName());
+		receiver.updateString("tostring", o.toString());
+		return true;
+	}
+
+	@Override
+	public void close() throws SQLException
+	{
+		fill(m_values, null);
+	}
+}


### PR DESCRIPTION
PL/Java has long had the ability to declare a function parameter that is of a row type, even of the row type `RECORD` with no _a priori_ known structure. This is quite convenient for implementing functions that can be passed an arbitrary sequence of named, typed parameters by the SQL caller.

This patch tweaks the SQL deployment descriptor generator to be able to emit default values for parameters of row types (where previously it could only emit working syntax for scalars or arrays). This simplifies the development of functions accepting _optional_ sequences of arbitrary named, typed parameters.

Adds `RecordParameterDefaults.java` in `pljava-examples` for illustration.