### PR TITLE
Give ResultSets actual CLOSE_CURSORS_AT_COMMIT holdability (issue 168)

### DIFF
--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/Holdability.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/Holdability.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2018- Tada AB and other contributors, as listed below.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Chapman Flack
+ */
+package org.postgresql.pljava.example.annotation;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import org.postgresql.pljava.ResultSetHandle;
+import org.postgresql.pljava.annotation.Function;
+
+/**
+ * Demonstrate holdability of ResultSets (test for issue 168).
+ *<p>
+ * The {@code stashResultSet} method will execute a query and save its
+ * {@code ResultSet} (wrapped in a {@code ResultSetHandle} in a static
+ * for later retrieval. The {@code unstashResultSet} method, called later
+ * in the same transaction, retrieves and returns the result set. A call after
+ * the transaction has ended will fail.
+ *<p>
+ * The query selects all rows from {@code pg_description}, a table that should
+ * always exist, with more rows than the default connection {@code fetchSize},
+ * to ensure the stashed {@code ResultSet} has work to do.
+ */
+public class Holdability implements ResultSetHandle
+{
+	private static Holdability s_stash;
+
+	private ResultSet m_resultSet;
+	private Statement m_stmt;
+
+	private Holdability(Statement s, ResultSet rs)
+	{
+		m_stmt = s;
+		m_resultSet = rs;
+	}
+
+	/**
+	 * Query all rows from {@code pg_description}, but stash the
+	 * {@code ResultSet} for retrieval later in the same transaction by
+	 * {@code unstashResultSet}.
+	 *<p>
+	 * This must be called in an open, multiple-statement (non-auto) transaction
+	 * to have any useful effect.
+	 */
+	@Function(schema="javatest")
+	public static void stashResultSet() throws SQLException
+	{
+		Connection c = DriverManager.getConnection("jdbc:default:connection");
+		Statement s = c.createStatement();
+		ResultSet rs = s.executeQuery(
+			"SELECT * FROM pg_catalog.pg_description");
+		s_stash = new Holdability(s, rs);
+	}
+
+	/**
+	 * Return the results stashed earlier in the same transaction by
+	 * {@code stashResultSet}.
+	 */
+	@Function(schema="javatest", type="pg_catalog.pg_description")
+	public static ResultSetHandle unstashResultSet() throws SQLException
+	{
+		return s_stash;
+	}
+
+	/*
+	 * Necessary methods to implement ResultSetHandle follow.
+	 */
+
+	@Override
+	public ResultSet getResultSet() throws SQLException
+	{
+		return m_resultSet;
+	}
+
+	@Override
+	public void close() throws SQLException
+	{
+		Connection c = m_stmt.getConnection();
+		m_stmt.close();
+		c.close();
+	}
+}

--- a/pljava-so/src/main/c/Invocation.c
+++ b/pljava-so/src/main/c/Invocation.c
@@ -1,10 +1,14 @@
 /*
- * Copyright (c) 2004, 2005, 2006 TADA AB - Taby Sweden
- * Distributed under the terms shown in the file COPYRIGHT
- * found in the root folder of this project or at
- * http://eng.tada.se/osprojects/COPYRIGHT.html
+ * Copyright (c) 2004-2018 Tada AB and other contributors, as listed below.
  *
- * @author Thomas Hallgren
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Tada AB
+ *   Chapman Flack
  */
 #include <postgres.h>
 #include <executor/spi.h>
@@ -88,7 +92,7 @@ void Invocation_assertConnect(void)
 	{
 		rslt = SPI_connect();
 		if ( SPI_OK_CONNECT != rslt )
-			elog(ERROR, "SPI_register_trigger_data returned %s",
+			elog(ERROR, "SPI_connect returned %s",
 						SPI_result_code_string(rslt));
 #if PG_VERSION_NUM >= 100000
 		if ( NULL != currentInvocation->triggerData )

--- a/pljava-so/src/main/c/type/Portal.c
+++ b/pljava-so/src/main/c/type/Portal.c
@@ -193,6 +193,7 @@ Java_org_postgresql_pljava_internal_Portal__1fetch(JNIEnv* env, jclass clazz, jl
 		p2l.longVal = _this;
 		PG_TRY();
 		{
+			Invocation_assertConnect();
 			SPI_cursor_fetch((Portal)p2l.ptrVal, forward == JNI_TRUE,
 				(long)count);
 			result = (jlong)SPI_processed;
@@ -340,6 +341,7 @@ Java_org_postgresql_pljava_internal_Portal__1move(JNIEnv* env, jclass clazz, jlo
 		p2l.longVal = _this;
 		PG_TRY();
 		{
+			Invocation_assertConnect();
 			SPI_cursor_move((Portal)p2l.ptrVal, forward == JNI_TRUE, (long)count);
 			result = (jlong)SPI_processed;
 		}

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/ResultSetBase.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/ResultSetBase.java
@@ -1,10 +1,15 @@
 /*
- * Copyright (c) 2004, 2005, 2006 TADA AB - Taby Sweden
- * Copyright (c) 2010, 2011 PostgreSQL Global Development Group
+ * Copyright (c) 2005-2018 Tada AB and other contributors, as listed below.
  *
- * Distributed under the terms shown in the file COPYRIGHT
- * found in the root folder of this project or at
- * http://wiki.tada.se/index.php?title=PLJava_License
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Filip Hrbek
+ *   PostgreSQL Global Development Group
+ *   Chapman Flack
  */
 package org.postgresql.pljava.jdbc;
 
@@ -167,8 +172,7 @@ abstract class ResultSetBase extends ReadOnlyResultSet
 	}
 
 	/**
-	 * Returns {@link ResultSet#CLOSE_CURSORS_AT_COMMIT}. Cursors
-	 * are actually closed when a function returns to SQL.
+	 * Returns {@link ResultSet#CLOSE_CURSORS_AT_COMMIT}.
 	 */
 	public int getHoldability()
 		throws SQLException

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/SPIConnection.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/SPIConnection.java
@@ -148,8 +148,7 @@ public class SPIConnection implements Connection
 	}
 
 	/**
-	 * Returns {@link ResultSet#CLOSE_CURSORS_AT_COMMIT}. Cursors are actually
-	 * closed when a function returns to SQL.
+	 * Returns {@link ResultSet#CLOSE_CURSORS_AT_COMMIT}.
 	 */
 	@Override
 	public int getHoldability()

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/SPIDatabaseMetaData.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/SPIDatabaseMetaData.java
@@ -3344,7 +3344,7 @@ public class SPIDatabaseMetaData implements DatabaseMetaData
 	public boolean supportsResultSetHoldability(int holdability)
 	throws SQLException
 	{
-		return true;
+		return ResultSet.CLOSE_CURSORS_AT_COMMIT == holdability;
 	}
 
 	/**
@@ -3359,7 +3359,7 @@ public class SPIDatabaseMetaData implements DatabaseMetaData
 	 */
 	public int getResultSetHoldability() throws SQLException
 	{
-		return ResultSet.HOLD_CURSORS_OVER_COMMIT;
+		return ResultSet.CLOSE_CURSORS_AT_COMMIT;
 	}
 
 	/**

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/SingleRowResultSet.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/SingleRowResultSet.java
@@ -1,10 +1,15 @@
 /*
- * Copyright (c) 2004, 2005, 2006 TADA AB - Taby Sweden
- * Copyright (c) 2010, 2011 PostgreSQL Global Development Group
+ * Copyright (c) 2004-2018 Tada AB and other contributors, as listed below.
  *
- * Distributed under the terms shown in the file COPYRIGHT
- * found in the root folder of this project or at
- * http://wiki.tada.se/index.php?title=PLJava_License
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Thomas Hallgren
+ *   PostgreSQL Global Development Group
+ *   Chapman Flack
  */
 package org.postgresql.pljava.jdbc;
 
@@ -281,8 +286,9 @@ public abstract class SingleRowResultSet extends ObjectResultSet
 	// ************************************************************
 
 	/**
-	 * Returns {@link ResultSet#CLOSE_CURSORS_AT_COMMIT}. Cursors
-	 * are actually closed when a function returns to SQL.
+	 * Returns {@link ResultSet#CLOSE_CURSORS_AT_COMMIT}. A single-row result
+	 * set serves a special purpose in the call or return of a function, and is
+	 * not guaranteed to be usable beyond that function's return.
 	 */
 	public int getHoldability()
 	{

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/SingleRowWriter.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/SingleRowWriter.java
@@ -152,15 +152,6 @@ public class SingleRowWriter extends SingleRowResultSet
 		return m_tuple == null;
 	}
 
-	/**
-	 * Returns {@link ResultSet#CLOSE_CURSORS_AT_COMMIT}. Cursors
-	 * are actually closed when a function returns to SQL.
-	 */
-	public int getHoldability()
-	{
-		return ResultSet.CLOSE_CURSORS_AT_COMMIT;
-	}
-
 	// ************************************************************
 	// End of implementation of JDBC 4 methods.
 	// ************************************************************


### PR DESCRIPTION
There were several comments scattered through the code saying PL/Java's `ResultSet`s were unusable after function return, even though they would report holdability of `CLOSE_CURSORS_AT_COMMIT`.

That was true, but only because of a couple of missing `Invocation_assertConnect` calls, so insert those, and update the old pessimistic comments.