### PR TITLE
Improve DDR generator on the dont-repeat-yourself dimension for UDT type mapping.

### DIFF
--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/ComplexScalar.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/ComplexScalar.java
@@ -23,7 +23,6 @@ import java.util.logging.Logger;
 
 import org.postgresql.pljava.annotation.Function;
 import org.postgresql.pljava.annotation.SQLAction;
-import org.postgresql.pljava.annotation.SQLType;
 import org.postgresql.pljava.annotation.BaseUDT;
 
 import static org.postgresql.pljava.annotation.Function.Effects.IMMUTABLE;
@@ -51,11 +50,10 @@ public class ComplexScalar implements SQLData {
 	 * @param cpl any instance of this UDT
 	 * @return the same instance passed in
 	 */
-	@Function(requires="scalar complex type", type="javatest.complex",
+	@Function(requires="scalar complex type",
 		schema="javatest", name="logcomplex", effects=IMMUTABLE,
 		onNullInput=RETURNS_NULL)
-	public static ComplexScalar logAndReturn(
-		@SQLType("javatest.complex") ComplexScalar cpl) {
+	public static ComplexScalar logAndReturn(ComplexScalar cpl) {
 		s_logger.info(cpl.getSQLTypeName() + cpl);
 		return cpl;
 	}
@@ -71,8 +69,7 @@ public class ComplexScalar implements SQLData {
 	@Function(schema="javatest",
 		requires="scalar complex type", provides="complex assertHasValues",
 		effects=IMMUTABLE, onNullInput=RETURNS_NULL)
-	public static void assertHasValues(
-		@SQLType("javatest.complex") ComplexScalar cpl, double re, double im)
+	public static void assertHasValues(ComplexScalar cpl, double re, double im)
 		throws SQLException
 	{
 		if ( cpl.m_x != re  ||  cpl.m_y != im )

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/ComplexTuple.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/ComplexTuple.java
@@ -25,7 +25,6 @@ import java.util.logging.Logger;
 import org.postgresql.pljava.annotation.Function;
 import org.postgresql.pljava.annotation.MappedUDT;
 import org.postgresql.pljava.annotation.SQLAction;
-import org.postgresql.pljava.annotation.SQLType;
 
 import static org.postgresql.pljava.annotation.Function.Effects.IMMUTABLE;
 import static
@@ -58,9 +57,8 @@ public class ComplexTuple implements SQLData {
 	 */
 	@Function(schema="javatest", name="logcomplex",
 		effects=IMMUTABLE, onNullInput=RETURNS_NULL,
-		type="javatest.complextuple", requires="complextuple type")
-	public static ComplexTuple logAndReturn(
-		@SQLType("javatest.complextuple") ComplexTuple cpl) {
+		requires="complextuple type")
+	public static ComplexTuple logAndReturn(ComplexTuple cpl) {
 		s_logger.info(cpl.getSQLTypeName() + "(" + cpl.m_x + ", " + cpl.m_y
 				+ ")");
 		return cpl;
@@ -77,9 +75,7 @@ public class ComplexTuple implements SQLData {
 	@Function(schema="javatest",
 		requires="complextuple type", provides="complextuple assertHasValues",
 		effects=IMMUTABLE, onNullInput=RETURNS_NULL)
-	public static void assertHasValues(
-		@SQLType("javatest.complextuple") ComplexTuple cpl,
-		double re, double im)
+	public static void assertHasValues(ComplexTuple cpl, double re, double im)
 		throws SQLException
 	{
 		if ( cpl.m_x != re  ||  cpl.m_y != im )

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/IntWithMod.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/IntWithMod.java
@@ -156,11 +156,10 @@ public class IntWithMod implements SQLData {
 	 */
 	@Function(schema="javatest", name="intwithmod_typmodapply",
 		requires="IntWithMod type", provides="IntWithMod modApply",
-		type="javatest.IntWithMod", effects=IMMUTABLE, onNullInput=RETURNS_NULL)
-	public static IntWithMod modApply(
-		@SQLType("javatest.IntWithMod") IntWithMod iwm,
-		int mod, boolean explicit) throws SQLException {
-
+		effects=IMMUTABLE, onNullInput=RETURNS_NULL)
+	public static IntWithMod modApply(IntWithMod iwm, int mod, boolean explicit)
+		throws SQLException
+	{
 		if ( -1 == mod )
 			return iwm;
 		if ( (iwm.m_value & 1) != mod )

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/Point.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/Point.java
@@ -21,7 +21,6 @@ import java.util.logging.Logger;
 import org.postgresql.pljava.annotation.Function;
 import org.postgresql.pljava.annotation.MappedUDT;
 import org.postgresql.pljava.annotation.SQLAction;
-import org.postgresql.pljava.annotation.SQLType;
 
 import static org.postgresql.pljava.annotation.Function.Effects.IMMUTABLE;
 import static
@@ -46,9 +45,9 @@ public class Point implements SQLData {
 	 * @param pt any instance of the type this UDT mirrors
 	 * @return the same instance passed in
 	 */
-	@Function(schema="javatest", type="point", requires="point mirror type",
+	@Function(schema="javatest", requires="point mirror type",
 		effects=IMMUTABLE, onNullInput=RETURNS_NULL)
-	public static Point logAndReturn(@SQLType("point") Point pt) {
+	public static Point logAndReturn(Point pt) {
 		s_logger.info(pt.getSQLTypeName() + pt);
 		return pt;
 	}
@@ -64,9 +63,7 @@ public class Point implements SQLData {
 	@Function(schema="javatest",
 		requires="point mirror type", provides="point assertHasValues",
 		effects=IMMUTABLE, onNullInput=RETURNS_NULL)
-	public static void assertHasValues(
-		@SQLType("point") Point pt,
-		double x, double y)
+	public static void assertHasValues(Point pt, double x, double y)
 		throws SQLException
 	{
 		if ( pt.m_x != x  ||  pt.m_y != y )


### PR DESCRIPTION
It was never satisfying to define a UDT in Java through annotations
and still have the DDR generator give "no mapping to an SQL type" errors
for functions accepting or returning that type. It was easy enough (if
tedious) to work around by adding explicit `type=` or `@SQLType` annotations,
but the DDR generator had all the necessary information to figure that out
without such manual help. Now it does so, eliminating the tedium
illustrated in jcflack/pljava-udt-type-extension@bcb5734.

To accommodate mappings added from the source being compiled, the
protoMappings collection is now of TypeMirror instances rather than
of Class instances.

Still future work: also add implied ordering dependencies for uses of
the new type (such as functions that have it as parameter or return
types and have to follow the type declaration, as illustrated in
jcflack/pljava-udt-type-extension@225ef5c, or that are named in it as,
for example, typmod in/out functions, and have to precede it).