### PR TITLE
Correct timestamp/timestamptz as reported in #155

### DIFF
--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/TypeRoundTripper.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/TypeRoundTripper.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright (c) 2018- Tada AB and other contributors, as listed below.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Chapman Flack
+ */
+package org.postgresql.pljava.example.annotation;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import static java.lang.reflect.Modifier.isPublic;
+import static java.lang.reflect.Modifier.isStatic;
+
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.Types;
+import static java.sql.Types.VARCHAR;
+
+import java.sql.SQLException;
+import java.sql.SQLDataException;
+
+import org.postgresql.pljava.annotation.Function;
+
+/**
+ * A class to simplify testing of PL/Java's mappings between PostgreSQL and
+ * Java/JDBC types.
+ *<p>
+ * Provides one function, {@link #roundTrip roundTrip()}. Its single input
+ * parameter is an unspecified row type, so you can pass it a row that has
+ * exactly one column of any type.
+ *<p>
+ * Its return type is also an unspecified row type, so you need to follow the
+ * function call with a column definition list of up to six columns. Each
+ * requested output column must have its name (case-insensitively) and type
+ * drawn from this table:
+ *<table>
+ *<thead>
+ *<tr>
+ *<th>Column name</th><th>Column type</th><th>What is returned</th>
+ *</tr>
+ *</thead>
+ *<tbody>
+ *<tr>
+ *<td>TYPEPG</td><td>any text/varchar</td><td>The PostgreSQL type name</td>
+ *</tr>
+ *<tr>
+ *<td>TYPEJDBC</td><td>any text/varchar</td><td>The JDBC Types constant</td>
+ *</tr>
+ *<tr>
+ *<td>CLASSJDBC</td><td>any text/varchar</td>
+ *<td>Name of the Java class JDBC claims (in metadata) it will instantiate</td>
+ *</tr>
+ *<tr>
+ *<td>CLASS</td><td>any text/varchar</td>
+ *<td>Name of the Java class JDBC did instantiate</td>
+ *</tr>
+ *<tr>
+ *<td>TOSTRING</td><td>any text/varchar</td>
+ *<td>Result of {@code toString()} on the object returned by
+ * {@code ResultSet.getObject()}</td>
+ *</tr>
+ *<tr>
+ *<td>ROUNDTRIPPED</td><td>same as input column</td>
+ *<td>Result of passing the object returned by {@code ResultSet.getObject()}
+ * directly to {@code ResultSet.updateObject()}</td>
+ *</tr>
+ *</tbody>
+ *</table>
+ *<p>
+ * Serving suggestion:
+ *<pre>
+ *SELECT
+ *  orig = roundtripped AS good, *
+ *FROM
+ *  (VALUES (timestamptz '2017-08-21 18:25:29.900005Z')) AS p(orig),
+ *  roundtrip(p) AS r(roundtripped timestamptz);
+ *</pre>
+ */
+public class TypeRoundTripper
+{
+	private TypeRoundTripper() { }
+
+	/**
+	 * Function accepting one parameter of row type (one column, any type)
+	 * and returning a row with up to six columns (use a column definition list
+	 * after the function call, choose column names from TYPEPG, TYPEJDBC,
+	 * CLASSJDBC, CLASS, TOSTRING, ROUNDTRIPPED where any of the first five
+	 * must have text/varchar type, while ROUNDTRIPPED must match the type of
+	 * the input column).
+	 * @param in The input row value (required to have exactly one column).
+	 * @param out The output row (supplied by PL/Java, representing the column
+	 * definition list that follows the call of this function in SQL).
+	 * @throws SQLException if {@code in} does not have exactly one column, if
+	 * {@code out} has more than six, if a requested column name in {@code out}
+	 * is not among those recognized, if a column of {@code out} is not of its
+	 * required type, or if other stuff goes wrong.
+	 */
+	@Function(
+		schema = "javatest",
+		type = "RECORD"
+		)
+	public static boolean roundTrip(ResultSet in, ResultSet out)
+	throws SQLException
+	{
+		ResultSetMetaData inmd = in.getMetaData();
+		ResultSetMetaData outmd = out.getMetaData();
+
+		if ( 1 != inmd.getColumnCount() )
+			throw new SQLDataException(
+				"in parameter must be a one-column row type", "22000");
+
+		int outcols = outmd.getColumnCount();
+		if ( 6 < outcols )
+			throw new SQLDataException(
+				"result description may have no more than six columns",
+				"22000");
+
+		String inTypePG = inmd.getColumnTypeName(1);
+		int inTypeJDBC = inmd.getColumnType(1);
+		Object val = in.getObject(1);
+
+		for ( int i = 1; i <= outcols; ++ i )
+		{
+			String what = outmd.getColumnLabel(i);
+
+			if ( "TYPEPG".equals(what) )
+			{
+				assertTypeJDBC(outmd, i, VARCHAR);
+				out.updateObject(i, inTypePG);
+			}
+			else if ( "TYPEJDBC".equals(what) )
+			{
+				assertTypeJDBC(outmd, i, VARCHAR);
+				out.updateObject(i, typeNameJDBC(inTypeJDBC));
+			}
+			else if ( "CLASSJDBC".equals(what) )
+			{
+				assertTypeJDBC(outmd, i, VARCHAR);
+				out.updateObject(i, inmd.getColumnClassName(1));
+			}
+			else if ( "CLASS".equals(what) )
+			{
+				assertTypeJDBC(outmd, i, VARCHAR);
+				out.updateObject(i, val.getClass().getName());
+			}
+			else if ( "TOSTRING".equals(what) )
+			{
+				assertTypeJDBC(outmd, i, VARCHAR);
+				out.updateObject(i, val.toString());
+			}
+			else if ( "ROUNDTRIPPED".equals(what) )
+			{
+				if ( ! inTypePG.equals(outmd.getColumnTypeName(i)) )
+					throw new SQLDataException(
+					"Result ROUNDTRIPPED column must have same type as input",
+						"22000");
+				out.updateObject(i, val);
+			}
+			else
+				throw new SQLDataException(
+					"Output column label \""+ what + "\" should be one of: " +
+					"TYPEPG, TYPEJDBC, CLASSJDBC, CLASS, TOSTRING, VALUE",
+					"22000");
+		}
+
+		return true;
+	}
+
+	static void assertTypeJDBC(ResultSetMetaData md, int i, int t)
+	throws SQLException
+	{
+		if ( md.getColumnType(i) != t )
+			throw new SQLDataException(
+				"Result column " + i + " must be of JDBC type " +
+				typeNameJDBC(t));
+	}
+
+	static String typeNameJDBC(int t)
+	{
+		for ( Field f : Types.class.getFields() )
+		{
+			int m = f.getModifiers();
+			if ( isPublic(m) && isStatic(m) && int.class == f.getType() )
+				try
+				{
+					if ( f.getInt(null) == t )
+						return f.getName();
+				}
+				catch ( IllegalAccessException e ) { }
+		}
+		return String.valueOf(t);
+	}
+}

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/TypeRoundTripper.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/TypeRoundTripper.java
@@ -25,6 +25,7 @@ import java.sql.SQLException;
 import java.sql.SQLDataException;
 
 import org.postgresql.pljava.annotation.Function;
+import org.postgresql.pljava.annotation.SQLAction;
 
 /**
  * A class to simplify testing of PL/Java's mappings between PostgreSQL and
@@ -81,6 +82,33 @@ import org.postgresql.pljava.annotation.Function;
  *  roundtrip(p) AS r(roundtripped timestamptz);
  *</pre>
  */
+@SQLAction(requires = "TypeRoundTripper.roundTrip", install = {
+"	SELECT	"+
+"		CASE WHEN every(orig = roundtripped)	"+
+"		THEN javatest.logmessage('INFO', 'timestamp roundtrip passes')	"+
+"		ELSE javatest.logmessage('WARNING', 'timestamp roundtrip fails')"+
+"		END	"+
+"	FROM	"+
+"		(values	"+
+"			(timestamp '2017-08-21 18:25:29.900005'),	"+
+"			(timestamp '1970-03-07 17:37:49.300009'),	"+
+"			(timestamp '1919-05-29 13:08:33.600001')	"+
+"		) as p(orig),	"+
+"		roundtrip(p) as r(roundtripped timestamp)	",
+
+"	SELECT	"+
+"		CASE WHEN every(orig = roundtripped)	"+
+"		THEN javatest.logmessage('INFO', 'timestamptz roundtrip passes')	"+
+"		ELSE javatest.logmessage('WARNING', 'timestamptz roundtrip fails')	"+
+"		END	"+
+"	FROM	"+
+"		(values	"+
+"			(timestamptz '2017-08-21 18:25:29.900005Z'),	"+
+"			(timestamptz '1970-03-07 17:37:49.300009Z'),	"+
+"			(timestamptz '1919-05-29 13:08:33.600001Z')	"+
+"		) as p(orig),	"+
+"		roundtrip(p) as r(roundtripped timestamptz)	",
+})
 public class TypeRoundTripper
 {
 	private TypeRoundTripper() { }
@@ -102,7 +130,8 @@ public class TypeRoundTripper
 	 */
 	@Function(
 		schema = "javatest",
-		type = "RECORD"
+		type = "RECORD",
+		provides = "TypeRoundTripper.roundTrip"
 		)
 	public static boolean roundTrip(ResultSet in, ResultSet out)
 	throws SQLException

--- a/pljava-so/src/main/c/type/Timestamp.c
+++ b/pljava-so/src/main/c/type/Timestamp.c
@@ -1,12 +1,16 @@
 /*
- * Copyright (c) 2004, 2005, 2006 TADA AB - Taby Sweden
- * Copyright (c) 2007, 2008, 2010, 2011 PostgreSQL Global Development Group
+ * Copyright (c) 2004-2018 Tada AB and other contributors, as listed below.
  *
- * Distributed under the terms shown in the file COPYRIGHT
- * found in the root folder of this project or at
- * http://wiki.tada.se/index.php?title=PLJava_License
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
  *
- * @author Thomas Hallgren
+ * Contributors:
+ *   Tada AB
+ *   Thomas Hallgren
+ *   PostgreSQL Global Development Group
+ *   Chapman Flack
  */
 #include <postgres.h>
 #include <utils/nabstime.h>
@@ -46,7 +50,7 @@ static jvalue Timestamp_coerceDatumTZ_id(Type self, Datum arg, bool tzAdjust)
 	jvalue result;
 	int64 ts = DatumGetInt64(arg);
 
-	/* Expect number of microseconds since 01 Jan 2000. Separate out a positive
+	/* Expect number of microseconds since 01 Jan 2000. Tease out a non-negative
 	 * sub-second microseconds value (whether this C compiler's signed %
 	 * has trunc or floor behavior).
 	 */
@@ -106,9 +110,10 @@ static Datum Timestamp_coerceObjectTZ_id(Type self, jobject jts, bool tzAdjust)
 	jlong mSecs = JNI_callLongMethod(jts, s_Timestamp_getTime);
 	jint  nSecs = JNI_callIntMethod(jts, s_Timestamp_getNanos);
 	/*
-	 * getNanos() should have supplied positive nSecs, whether mSecs is positive
-	 * or negative. So mSecs needs to be floor()ed to a multiple of 1000 ms,
-	 * whether this C compiler does signed integer division with floor or trunc.
+	 * getNanos() should have supplied non-negative nSecs, whether mSecs is
+	 * positive or negative. So mSecs needs to be floor()ed to a multiple of
+	 * 1000 ms, whether this C compiler does signed integer division with floor
+	 * or trunc.
 	 */
 	mSecs -= ((mSecs % 1000) + 1000) % 1000;
 	mSecs -= ((jlong)EPOCH_DIFF) * 1000L;

--- a/pljava-so/src/main/c/type/Timestamp.c
+++ b/pljava-so/src/main/c/type/Timestamp.c
@@ -45,15 +45,19 @@ static jvalue Timestamp_coerceDatumTZ_id(Type self, Datum arg, bool tzAdjust)
 {
 	jvalue result;
 	int64 ts = DatumGetInt64(arg);
-	int   tz = Timestamp_getTimeZone_id(ts);
 
-	/* Expect number of microseconds since 01 Jan 2000
+	/* Expect number of microseconds since 01 Jan 2000. Separate out a positive
+	 * sub-second microseconds value (whether this C compiler's signed %
+	 * has trunc or floor behavior).
 	 */
-	jlong mSecs = ts / 1000; /* Convert to millisecs */
-	jint  uSecs = (jint)(ts % 1000000); /* preserve microsecs */
+	jint  uSecs = (jint)(((ts % 1000000) + 1000000) % 1000000);
+	jlong mSecs = (ts - uSecs) / 1000; /* Convert to millisecs */
 
 	if(tzAdjust)
+	{
+		int tz = Timestamp_getTimeZone_id(ts);
 		mSecs += tz * 1000; /* Adjust from local time to UTC */
+	}
 
 	/* Adjust for diff between Postgres and Java (Unix) */
 	mSecs += ((jlong)EPOCH_DIFF) * 1000L;
@@ -101,6 +105,12 @@ static Datum Timestamp_coerceObjectTZ_id(Type self, jobject jts, bool tzAdjust)
 	int64 ts;
 	jlong mSecs = JNI_callLongMethod(jts, s_Timestamp_getTime);
 	jint  nSecs = JNI_callIntMethod(jts, s_Timestamp_getNanos);
+	/*
+	 * getNanos() should have supplied positive nSecs, whether mSecs is positive
+	 * or negative. So mSecs needs to be floor()ed to a multiple of 1000 ms,
+	 * whether this C compiler does signed integer division with floor or trunc.
+	 */
+	mSecs -= ((mSecs % 1000) + 1000) % 1000;
 	mSecs -= ((jlong)EPOCH_DIFF) * 1000L;
 	ts  = mSecs * 1000L; /* Convert millisecs to microsecs */
 	if(nSecs != 0)
@@ -167,7 +177,12 @@ static Datum _Timestamptz_coerceObject(Type self, jobject ts)
 
 static int32 Timestamp_getTimeZone(pg_time_t time)
 {
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && ( \
+	100000<=PG_VERSION_NUM && PG_VERSION_NUM<102000 || \
+	 90600<=PG_VERSION_NUM && PG_VERSION_NUM< 90607 || \
+	 90500<=PG_VERSION_NUM && PG_VERSION_NUM< 90511 || \
+	 90400<=PG_VERSION_NUM && PG_VERSION_NUM< 90416 || \
+	PG_VERSION_NUM < 90321 )
 	/* This is gross, but pg_tzset has a cache, so not as gross as you think.
 	 * There is some renewed interest on pgsql-hackers to find a good answer for
 	 * the MSVC PGDLLIMPORT nonsense, so this may not have to stay gross.


### PR DESCRIPTION
The C code was failing to preserve the invariant that the `nanos` component of the Java Timestamp representation is never negative, no matter the sign of the millis-from-epoch component, and was also double-counting the millisecond portion of the fractional second (which is represented both in the millis-from-epoch and in the nanos component).

Adds a test class and tests to confirm the fixed behavior.

In passing, adds `PG_VERSION_NUM` conditionals to reduce the cost of timezone retrieval in MSVC in versions where the variable has been made accessible.