### PR TITLE
Fix SQL generator failure to map byte[] to bytea

### DIFF
--- a/pljava-api/src/main/java/org/postgresql/pljava/sqlgen/DDRProcessor.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/sqlgen/DDRProcessor.java
@@ -2291,12 +2291,19 @@ hunt:	for ( ExecutableElement ee : ees )
 				}
 				else
 				{
-					TypeElement te =
-						elmu.getTypeElement( k.getName());
-					if ( null == te ) // can't find it -> not used in code?
+					String cname = k.getCanonicalName();
+					if ( null == cname )
 					{
 						msg( Kind.WARNING,
-							"Found no TypeElement for %s", k.getName());
+							"Cannot register type mapping for class %s" +
+							"that lacks a canonical name", k.getName());
+						continue;
+					}
+					TypeElement te = elmu.getTypeElement( cname);
+					if ( null == te )
+					{
+						msg( Kind.WARNING,
+							"Found no TypeElement for %s", cname);
 						continue; // hope it wasn't one we'll need!
 					}
 					ktm = te.asType();

--- a/pljava-api/src/main/java/org/postgresql/pljava/sqlgen/DDRProcessor.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/sqlgen/DDRProcessor.java
@@ -2282,36 +2282,45 @@ hunt:	for ( ExecutableElement ee : ees )
 				Vertex<Map.Entry<Class<?>, String>> v = q.remove();
 				v.use( q);
 				Class<?> k = v.payload.getKey();
-				TypeMirror ktm;
-				if ( k.isPrimitive() )
-				{
-					TypeKind tk = 
-						TypeKind.valueOf( k.getName().toUpperCase());
-					ktm = typu.getPrimitiveType( tk);
-				}
-				else
-				{
-					String cname = k.getCanonicalName();
-					if ( null == cname )
-					{
-						msg( Kind.WARNING,
-							"Cannot register type mapping for class %s" +
-							"that lacks a canonical name", k.getName());
-						continue;
-					}
-					TypeElement te = elmu.getTypeElement( cname);
-					if ( null == te )
-					{
-						msg( Kind.WARNING,
-							"Found no TypeElement for %s", cname);
-						continue; // hope it wasn't one we'll need!
-					}
-					ktm = te.asType();
-				}
+				TypeMirror ktm = typeMirrorFromClass( k);
+				if ( null == ktm )
+					continue; // typeMirrorFromClass already emitted warning
 				finalMappings.add(
 					new AbstractMap.SimpleImmutableEntry<TypeMirror, String>(
 						ktm, v.payload.getValue()));
 			}
+		}
+
+		private TypeMirror typeMirrorFromClass( Class<?> k)
+		{
+			if ( k.isArray() )
+			{
+				TypeMirror ctm = typeMirrorFromClass( k.getComponentType());
+				return typu.getArrayType( ctm);
+			}
+
+			if ( k.isPrimitive() )
+			{
+				TypeKind tk = TypeKind.valueOf( k.getName().toUpperCase());
+				return typu.getPrimitiveType( tk);
+			}
+
+			String cname = k.getCanonicalName();
+			if ( null == cname )
+			{
+				msg( Kind.WARNING,
+					"Cannot register type mapping for class %s" +
+					"that lacks a canonical name", k.getName());
+				return null;
+			}
+
+			TypeElement te = elmu.getTypeElement( cname);
+			if ( null == te )
+			{
+				msg( Kind.WARNING, "Found no TypeElement for %s", cname);
+				return null; // hope it wasn't one we'll need!
+			}
+			return te.asType();
 		}
 
 		/**

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/Parameters.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/Parameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2013 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2018 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -8,8 +8,9 @@
  *
  * Contributors:
  *   Tada AB
+ *   Chapman Flack
  */
-package org.postgresql.pljava.example;
+package org.postgresql.pljava.example.annotation;
 
 import java.math.BigDecimal;
 import java.sql.Date;
@@ -22,12 +23,33 @@ import java.text.SimpleDateFormat;
 import java.util.TimeZone;
 import java.util.logging.Logger;
 
+import org.postgresql.pljava.annotation.Function;
+import static org.postgresql.pljava.annotation.Function.Effects.IMMUTABLE;
+import org.postgresql.pljava.annotation.SQLAction;
+import org.postgresql.pljava.annotation.SQLType;
+
 /**
  * Some methods used for testing parameter and return value coersion and
  * resolution of overloaded methods.
- * 
+ *<p>
+ * About the {@code @SQLAction} here: the original, hand-crafted deployment
+ * descriptor declared <em>two</em> SQL functions both implemented by the same
+ * {@link #getTimestamp() getTimestamp} method here. Only one declaration can be
+ * automatically generated from a {@code @Function} annotation on the method
+ * itself. This {@code @SQLAction} takes care of the other declaration.
+ * Of course, there is now a burden on the author to get this declaration right
+ * and to keep it up to date if the method evolves, but at least it is here in
+ * the same file, rather than in a separate hand-maintained DDR file.
  * @author Thomas Hallgren
  */
+@SQLAction(install = {
+	"CREATE OR REPLACE FUNCTION javatest.java_getTimestamptz()" +
+	"	RETURNS timestamptz" +
+	"	AS 'org.postgresql.pljava.example.annotation.Parameters.getTimestamp'" +
+	"	LANGUAGE java"
+	},
+	remove = "DROP FUNCTION javatest.java_getTimestamptz()"
+)
 public class Parameters {
 	public static double addNumbers(short a, int b, long c, BigDecimal d,
 			BigDecimal e, float f, double g) {
@@ -38,6 +60,7 @@ public class Parameters {
 		return value + 1;
 	}
 
+	@Function(schema = "javatest", name = "java_addOne", effects = IMMUTABLE)
 	public static int addOne(Integer value) {
 		return value.intValue() + 1;
 	}
@@ -46,6 +69,7 @@ public class Parameters {
 		return (int) value + 1;
 	}
 
+	@Function(schema = "javatest")
 	public static int countNulls(Integer[] intArray) throws SQLException {
 		int nullCount = 0;
 		int top = intArray.length;
@@ -56,6 +80,7 @@ public class Parameters {
 		return nullCount;
 	}
 
+	@Function(schema = "javatest")
 	public static int countNulls(ResultSet input) throws SQLException {
 		int nullCount = 0;
 		int top = input.getMetaData().getColumnCount();
@@ -75,6 +100,7 @@ public class Parameters {
 		return new Time(System.currentTimeMillis());
 	}
 
+	@Function(schema = "javatest", name = "java_getTimestamp")
 	public static Timestamp getTimestamp() {
 		return new Timestamp(System.currentTimeMillis());
 	}
@@ -89,15 +115,30 @@ public class Parameters {
 			Logger.getAnonymousLogger().info(msg);
 	}
 
+	@Function(schema = "javatest", effects = IMMUTABLE)
 	public static Integer nullOnEven(int value) {
 		return (value % 2) == 0 ? null : new Integer(value);
 	}
 
-	public static byte print(byte value) {
+	/*
+	 * Declare parameter and return type as the PostgreSQL-specific "char"
+	 * (the quoted one, not SQL CHAR) type ... that's how it was declared
+	 * in the original hand-generated deployment descriptor. PL/Java's SQL
+	 * generator would otherwise have emitted smallint by default for the
+	 * Java byte type.
+	 *
+	 * Note that the SQL rules for quoted vs. regular identifiers are complex,
+	 * and PL/Java has not yet precisely specified how the identifiers given in
+	 * annotations are to be treated. A future release may lay down more precise
+	 * rules, which may affect code supplying quoted identifiers like this.
+	 */
+	@Function(schema = "javatest", type = "\"char\"")
+	public static byte print(@SQLType("\"char\"") byte value) {
 		log("byte " + value);
 		return value;
 	}
 
+	@Function(schema = "javatest")
 	public static byte[] print(byte[] byteArray) {
 		StringBuffer buf = new StringBuffer();
 		int top = byteArray.length;
@@ -115,19 +156,22 @@ public class Parameters {
 		return byteArray;
 	}
 
-	public static void print(Date time) {
+	@Function(schema = "javatest")
+	public static void print(Date value) {
 		DateFormat p = DateFormat.getDateInstance(DateFormat.FULL);
-		log("Local Date is " + p.format(time));
+		log("Local Date is " + p.format(value));
 		p.setTimeZone(TimeZone.getTimeZone("UTC"));
-		log("UTC Date is " + p.format(time));
+		log("UTC Date is " + p.format(value));
 		log("TZ =  " + TimeZone.getDefault().getDisplayName());
 	}
 
+	@Function(schema = "javatest")
 	public static double print(double value) {
 		log("double " + value);
 		return value;
 	}
 
+	@Function(schema = "javatest")
 	public static double[] print(double[] doubleArray) {
 		StringBuffer buf = new StringBuffer();
 		int top = doubleArray.length;
@@ -145,11 +189,13 @@ public class Parameters {
 		return doubleArray;
 	}
 
+	@Function(schema = "javatest")
 	public static float print(float value) {
 		log("float " + value);
 		return value;
 	}
 
+	@Function(schema = "javatest")
 	public static float[] print(float[] floatArray) {
 		StringBuffer buf = new StringBuffer();
 		int top = floatArray.length;
@@ -167,11 +213,13 @@ public class Parameters {
 		return floatArray;
 	}
 
+	@Function(schema = "javatest")
 	public static int print(int value) {
 		log("int " + value);
 		return value;
 	}
 
+	@Function(schema = "javatest")
 	public static int[] print(int[] intArray) {
 		StringBuffer buf = new StringBuffer();
 		int top = intArray.length;
@@ -189,6 +237,7 @@ public class Parameters {
 		return intArray;
 	}
 
+	@Function(schema = "javatest", name = "printObj")
 	public static Integer[] print(Integer[] intArray) {
 		StringBuffer buf = new StringBuffer();
 		int top = intArray.length;
@@ -206,11 +255,13 @@ public class Parameters {
 		return intArray;
 	}
 
+	@Function(schema = "javatest")
 	public static long print(long value) {
 		log("long " + value);
 		return value;
 	}
 
+	@Function(schema = "javatest")
 	public static long[] print(long[] longArray) {
 		StringBuffer buf = new StringBuffer();
 		int top = longArray.length;
@@ -228,11 +279,13 @@ public class Parameters {
 		return longArray;
 	}
 
+	@Function(schema = "javatest")
 	public static short print(short value) {
 		log("short " + value);
 		return value;
 	}
 
+	@Function(schema = "javatest")
 	public static short[] print(short[] shortArray) {
 		StringBuffer buf = new StringBuffer();
 		int top = shortArray.length;
@@ -250,20 +303,32 @@ public class Parameters {
 		return shortArray;
 	}
 
-	public static void print(Time time) {
+	/*
+	 * Declare the parameter type to be timetz in SQL, to match what the
+	 * original hand-crafted deployment descriptor did. The SQL generator
+	 * would otherwise assume time (without time zone).
+	 */
+	@Function(schema = "javatest")
+	public static void print(@SQLType("timetz") Time value) {
 		DateFormat p = new SimpleDateFormat("HH:mm:ss z Z");
-		log("Local Time is " + p.format(time));
+		log("Local Time is " + p.format(value));
 		p.setTimeZone(TimeZone.getTimeZone("UTC"));
-		log("UTC Time is " + p.format(time));
+		log("UTC Time is " + p.format(value));
 		log("TZ =  " + TimeZone.getDefault().getDisplayName());
 	}
 
-	public static void print(Timestamp time) {
+	/*
+	 * Declare the parameter type to be timestamptz in SQL, to match what the
+	 * original hand-crafted deployment descriptor did. The SQL generator
+	 * would otherwise assume timestamp (without time zone).
+	 */
+	@Function(schema = "javatest")
+	public static void print(@SQLType("timestamptz") Timestamp value) {
 		DateFormat p = DateFormat.getDateTimeInstance(DateFormat.FULL,
 				DateFormat.FULL);
-		log("Local Timestamp is " + p.format(time));
+		log("Local Timestamp is " + p.format(value));
 		p.setTimeZone(TimeZone.getTimeZone("UTC"));
-		log("UTC Timestamp is " + p.format(time));
+		log("UTC Timestamp is " + p.format(value));
 		log("TZ =  " + TimeZone.getDefault().getDisplayName());
 	}
 }

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/Parameters.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/Parameters.java
@@ -106,13 +106,7 @@ public class Parameters {
 	}
 
 	static void log(String msg) {
-		// GCJ has a somewhat serious bug (reported)
-		//
-		if ("GNU libgcj".equals(System.getProperty("java.vm.name"))) {
-			System.out.print("INFO: ");
-			System.out.println(msg);
-		} else
-			Logger.getAnonymousLogger().info(msg);
+		Logger.getAnonymousLogger().info(msg);
 	}
 
 	@Function(schema = "javatest", effects = IMMUTABLE)

--- a/pljava-examples/src/main/resources/deployment/examples.ddr
+++ b/pljava-examples/src/main/resources/deployment/examples.ddr
@@ -3,106 +3,6 @@ SQLActions[ ] = {
 		CREATE SCHEMA javatest;
 		BEGIN PostgreSQL SET search_path TO javatest,public ENd postgreSQL;
 
-		CREATE FUNCTION javatest.java_getTimestamp()
-			RETURNS timestamp
-			AS 'org.postgresql.pljava.example.Parameters.getTimestamp'
-			LANGUAGE java;
-
-		CREATE FUNCTION javatest.java_getTimestamptz()
-			RETURNS timestamptz
-			AS 'org.postgresql.pljava.example.Parameters.getTimestamp'
-			LANGUAGE java;
-
-		CREATE FUNCTION javatest.print(date)
-			RETURNS void
-			AS 'org.postgresql.pljava.example.Parameters.print'
-			LANGUAGE java;
-
-		CREATE FUNCTION javatest.print(timetz)
-			RETURNS void
-			AS 'org.postgresql.pljava.example.Parameters.print'
-			LANGUAGE java;
-
-		CREATE FUNCTION javatest.print(timestamptz)
-			RETURNS void
-			AS 'org.postgresql.pljava.example.Parameters.print'
-			LANGUAGE java;
-
-		CREATE FUNCTION javatest.print("char")
-			RETURNS "char"
-			AS 'org.postgresql.pljava.example.Parameters.print'
-			LANGUAGE java;
-
-		CREATE FUNCTION javatest.print(bytea)
-			RETURNS bytea
-			AS 'org.postgresql.pljava.example.Parameters.print'
-			LANGUAGE java;
-
-		CREATE FUNCTION javatest.print(int2)
-			RETURNS int2
-			AS 'org.postgresql.pljava.example.Parameters.print'
-			LANGUAGE java;
-
-		CREATE FUNCTION javatest.print(int2[])
-			RETURNS int2[]
-			AS 'org.postgresql.pljava.example.Parameters.print'
-			LANGUAGE java;
-
-		CREATE FUNCTION javatest.print(int4)
-			RETURNS int4
-			AS 'org.postgresql.pljava.example.Parameters.print'
-			LANGUAGE java;
-
-		CREATE FUNCTION javatest.print(int4[])
-			RETURNS int4[]
-			AS 'org.postgresql.pljava.example.Parameters.print'
-			LANGUAGE java;
-
-		CREATE FUNCTION javatest.print(int8)
-			RETURNS int8
-			AS 'org.postgresql.pljava.example.Parameters.print'
-			LANGUAGE java;
-
-		CREATE FUNCTION javatest.print(int8[])
-			RETURNS int8[]
-			AS 'org.postgresql.pljava.example.Parameters.print'
-			LANGUAGE java;
-
-		CREATE FUNCTION javatest.print(real)
-			RETURNS real
-			AS 'org.postgresql.pljava.example.Parameters.print'
-			LANGUAGE java;
-
-		CREATE FUNCTION javatest.print(real[])
-			RETURNS real[]
-			AS 'org.postgresql.pljava.example.Parameters.print'
-			LANGUAGE java;
-
-		CREATE FUNCTION javatest.print(double precision)
-			RETURNS double precision
-			AS 'org.postgresql.pljava.example.Parameters.print'
-			LANGUAGE java;
-
-		CREATE FUNCTION javatest.print(double precision[])
-			RETURNS double precision[]
-			AS 'org.postgresql.pljava.example.Parameters.print'
-			LANGUAGE java;
-
-		CREATE FUNCTION javatest.printObj(int[])
-			RETURNS int[]
-			AS 'org.postgresql.pljava.example.Parameters.print(java.lang.Integer[])'
-			LANGUAGE java;
-
-		CREATE FUNCTION javatest.java_addOne(int)
-			RETURNS int
-			AS 'org.postgresql.pljava.example.Parameters.addOne(java.lang.Integer)'
-			IMMUTABLE LANGUAGE java;
-
-		CREATE FUNCTION javatest.nullOnEven(int)
-			RETURNS int
-			AS 'org.postgresql.pljava.example.Parameters.nullOnEven'
-			IMMUTABLE LANGUAGE java;
-
 		CREATE FUNCTION javatest.java_getSystemProperty(varchar)
 			RETURNS varchar
 			AS 'java.lang.System.getProperty'
@@ -341,16 +241,6 @@ SQLActions[ ] = {
 		CREATE FUNCTION javatest.executeSelect(varchar)
 			RETURNS SETOF VARCHAR
 			AS 'org.postgresql.pljava.example.ResultSetTest.executeSelect'
-			LANGUAGE java;
-
-		CREATE FUNCTION javatest.countNulls(record)
-			RETURNS int
-			AS 'org.postgresql.pljava.example.Parameters.countNulls'
-			LANGUAGE java;
-
-		CREATE FUNCTION javatest.countNulls(int[])
-			RETURNS int
-			AS 'org.postgresql.pljava.example.Parameters.countNulls(java.lang.Integer[])'
 			LANGUAGE java;
 
 		/*


### PR DESCRIPTION
The annotation processor was failing to register a mapping of Java `byte[]` to SQL `bytea` as intended (issue #157), because the code assumed a `TypeElement` could be created from the name of an array type, which turns out not to be the case. It is necessary to first make a `TypeMirror` representing the component type, then wrap that in the right number of `ArrayType`s.

None of the existing annotation examples covered the cases of `bytea` parameter or return types. The non-annotation example `Parameters.java` did, and is now an annotation example so future regressions can be caught.

This patch also eliminates a long-standing mysterious warning from the annotation processor that had not been pursued because of the lack of problem reports.