### PR TITLE
Add support for PostgreSQL 11 (beta2).

### DIFF
--- a/pljava-so/src/main/c/Backend.c
+++ b/pljava-so/src/main/c/Backend.c
@@ -1457,7 +1457,11 @@ static void registerGUCOptions(void)
 		#endif
 		PGC_USERSET,
 		#if PG_VERSION_NUM >= 80400
-			GUC_LIST_INPUT | GUC_LIST_QUOTE,
+			GUC_LIST_INPUT
+			#if PG_VERSION_NUM < 110000
+				| GUC_LIST_QUOTE
+			#endif
+			,
 		#endif
 		#if PG_VERSION_NUM >= 90100
 			NULL, /* check hook */

--- a/pljava-so/src/main/c/type/JavaWrapper.c
+++ b/pljava-so/src/main/c/type/JavaWrapper.c
@@ -61,9 +61,7 @@ void JavaWrapper_initialize(void)
 
 	JavaMemoryContext = AllocSetContextCreate(TopMemoryContext,
 									 "PL/Java",
-									 ALLOCSET_DEFAULT_MINSIZE,
-									 ALLOCSET_DEFAULT_INITSIZE,
-									 ALLOCSET_DEFAULT_MAXSIZE);
+									 ALLOCSET_DEFAULT_SIZES);
 }
 
 /*

--- a/pljava-so/src/main/c/type/Type.c
+++ b/pljava-so/src/main/c/type/Type.c
@@ -402,9 +402,7 @@ Datum Type_invokeSRF(Type self, jclass cls, jmethodID method, jvalue* args, PG_F
 
 		ctxData->rowContext = AllocSetContextCreate(context->multi_call_memory_ctx,
 								  "PL/Java row context",
-								  ALLOCSET_DEFAULT_MINSIZE,
-								  ALLOCSET_DEFAULT_INITSIZE,
-								  ALLOCSET_DEFAULT_MAXSIZE);
+								  ALLOCSET_DEFAULT_SIZES);
 
 		/* Register callback to be called when the function ends
 		 */

--- a/pljava-so/src/main/include/pljava/pljava.h
+++ b/pljava-so/src/main/include/pljava/pljava.h
@@ -50,6 +50,20 @@ extern int vsnprintf(char* buf, size_t count, const char* format, va_list arg);
 #define StaticAssertStmt(condition, errmessage)
 #endif
 
+/*
+ * AllocSetContextCreate sprouted these macros for common combinations of
+ * size parameters in PG 9.6. It becomes /necessary/ to use them in PG 11
+ * when using AllocSetContextCreate (which becomes a macro in that version)
+ * and not the (new in that version) AllocSetContextCreateExtended.
+ */
+#if PG_VERSION_NUM < 90600
+#define ALLOCSET_DEFAULT_SIZES \
+	ALLOCSET_DEFAULT_MINSIZE, ALLOCSET_DEFAULT_INITSIZE, ALLOCSET_DEFAULT_MAXSIZE
+#define ALLOCSET_SMALL_SIZES \
+	ALLOCSET_SMALL_MINSIZE, ALLOCSET_SMALL_INITSIZE, ALLOCSET_SMALL_MAXSIZE
+#define ALLOCSET_START_SMALL_SIZES \
+	ALLOCSET_SMALL_MINSIZE, ALLOCSET_SMALL_INITSIZE, ALLOCSET_DEFAULT_MAXSIZE
+#endif
 
 /*
  * GETSTRUCT require "access/htup_details.h" to be included in PG9.3

--- a/src/site/markdown/releasenotes.md.vm
+++ b/src/site/markdown/releasenotes.md.vm
@@ -167,6 +167,7 @@ $h3 Updated PostgreSQL APIs tracked
 * `IsBinaryUpgrade`
 * `SPI_register_trigger_data`
 * `SPI` without `SPI_push`/`SPI_pop`
+* `AllocSetContextCreate`
 
 $h2 Earlier releases
 

--- a/src/site/markdown/releasenotes.md.vm
+++ b/src/site/markdown/releasenotes.md.vm
@@ -168,6 +168,7 @@ $h3 Updated PostgreSQL APIs tracked
 * `SPI_register_trigger_data`
 * `SPI` without `SPI_push`/`SPI_pop`
 * `AllocSetContextCreate`
+* `DefineCustom...Variable` (no `GUC_LIST_QUOTE` in extensions)
 
 $h2 Earlier releases
 

--- a/src/site/markdown/use/variables.md
+++ b/src/site/markdown/use/variables.md
@@ -46,7 +46,11 @@ These PostgreSQL configuration variables can influence PL/Java's operation:
     only on a system recognizing that name. By default, this list contains only
     the entry `postgresql`. A deployment descriptor that contains commands with
     other implementor names can achieve a rudimentary kind of conditional
-    execution if earlier commands adjust this list of names.
+    execution if earlier commands adjust this list of names. _Commas separate
+    elements of this list. Elements that are not regular identifiers need to be
+    surrounded by double-quotes; prior to PostgreSQL 11, that syntax can be used
+    directly in a `SET` command, while in 11 and after, such a value needs to be
+    a (single-quoted) string explicitly containing the double quotes._
 
 `pljava.libjvm_location`
 : Used by PL/Java to load the Java runtime. The full path to a `libjvm` shared


### PR DESCRIPTION
Thanks to Luca Ferrari who in #160 presented both of these patches that allow PL/Java to build and deploy the examples jar without problems in PG 11. This PR includes both patches, and I have also just gone through the PG 11 release notes looking for other possible trouble spots, and saw nothing obvious. Perhaps nothing more will be needed.