### PR TITLE
Do not clobber timeouts when loaded (#166).

### DIFF
--- a/pljava-so/src/main/c/Backend.c
+++ b/pljava-so/src/main/c/Backend.c
@@ -1084,7 +1084,6 @@ static void _destroyJavaVM(int status, Datum dummy)
 		}
 
 #if PG_VERSION_NUM >= 90300
-		InitializeTimeouts();           /* establishes SIGALRM handler */
 		tid = RegisterTimeout(USER_TIMEOUT, terminationTimeoutHandler);
 #else
 		saveSigAlrm = pqsignal(SIGALRM, terminationTimeoutHandler);


### PR DESCRIPTION
The call to InitializeTimeouts here was probably added based on
a quick reading of the code comment in PG's timeout.c, where it
says "This must be called in every process that wants to use timeouts."
But it has been called already in a backend process (PostgresMain
did that), and calling it again here is not necessary or correct.