### PR TITLE
Actually check all PG major versions for which support is claimed.

### DIFF
--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/ConditionalDDR.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/ConditionalDDR.java
@@ -51,6 +51,10 @@ import org.postgresql.pljava.annotation.SQLActions;
  * default implementor PostgreSQL being recognized, probably not what's wanted.
  * The final {@code true} argument to {@code set_config} makes the setting
  * local, so it is reverted when the transaction completes.
+ * <p>
+ * In addition to the goodness-of-life examples, this file also generates
+ * several statements setting PostgreSQL-version-based implementor tags that
+ * are relied on by various other examples in this directory.
  */
 @SQLActions({
 	@SQLAction(provides={"LifeIsGood","LifeIsNotGood"}, install=
@@ -69,6 +73,54 @@ import org.postgresql.pljava.annotation.SQLActions;
 
 	@SQLAction(implementor="LifeIsNotGood", install=
 		"SELECT javatest.logmessage('WARNING', 'This should not be executed')"
-	)
+	),
+
+	@SQLAction(provides="postgresql_ge_80300", install=
+		"SELECT CASE WHEN" +
+		" 80300 <= CAST(current_setting('server_version_num') AS integer)" +
+		" THEN set_config('pljava.implementors', 'postgresql_ge_80300,' || " +
+		" current_setting('pljava.implementors'), true) " +
+		"END"
+	),
+
+	@SQLAction(provides="postgresql_ge_80400", install=
+		"SELECT CASE WHEN" +
+		" 80400 <= CAST(current_setting('server_version_num') AS integer)" +
+		" THEN set_config('pljava.implementors', 'postgresql_ge_80400,' || " +
+		" current_setting('pljava.implementors'), true) " +
+		"END"
+	),
+
+	@SQLAction(provides="postgresql_ge_90000", install=
+		"SELECT CASE WHEN" +
+		" 90000 <= CAST(current_setting('server_version_num') AS integer)" +
+		" THEN set_config('pljava.implementors', 'postgresql_ge_90000,' || " +
+		" current_setting('pljava.implementors'), true) " +
+		"END"
+	),
+
+	@SQLAction(provides="postgresql_ge_90100", install=
+		"SELECT CASE WHEN" +
+		" 90100 <= CAST(current_setting('server_version_num') AS integer)" +
+		" THEN set_config('pljava.implementors', 'postgresql_ge_90100,' || " +
+		" current_setting('pljava.implementors'), true) " +
+		"END"
+	),
+
+	@SQLAction(provides="postgresql_ge_90300", install=
+		"SELECT CASE WHEN" +
+		" 90300 <= CAST(current_setting('server_version_num') AS integer)" +
+		" THEN set_config('pljava.implementors', 'postgresql_ge_90300,' || " +
+		" current_setting('pljava.implementors'), true) " +
+		"END"
+	),
+
+	@SQLAction(provides="postgresql_ge_100000", install=
+		"SELECT CASE WHEN" +
+		" 100000 <= CAST(current_setting('server_version_num') AS integer)" +
+		" THEN set_config('pljava.implementors', 'postgresql_ge_100000,' || " +
+		" current_setting('pljava.implementors'), true) " +
+		"END"
+	),
 })
 public class ConditionalDDR { }

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/Enumeration.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/Enumeration.java
@@ -22,13 +22,17 @@ import org.postgresql.pljava.annotation.Function;
 /**
  * Confirms the mapping of PG enum and Java String, and arrays of each, as
  * parameter and return types.
+ *<p>
+ * This example relies on {@code implementor} tags reflecting the PostgreSQL
+ * version, set up in the {@link ConditionalDDR} example. PostgreSQL before 8.3
+ * did not have enum types.
  */
 @SQLActions({
-	@SQLAction(provides="mood type",
+	@SQLAction(provides="mood type", implementor="postgresql_ge_80300",
 		install="CREATE TYPE mood AS ENUM ('sad', 'ok', 'happy')",
 		remove="DROP TYPE mood"
 	),
-	@SQLAction(
+	@SQLAction(implementor="postgresql_ge_80300",
 		requires={"textToMood", "moodToText", "textsToMoods", "moodsToTexts"},
 		install={
 			"SELECT textToMood('happy')",
@@ -40,22 +44,26 @@ import org.postgresql.pljava.annotation.Function;
 })
 public class Enumeration
 {
-	@Function(requires="mood type", provides="textToMood", type="mood")
+	@Function(requires="mood type", provides="textToMood", type="mood",
+			  implementor="postgresql_ge_80300")
 	public static String textToMood(String s)
 	{
 		return s;
 	}
-	@Function(requires="mood type", provides="moodToText")
+	@Function(requires="mood type", provides="moodToText",
+			  implementor="postgresql_ge_80300")
 	public static String moodToText(@SQLType("mood")String s)
 	{
 		return s;
 	}
-	@Function(requires="mood type", provides="textsToMoods", type="mood")
+	@Function(requires="mood type", provides="textsToMoods", type="mood",
+			  implementor="postgresql_ge_80300")
 	public static Iterator<String> textsToMoods(String[] ss)
 	{
 		return Arrays.asList(ss).iterator();
 	}
-	@Function(requires="mood type", provides="moodsToTexts")
+	@Function(requires="mood type", provides="moodsToTexts",
+			  implementor="postgresql_ge_80300")
 	public static Iterator<String> moodsToTexts(@SQLType("mood[]")String[] ss)
 	{
 		return Arrays.asList(ss).iterator();

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/IntWithMod.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/IntWithMod.java
@@ -51,8 +51,15 @@ import static
  *<p>
  * Certainly, it would be less tedious with some more annotation support and
  * autogeneration of the ordering dependencies that are now added by hand here.
+ *<p>
+ * Most of this must be suppressed (using conditional implementor tags) if the
+ * PostgreSQL instance is older than 8.3, because it won't have the cstring[]
+ * type, so the typeModifierInput function can't be declared, and so neither
+ * can the type, or functions that accept or return it. See the
+ * {@link ConditionalDDR} example for where the implementor tag is set up.
  */
 @SQLAction(requires={"IntWithMod type", "IntWithMod modApply"},
+	implementor="postgresql_ge_80300",
 	remove="DROP CAST (javatest.IntWithMod AS javatest.IntWithMod)",
 	install={
 		"CREATE CAST (javatest.IntWithMod AS javatest.IntWithMod)" +
@@ -64,6 +71,7 @@ import static
 	}
 )
 @BaseUDT(schema="javatest", provides="IntWithMod type",
+	implementor="postgresql_ge_80300",
 	requires={"IntWithMod modIn", "IntWithMod modOut"},
 	typeModifierInput="javatest.intwithmod_typmodin",
 	typeModifierOutput="javatest.intwithmod_typmodout",
@@ -121,7 +129,7 @@ public class IntWithMod implements SQLData {
 	 * "even" or "odd". The modifier value is 0 for even or 1 for odd.
 	 */
 	@Function(schema="javatest", name="intwithmod_typmodin",
-		provides="IntWithMod modIn",
+		provides="IntWithMod modIn", implementor="postgresql_ge_80300",
 		effects=IMMUTABLE, onNullInput=RETURNS_NULL)
 	public static int modIn(@SQLType("cstring[]") String[] toks)
 		throws SQLException {
@@ -155,6 +163,7 @@ public class IntWithMod implements SQLData {
 	 * Function backing the type-modifier application cast for IntWithMod type.
 	 */
 	@Function(schema="javatest", name="intwithmod_typmodapply",
+		implementor="postgresql_ge_80300",
 		requires="IntWithMod type", provides="IntWithMod modApply",
 		effects=IMMUTABLE, onNullInput=RETURNS_NULL)
 	public static IntWithMod modApply(IntWithMod iwm, int mod, boolean explicit)

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/PGF1010962.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/PGF1010962.java
@@ -10,16 +10,23 @@ import org.postgresql.pljava.annotation.SQLAction;
 /**
  * A gnarly test of TupleDesc reference management, crafted by Johann Oskarsson
  * for bug report 1010962 on pgFoundry.
+ *<p>
+ * This example relies on {@code implementor} tags reflecting the PostgreSQL
+ * version, set up in the {@link ConditionalDDR} example. Before PostgreSQL 8.4,
+ * there is no array of {@code RECORD}, which this test requires.
  */
-@SQLAction(requires="1010962 func",
+@SQLAction(requires="1010962 func", implementor="postgresql_ge_80400",
 	install={
 		"CREATE TYPE javatest.B1010962 AS ( b1_val float8, b2_val int)",
+
 		"CREATE TYPE javatest.C1010962 AS ( c1_val float8, c2_val float8)",
+
 		"CREATE TYPE javatest.A1010962 as (" +
 		" b B1010962," +
 		" c C1010962," +
 		" a_val int" +
 		")",
+
 		"SELECT javatest.complexParam(array_agg(" +
 		" CAST(" +
 		"  (" +
@@ -44,7 +51,8 @@ public class PGF1010962
 	 * @param receiver Looks polymorphic, but expects an array of A1010962
 	 * @return 0
 	 */
-	@Function(schema="javatest", provides="1010962 func")
+	@Function(schema="javatest", provides="1010962 func",
+				implementor="postgresql_ge_80400")
 	public static int complexParam( ResultSet receiver[] )
 	throws SQLException
 	{

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/RecordParameterDefaults.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/RecordParameterDefaults.java
@@ -29,19 +29,22 @@ import org.postgresql.pljava.annotation.SQLType;
  * function.
  *<p>
  * Also tests the proper DDR generation of defaults for such parameters.
+ *<p>
+ * This example relies on {@code implementor} tags reflecting the PostgreSQL
+ * version, set up in the {@link ConditionalDDR} example.
  */
 @SQLActions({
 	@SQLAction(
 		provides = "paramtypeinfo type", // created in Triggers.java
 		install = {
 			"CREATE TYPE javatest.paramtypeinfo AS (" +
-			"name text, pgtypename text, javaclass text, tostring text" +
+			" name text, pgtypename text, javaclass text, tostring text" +
 			")"
 		},
 		remove = {
 			"DROP TYPE javatest.paramtypeinfo"
 		}
-	),
+	)
 })
 public class RecordParameterDefaults implements ResultSetProvider
 {
@@ -64,6 +67,7 @@ public class RecordParameterDefaults implements ResultSetProvider
 	@Function(
 		requires = "paramtypeinfo type",
 		schema = "javatest",
+		implementor = "postgresql_ge_80400", // supports function param DEFAULTs
 		type = "javatest.paramtypeinfo"
 		)
 	public static ResultSetProvider paramDefaultsRecord(
@@ -86,6 +90,7 @@ public class RecordParameterDefaults implements ResultSetProvider
 	 */
 	@Function(
 		requires = "foobar tables", // created in Triggers.java
+		implementor = "postgresql_ge_80400", // supports function param DEFAULTs
 		schema = "javatest"
 		)
 	public static String paramDefaultsNamedRow(

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/SetOfRecordTest.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/SetOfRecordTest.java
@@ -26,8 +26,13 @@ import org.postgresql.pljava.annotation.SQLAction;
  * Example implementing the {@code ResultSetHandle} interface, to return
  * the {@link ResultSet} from any SQL {@code SELECT} query passed as a string
  * to the {@link #executeSelect executeSelect} function.
+ *<p>
+ * This example relies on {@code implementor} tags reflecting the PostgreSQL
+ * version, set up in the {@link ConditionalDDR} example. Before PostgreSQL 8.4,
+ * there was no {@code =} or {@code DISTINCT FROM} operator between row types.
  */
-@SQLAction(requires="selecttorecords fn", install=
+@SQLAction(requires="selecttorecords fn", implementor="postgresql_ge_80400",
+install=
 " SELECT " +
 "  CASE WHEN r IS DISTINCT FROM ROW('Foo'::varchar, 1::integer, 1.5::float, " +
 "       23.67::decimal(8,2), '2005-06-01'::date, '20:56'::time, " +

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/Triggers.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/Triggers.java
@@ -36,6 +36,10 @@ import static org.postgresql.pljava.example.LoggerTest.logMessage;
  * Example creating a couple of tables, and a function to be called when
  * triggered by insertion into either table. In PostgreSQL 10 or later,
  * also create a function and trigger that uses transition tables.
+ *<p>
+ * This example relies on {@code implementor} tags reflecting the PostgreSQL
+ * version, set up in the {@link ConditionalDDR} example. Constraint triggers
+ * appear in PG 9.1, transition tables in PG 10.
  */
 @SQLActions({
 	@SQLAction(
@@ -48,20 +52,6 @@ import static org.postgresql.pljava.example.LoggerTest.logMessage;
 			"DROP TABLE javatest.foobar_2",
 			"DROP TABLE javatest.foobar_1"
 		}
-	),
-	@SQLAction(provides="postgresql_transitiontables", install=
-"   select case " +
-"    when 100000 <= cast(current_setting('server_version_num') as integer) " +
-"    then set_config('pljava.implementors', 'postgresql_transitiontables,' " +
-"    || current_setting('pljava.implementors'), true) " +
-"   end"
-	),
-	@SQLAction(provides="postgresql_constrainttriggers", install=
-"   select case " +
-"    when 90100 <= cast(current_setting('server_version_num') as integer) " +
-"    then set_config('pljava.implementors', 'postgresql_constrainttriggers,' " +
-"    || current_setting('pljava.implementors'), true) " +
-"   end"
 	),
 	@SQLAction(
 		requires = "constraint triggers",
@@ -117,7 +107,7 @@ public class Triggers
 	 * Transition tables first became available in PostgreSQL 10.
 	 */
 	@Function(
-		implementor = "postgresql_transitiontables",
+		implementor = "postgresql_ge_100000",
 		requires = "foobar tables",
 		provides = "transition triggers",
 		schema = "javatest",
@@ -150,7 +140,7 @@ public class Triggers
 	 * Constraint triggers first became available in PostgreSQL 9.1.
 	 */
 	@Function(
-		implementor = "postgresql_constrainttriggers",
+		implementor = "postgresql_ge_90100",
 		requires = "foobar tables",
 		provides = "constraint triggers",
 		schema = "javatest",

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/TypeRoundTripper.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/TypeRoundTripper.java
@@ -82,34 +82,40 @@ import org.postgresql.pljava.annotation.SQLAction;
  *  (VALUES (timestamptz '2017-08-21 18:25:29.900005Z')) AS p(orig),
  *  roundtrip(p) AS r(roundtripped timestamptz);
  *</pre>
+ *<p>
+ * This example relies on {@code implementor} tags reflecting the PostgreSQL
+ * version, set up in the {@link ConditionalDDR} example.
  */
-@SQLAction(requires = "TypeRoundTripper.roundTrip", install = {
-"	SELECT	"+
-"		CASE WHEN every(orig = roundtripped)	"+
-"		THEN javatest.logmessage('INFO', 'timestamp roundtrip passes')	"+
-"		ELSE javatest.logmessage('WARNING', 'timestamp roundtrip fails')"+
-"		END	"+
-"	FROM	"+
-"		(values	"+
-"			(timestamp '2017-08-21 18:25:29.900005'),	"+
-"			(timestamp '1970-03-07 17:37:49.300009'),	"+
-"			(timestamp '1919-05-29 13:08:33.600001')	"+
-"		) as p(orig),	"+
-"		roundtrip(p) as r(roundtripped timestamp)	",
+@SQLAction(implementor = "postgresql_ge_90300", // funcs see earlier FROM items
+	requires = "TypeRoundTripper.roundTrip",
+	install = {
+	" SELECT" +
+	"  CASE WHEN every(orig = roundtripped)" +
+	"  THEN javatest.logmessage('INFO', 'timestamp roundtrip passes')" +
+	"  ELSE javatest.logmessage('WARNING', 'timestamp roundtrip fails')" +
+	"  END" +
+	" FROM" +
+	"  (VALUES" +
+	"   (timestamp '2017-08-21 18:25:29.900005')," +
+	"   (timestamp '1970-03-07 17:37:49.300009')," +
+	"   (timestamp '1919-05-29 13:08:33.600001')" +
+	"  ) AS p(orig)," +
+	"  roundtrip(p) AS r(roundtripped timestamp)",
 
-"	SELECT	"+
-"		CASE WHEN every(orig = roundtripped)	"+
-"		THEN javatest.logmessage('INFO', 'timestamptz roundtrip passes')	"+
-"		ELSE javatest.logmessage('WARNING', 'timestamptz roundtrip fails')	"+
-"		END	"+
-"	FROM	"+
-"		(values	"+
-"			(timestamptz '2017-08-21 18:25:29.900005Z'),	"+
-"			(timestamptz '1970-03-07 17:37:49.300009Z'),	"+
-"			(timestamptz '1919-05-29 13:08:33.600001Z')	"+
-"		) as p(orig),	"+
-"		roundtrip(p) as r(roundtripped timestamptz)	",
-})
+	" SELECT" +
+	"  CASE WHEN every(orig = roundtripped)" +
+	"  THEN javatest.logmessage('INFO', 'timestamptz roundtrip passes')" +
+	"  ELSE javatest.logmessage('WARNING', 'timestamptz roundtrip fails')" +
+	"  END" +
+	" FROM" +
+	"  (VALUES" +
+	"   (timestamptz '2017-08-21 18:25:29.900005Z')," +
+	"   (timestamptz '1970-03-07 17:37:49.300009Z')," +
+	"   (timestamptz '1919-05-29 13:08:33.600001Z')" +
+	"  ) AS p(orig)," +
+	"  roundtrip(p) AS r(roundtripped timestamptz)",
+	}
+)
 public class TypeRoundTripper
 {
 	private TypeRoundTripper() { }

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/UnicodeRoundTripTest.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/UnicodeRoundTripTest.java
@@ -35,15 +35,18 @@ import org.postgresql.pljava.annotation.Function;
  * calls this function on each (1k array, 1k string) pair, and counts a failure
  * if {@code matched} is false or the original and returned arrays or strings
  * do not match as seen in SQL.
+ * <p>
+ * This example relies on {@code implementor} tags reflecting the PostgreSQL
+ * version, set up in the {@link ConditionalDDR} example, and also sets its own.
  */
 @SQLActions({
-	@SQLAction(provides="postgresql_unicodetest", install=
-"   select case " +
-"    when 90000 <= cast(current_setting('server_version_num') as integer) " +
-"    and 'UTF8' = current_setting('server_encoding') " +
-"    then set_config('pljava.implementors', 'postgresql_unicodetest,' || " +
-"    current_setting('pljava.implementors'), true) " +
-"   end"
+	@SQLAction(provides="postgresql_unicodetest",
+		implementor="postgresql_ge_90000", install=
+		"SELECT CASE" +
+		" WHEN 'UTF8' = current_setting('server_encoding')" +
+		" THEN set_config('pljava.implementors', 'postgresql_unicodetest,' ||" +
+		" current_setting('pljava.implementors'), true) " +
+		"END"
 	),
 	@SQLAction(requires="unicodetest fn",
 	implementor="postgresql_unicodetest",
@@ -77,9 +80,9 @@ import org.postgresql.pljava.annotation.Function;
 "    ) " +
 "   select " +
 "    case when n_failing_groups > 0 then " +
-"     javatest.logmessage('WARNING', format( " +
-"      '%s 1k codepoint ranges had mismatches, first is block starting 0x%s', " +
-"      n_failing_groups, to_hex(1024 * first_failing_group))) " +
+"     javatest.logmessage('WARNING', n_failing_groups || " +
+"      ' 1k codepoint ranges had mismatches, first is block starting 0x' || " +
+"      to_hex(1024 * first_failing_group)) " +
 "    else " +
 "     javatest.logmessage('INFO', " +
 "        'all Unicode codepoint ranges roundtripped successfully.') " +

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/VarlenaUDTTest.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/VarlenaUDTTest.java
@@ -27,8 +27,11 @@ import org.postgresql.pljava.annotation.BaseUDT;
  * characters. That makes it easy to test how big a value gets correctly stored
  * and retrieved. It should be about a GB, but in issue 52 was failing at 32768
  * because of a narrowing assignment in the native code.
+ *<p>
+ * This example relies on {@code implementor} tags reflecting the PostgreSQL
+ * version, set up in the {@link ConditionalDDR} example.
  */
-@SQLAction(requires="varlena UDT", install=
+@SQLAction(requires="varlena UDT", implementor="postgresql_ge_80300", install=
 "  SELECT CASE v::text = v::javatest.VarlenaUDTTest::text " +
 "   WHEN true THEN javatest.logmessage('INFO', 'works for ' || v) " +
 "   ELSE javatest.logmessage('WARNING', 'fails for ' || v) " +

--- a/pljava-so/src/main/c/Backend.c
+++ b/pljava-so/src/main/c/Backend.c
@@ -727,7 +727,11 @@ static void reLogWithChangedLevel(int level)
 	FreeErrorData(edata);
 #else
 	if (!errstart(level, edata->filename, edata->lineno,
-				  edata->funcname, NULL))
+				  edata->funcname
+#if PG_VERSION_NUM >= 80400
+				  , NULL
+#endif
+				 ))
 	{
 		FreeErrorData(edata);
 		return;
@@ -738,8 +742,10 @@ static void reLogWithChangedLevel(int level)
 		errmsg("%s", edata->message);
 	if (edata->detail)
 		errdetail("%s", edata->detail);
+#if PG_VERSION_NUM >= 80400
 	if (edata->detail_log)
 		errdetail_log("%s", edata->detail_log);
+#endif
 	if (edata->hint)
 		errhint("%s", edata->hint);
 	if (edata->context)
@@ -1310,122 +1316,125 @@ static jint initializeJavaVM(JVMOptList *optList)
 	return jstat;
 }
 
+#if PG_VERSION_NUM >= 80400
+#define GUCBOOTVAL(v) (v),
+#define GUCBOOTASSIGN(a, v)
+#define GUCFLAGS(f) (f),
+#else
+#define GUCBOOTVAL(v)
+#define GUCBOOTASSIGN(a, v) \
+	StaticAssertStmt(NULL != (valueAddr), "NULL valueAddr for GUC"); \
+	*(a) = (v);
+#define GUCFLAGS(f)
+#endif
+
+#if PG_VERSION_NUM >= 90100
+#define GUCCHECK(h) (h),
+#else
+#define GUCCHECK(h)
+#endif
+
+#define BOOL_GUC(name, short_desc, long_desc, valueAddr, bootValue, context, \
+                 flags, check_hook, assign_hook, show_hook) \
+	GUCBOOTASSIGN((valueAddr), (bootValue)) \
+	DefineCustomBoolVariable((name), (short_desc), (long_desc), (valueAddr), \
+		GUCBOOTVAL(bootValue) (context), GUCFLAGS(flags) GUCCHECK(check_hook) \
+		assign_hook, show_hook)
+
+#define INT_GUC(name, short_desc, long_desc, valueAddr, bootValue, minValue, \
+				maxValue, context, flags, check_hook, assign_hook, show_hook) \
+	GUCBOOTASSIGN((valueAddr), (bootValue)) \
+	DefineCustomIntVariable((name), (short_desc), (long_desc), (valueAddr), \
+		GUCBOOTVAL(bootValue) (minValue), (maxValue), (context), \
+		GUCFLAGS(flags) GUCCHECK(check_hook) assign_hook, show_hook)
+
+#define STRING_GUC(name, short_desc, long_desc, valueAddr, bootValue, context, \
+				   flags, check_hook, assign_hook, show_hook) \
+	GUCBOOTASSIGN((char const **)(valueAddr), (bootValue)) \
+	DefineCustomStringVariable((name), (short_desc), (long_desc), (valueAddr), \
+		GUCBOOTVAL(bootValue) (context), GUCFLAGS(flags) GUCCHECK(check_hook) \
+		assign_hook, show_hook)
+
 static void registerGUCOptions(void)
 {
 	static char pathbuf[MAXPGPATH];
 
-	DefineCustomStringVariable(
+	STRING_GUC(
 		"pljava.libjvm_location",
 		"Path to the libjvm (.so, .dll, etc.) file in Java's jre/lib area",
 		NULL, /* extended description */
 		&libjvmlocation,
-		#if PG_VERSION_NUM >= 80400
-			#ifdef PLJAVA_LIBJVMDEFAULT
-				CppAsString2(PLJAVA_LIBJVMDEFAULT),
-			#else
-				"libjvm",
-			#endif
+		#ifdef PLJAVA_LIBJVMDEFAULT
+			CppAsString2(PLJAVA_LIBJVMDEFAULT),
+		#else
+			"libjvm",
 		#endif
 		PGC_SUSET,
-		#if PG_VERSION_NUM >= 80400
-			0,    /* flags */
-		#endif
-		#if PG_VERSION_NUM >= 90100
-			check_libjvm_location,
-		#endif
+		0,    /* flags */
+		check_libjvm_location,
 		assign_libjvm_location,
 		NULL); /* show hook */
 
-	DefineCustomStringVariable(
+	STRING_GUC(
 		"pljava.vmoptions",
 		"Options sent to the JVM when it is created",
 		NULL, /* extended description */
 		&vmoptions,
-		#if PG_VERSION_NUM >= 80400
-			NULL, /* boot value */
-		#endif
+		NULL, /* boot value */
 		PGC_SUSET,
-		#if PG_VERSION_NUM >= 80400
-			0,    /* flags */
-		#endif
-		#if PG_VERSION_NUM >= 90100
-			check_vmoptions,
-		#endif
+		0,    /* flags */
+		check_vmoptions,
 		assign_vmoptions,
 		NULL); /* show hook */
 
-	DefineCustomStringVariable(
+	STRING_GUC(
 		"pljava.classpath",
 		"Classpath used by the JVM",
 		NULL, /* extended description */
 		&classpath,
-		#if PG_VERSION_NUM >= 80400
-			InstallHelper_defaultClassPath(pathbuf), /* boot value */
-		#endif
+		InstallHelper_defaultClassPath(pathbuf), /* boot value */
 		PGC_SUSET,
-		#if PG_VERSION_NUM >= 80400
-			0,    /* flags */
-		#endif
-		#if PG_VERSION_NUM >= 90100
-			check_classpath,
-		#endif
+		0,    /* flags */
+		check_classpath,
 		assign_classpath,
 		NULL); /* show hook */
 
-	DefineCustomBoolVariable(
+	BOOL_GUC(
 		"pljava.debug",
 		"Stop the backend to attach a debugger",
 		NULL, /* extended description */
 		&pljavaDebug,
-		#if PG_VERSION_NUM >= 80400
-			false, /* boot value */
-		#endif
+		false, /* boot value */
 		PGC_USERSET,
-		#if PG_VERSION_NUM >= 80400
-			0,    /* flags */
-		#endif
-		#if PG_VERSION_NUM >= 90100
-			NULL, /* check hook */
-		#endif
+		0,    /* flags */
+		NULL, /* check hook */
 		NULL, NULL); /* assign hook, show hook */
 
-	DefineCustomIntVariable(
+	INT_GUC(
 		"pljava.statement_cache_size",
 		"Size of the prepared statement MRU cache",
 		NULL, /* extended description */
 		&statementCacheSize,
-		#if PG_VERSION_NUM >= 80400
-			11,   /* boot value */
-		#endif
+		11,   /* boot value */
 		0, 512,   /* min, max values */
 		PGC_USERSET,
-		#if PG_VERSION_NUM >= 80400
-			0,    /* flags */
-		#endif
-		#if PG_VERSION_NUM >= 90100
-			NULL, /* check hook */
-		#endif
+		0,    /* flags */
+		NULL, /* check hook */
 		NULL, NULL); /* assign hook, show hook */
 
-	DefineCustomBoolVariable(
+	BOOL_GUC(
 		"pljava.release_lingering_savepoints",
 		"If true, lingering savepoints will be released on function exit. "
 		"If false, they will be rolled back",
 		NULL, /* extended description */
 		&pljavaReleaseLingeringSavepoints,
-		#if PG_VERSION_NUM >= 80400
-			false, /* boot value */
-		#endif
+		false, /* boot value */
 		PGC_USERSET,
-		#if PG_VERSION_NUM >= 80400
-			0,    /* flags */
-		#endif
-		#if PG_VERSION_NUM >= 90100
-			NULL, /* check hook */
-		#endif
+		0,    /* flags */
+		NULL, /* check hook */
 		NULL, NULL); /* assign hook, show hook */
 
-	DefineCustomBoolVariable(
+	BOOL_GUC(
 		"pljava.enable",
 		"If off, the Java virtual machine will not be started until set on.",
 		"This is mostly of use on PostgreSQL versions < 9.2, where option "
@@ -1434,42 +1443,40 @@ static void registerGUCOptions(void)
 		&pljavaEnabled,
 		#if PG_VERSION_NUM >= 90200
 			true,  /* boot value */
-		#elif PG_VERSION_NUM >= 80400
+		#else
 			false, /* boot value */
 		#endif
 		PGC_USERSET,
-		#if PG_VERSION_NUM >= 80400
-			0,    /* flags */
-		#endif
-		#if PG_VERSION_NUM >= 90100
-			check_enabled, /* check hook */
-		#endif
+		0,    /* flags */
+		check_enabled, /* check hook */
 		assign_enabled,
 		NULL); /* show hook */
 
-	DefineCustomStringVariable(
+	STRING_GUC(
 		"pljava.implementors",
 		"Implementor names recognized in deployment descriptors",
 		NULL, /* extended description */
 		&implementors,
-		#if PG_VERSION_NUM >= 80400
-			"postgresql", /* boot value */
-		#endif
+		"postgresql", /* boot value */
 		PGC_USERSET,
-		#if PG_VERSION_NUM >= 80400
-			GUC_LIST_INPUT
-			#if PG_VERSION_NUM < 110000
-				| GUC_LIST_QUOTE
-			#endif
-			,
+		GUC_LIST_INPUT
+		#if PG_VERSION_NUM < 110000
+			| GUC_LIST_QUOTE
 		#endif
-		#if PG_VERSION_NUM >= 90100
-			NULL, /* check hook */
-		#endif
+		,
+		NULL, /* check hook */
 		NULL, NULL); /* assign hook, show hook */
 
 	EmitWarningsOnPlaceholders("pljava");
 }
+
+#undef GUCBOOTVAL
+#undef GUCBOOTASSIGN
+#undef GUCFLAGS
+#undef GUCCHECK
+#undef BOOL_GUC
+#undef INT_GUC
+#undef STRING_GUC
 
 static Datum internalCallHandler(bool trusted, PG_FUNCTION_ARGS);
 

--- a/pljava-so/src/main/c/InstallHelper.c
+++ b/pljava-so/src/main/c/InstallHelper.c
@@ -45,14 +45,6 @@
 #include "pljava/type/String.h"
 
 /*
- * CppAsString2 first appears in PG8.4.  Once the compatibility target reaches
- * 8.4, this fallback will not be needed.
- */
-#ifndef CppAsString2
-#define CppAsString2(x) CppAsString(x)
-#endif
-
-/*
  * Before 9.1, there was no creating_extension. Before 9.5, it did not have
  * PGDLLIMPORT and so was not visible in Windows. In either case, just define
  * it to be false, but also define CREATING_EXTENSION_HACK if on Windows and

--- a/pljava-so/src/main/c/type/Type.c
+++ b/pljava-so/src/main/c/type/Type.c
@@ -46,7 +46,7 @@ static CoercionPathType fcp(Oid targetTypeId, Oid sourceTypeId,
 							CoercionContext ccontext, Oid *funcid)
 {
 	if ( find_coercion_pathway(targetTypeId, sourceTypeId, ccontext, funcid) )
-		return *funcId != InvalidOid ?
+		return *funcid != InvalidOid ?
 			COERCION_PATH_FUNC : COERCION_PATH_RELABELTYPE;
 	else
 		return COERCION_PATH_NONE;

--- a/pljava-so/src/main/include/pljava/InstallHelper.h
+++ b/pljava-so/src/main/include/pljava/InstallHelper.h
@@ -19,6 +19,15 @@
  */
 
 /*
+ * CppAsString2 first appears in PG8.4.  Once the compatibility target reaches
+ * 8.4, this fallback will not be needed. Used in InstallHelper and Backend,
+ * both of which include this file.
+ */
+#ifndef CppAsString2
+#define CppAsString2(x) CppAsString(x)
+#endif
+
+/*
  * The path from which this library is being loaded, which is surprisingly
  * tricky to find (and wouldn't be, if PostgreSQL called _PG_init functions
  * with the path of the library being loaded!). Set by pljavaCheckExtension().

--- a/pljava/src/main/java/org/postgresql/pljava/internal/InstallHelper.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/InstallHelper.java
@@ -45,7 +45,8 @@ public class InstallHelper
 	}
 
 	public static String hello(
-		String nativeVer, String user, String dbname, String clustername,
+		String nativeVer, String serverBuiltVer, String serverRunningVer,
+		String user, String dbname, String clustername,
 		String datadir, String libdir, String sharedir, String etcdir)
 	{
 		String implVersion =
@@ -120,6 +121,8 @@ public class InstallHelper
 		StringBuilder sb = new StringBuilder();
 		sb.append( "PL/Java native code (").append( nativeVer).append( ")\n");
 		sb.append( "PL/Java common code (").append( implVersion).append( ")\n");
+		sb.append( "Built for (").append( serverBuiltVer).append( ")\n");
+		sb.append( "Loaded in (").append( serverRunningVer).append( ")\n");
 		sb.append( jreName).append( " (").append( jreVer).append( ")\n");
 		sb.append( vmName).append( " (").append( vmVer);
 		if ( null != vmInfo )


### PR DESCRIPTION
A recent pull request added (with apparent success) PostgreSQL 11 support, and meanwhile `versions.md` for this, the 1.5.x branch, still says the "current aim is to avoid deliberately breaking compatibility back to 8.2."

That's a wide range of PG versions, and without a buildfarm regularly testing against them, some issues have found their way in to thwart building with some of those releases. (Additions to PL/Java itself not tested against all those PG versions can have that effect, as can PostgreSQL changes getting backpatched into old versions that were supposed to have worked.)

The next _major_ release of PL/Java is sure to drastically curtail the number of ancient PostgreSQL versions supported. That is another reason to undertake this chore on the 1.5 branch; it's good, before the master branch leaves the past all behind, to make sure that there is at least one point in git history where the 1.5 branch builds on all the PG releases it's intended to.

The testing here is still not _exhaustive_; building, loading, and running the examples are here confirmed on _one_ platform (linux), with the _latest_ maintenance release of each of the supported PG major releases. That feels good enough.