### PR TITLE
Emit REMOVE section of DDR in right order (#163).

### DIFF
--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/ConditionalDDR.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/ConditionalDDR.java
@@ -46,6 +46,18 @@ import org.postgresql.pljava.annotation.SQLActions;
  * placed as late in the generated DDR as other dependencies allow, in case
  * something in the preceding actions will be setting those implementor tags.
  * <p>
+ * The implicit {@code requires} derived from an {@code implementor} is also
+ * special in another way: it does not have its sense reversed when generating
+ * the "undeploy" actions of the deployment descriptor. Ordinary requirements
+ * do, so the dependent objects get dropped before the things they depend on.
+ * But the code for setting a conditional implementor tag has to be placed
+ * ahead of the uses of the tag, whether deploying or undeploying.
+ * <p>
+ * An {@code SQLAction} setting an implementor tag does not need to have any
+ * {@code remove=} actions. If it does not (the usual case), its
+ * {@code install=} actions will be used in both sections of the deployment
+ * descriptor.
+ * <p>
  * This example adds {@code LifeIsGood} ahead of the prior content of
  * {@code pljava.implementors}. Simply replacing the value would stop the
  * default implementor PostgreSQL being recognized, probably not what's wanted.


### PR DESCRIPTION
The implicitly-added provides/requires relationships between implementor
tags and the snippets that test the environment to activate or suppress
them need to be treated specially. Unlike other dependency
relationships, which have their sense reversed between the INSTALL and
REMOVE action groups, these implicit ones need to keep the same sense.
It always works better to test a condition before needing to use the
result.

The old augmentRequires method, which created the implied dependencies
by outright adding them to the snippet's other requires, is now gone;
the implied relationship is simply handled within the ordering code.
Two DAGs are created, one for install and one for remove, and an order
is found independently for each.

It's also necessary to use the deployStrings of tag-testing snippets
at undeploy time, at least in the case they don't have explicit
undeployStrings supplied, which is the usual case, because the
conditions to be tested are the same deploying and undeploying.