### PR TITLE
Support Java 8 java.time classes as alt mappings for SQL date/time/timestamp (w/wo tz)

### DIFF
--- a/pljava-api/src/main/java/org/postgresql/pljava/sqlgen/DDRProcessor.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/sqlgen/DDRProcessor.java
@@ -1613,6 +1613,8 @@ hunt:	for ( ExecutableElement ee : ees )
 
 		void appendAS( StringBuilder sb)
 		{
+			if ( ! ( complexViaInOut || setof || trigger ) )
+				sb.append( func.getReturnType()).append( '=');
 			Element e = func.getEnclosingElement();
 			if ( ! e.getKind().equals( ElementKind.CLASS) )
 				msg( Kind.ERROR, func,

--- a/pljava-api/src/main/java/org/postgresql/pljava/sqlgen/DDRProcessor.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/sqlgen/DDRProcessor.java
@@ -2259,6 +2259,14 @@ hunt:	for ( ExecutableElement ee : ees )
 			this.addMap(Object.class, "\"any\"");
 
 			this.addMap(byte[].class, "bytea");
+
+			// (Once Java back horizon advances to 8, do these the easy way.)
+			//
+			this.addMapIfExists("java.time.LocalDate", "date");
+			this.addMapIfExists("java.time.LocalTime", "time");
+			this.addMapIfExists("java.time.OffsetTime", "timetz");
+			this.addMapIfExists("java.time.LocalDateTime", "timestamp");
+			this.addMapIfExists("java.time.OffsetDateTime", "timestamptz");
 		}
 
 		private boolean mappingsFrozen()
@@ -2384,6 +2392,20 @@ hunt:	for ( ExecutableElement ee : ees )
 		void addMap(Class<?> k, String v)
 		{
 			addMap( typeMirrorFromClass( k), v);
+		}
+
+		/**
+		 * Add a custom mapping from a Java class to an SQL type, if a class
+		 * with the given name exists.
+		 *
+		 * @param k Canonical class name representing the Java type
+		 * @param v String representing the SQL type to be used
+		 */
+		void addMapIfExists(String k, String v)
+		{
+			TypeElement te = elmu.getTypeElement( k);
+			if ( null != te )
+				addMap( te.asType(), v);
 		}
 
 		/**

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/JDBC42_21.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/JDBC42_21.java
@@ -78,10 +78,19 @@ import org.postgresql.pljava.annotation.SQLActions;
 		"  ELSE javatest.logmessage('WARNING','java.time.LocalDateTime fails')"+
 		"  END" +
 		" FROM" +
-		"  (VALUES" +
-		"   (timestamp '2017-08-21 18:25:29.900005')," +
-		"   (timestamp '1970-03-07 17:37:49.300009')," +
-		"   (timestamp '1919-05-29 13:08:33.600001')" +
+		"  (SELECT 'on' = current_setting('integer_datetimes')) AS ck(idt)," +
+		"  LATERAL (" +
+		"   SELECT" +
+		"    value" +
+		"   FROM" +
+		"	 (VALUES" +
+		"	  (true, timestamp '2017-08-21 18:25:29.900005')," +
+		"	  (true, timestamp '1970-03-07 17:37:49.300009')," +
+		"	  (true, timestamp '1919-05-29 13:08:33.600001')," +
+		"	  (idt,  timestamp  'infinity')," +
+		"	  (idt,  timestamp '-infinity')" +
+		"	 ) AS vs(cond, value)" +
+		"   WHERE cond" +
 		"  ) AS p(orig)," +
 		"  javatest.roundtrip(p, 'java.time.LocalDateTime')" +
 		"  AS r(roundtripped timestamp)",
@@ -93,10 +102,19 @@ import org.postgresql.pljava.annotation.SQLActions;
 		"         'WARNING','java.time.OffsetDateTime fails')"+
 		"  END" +
 		" FROM" +
-		"  (VALUES" +
-		"   (timestamptz '2017-08-21 18:25:29.900005Z')," +
-		"   (timestamptz '1970-03-07 17:37:49.300009Z')," +
-		"   (timestamptz '1919-05-29 13:08:33.600001Z')" +
+		"  (SELECT 'on' = current_setting('integer_datetimes')) AS ck(idt)," +
+		"  LATERAL (" +
+		"   SELECT" +
+		"    value" +
+		"   FROM" +
+		"	 (VALUES" +
+		"	  (true, timestamptz '2017-08-21 18:25:29.900005Z')," +
+		"	  (true, timestamptz '1970-03-07 17:37:49.300009Z')," +
+		"	  (true, timestamptz '1919-05-29 13:08:33.600001Z')," +
+		"	  (idt,  timestamptz  'infinity')," +
+		"	  (idt,  timestamptz '-infinity')" +
+		"	 ) AS vs(cond, value)" +
+		"   WHERE cond" +
 		"  ) AS p(orig)," +
 		"  javatest.roundtrip(p, 'java.time.OffsetDateTime')" +
 		"  AS r(roundtripped timestamptz)",

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/JDBC42_21.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/JDBC42_21.java
@@ -99,7 +99,18 @@ import org.postgresql.pljava.annotation.SQLActions;
 		"   (timestamptz '1919-05-29 13:08:33.600001Z')" +
 		"  ) AS p(orig)," +
 		"  javatest.roundtrip(p, 'java.time.OffsetDateTime')" +
-		"  AS r(roundtripped timestamptz)"
+		"  AS r(roundtripped timestamptz)",
+
+		" SELECT" +
+		"  CASE WHEN every(orig = roundtripped)" +
+		"  THEN javatest.logmessage('INFO', 'OffsetTime as stmt param passes')"+
+		"  ELSE javatest.logmessage(" +
+		"         'WARNING','java.time.OffsetTime as stmt param fails')"+
+		"  END" +
+		" FROM" +
+		"  (SELECT current_time::timetz) AS p(orig)," +
+		"  javatest.roundtrip(p, 'java.time.OffsetTime', true)" +
+		"  AS r(roundtripped timetz)"
 	})
 })
 public class JDBC42_21

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/JDBC42_21.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/JDBC42_21.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2018- Tada AB and other contributors, as listed below.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Chapman Flack
+ */
+package org.postgresql.pljava.example.annotation;
+
+import org.postgresql.pljava.annotation.Function;
+import org.postgresql.pljava.annotation.SQLAction;
+import org.postgresql.pljava.annotation.SQLActions;
+
+/**
+ * Exercise new mappings between date/time types and java.time classes
+ * (JDBC 4.2 change 21).
+ *<p>
+ * Defines a method {@link #javaSpecificationGE javaSpecificationGE} that may be
+ * of use for other examples.
+ *<p>
+ * Relies on PostgreSQL-version-specific implementor tags set up in the
+ * {@link ConditionalDDR} example.
+ */
+@SQLActions({
+	@SQLAction(
+		implementor="postgresql_ge_90300", requires="javaSpecificationGE",
+		install=
+		"SELECT CASE WHEN javatest.javaSpecificationGE('1.8')" +
+		" THEN set_config('pljava.implementors', 'pg_jdbc42_21,' || " +
+		" current_setting('pljava.implementors'), true) " +
+		"END"
+	),
+
+	@SQLAction(
+		implementor="pg_jdbc42_21", requires="TypeRoundTripper.roundTrip",
+		install={
+		" SELECT" +
+		"  CASE WHEN every(orig = roundtripped)" +
+		"  THEN javatest.logmessage('INFO', 'java.time.LocalDate passes')" +
+		"  ELSE javatest.logmessage('WARNING', 'java.time.LocalDate fails')" +
+		"  END" +
+		" FROM" +
+		"  (VALUES" +
+		"   (date '2017-08-21')," +
+		"   (date '1970-03-07')," +
+		"   (date '1919-05-29')" +
+		"  ) AS p(orig)," +
+		"  javatest.roundtrip(p, 'java.time.LocalDate')" +
+		"  AS r(roundtripped date)",
+
+		" SELECT" +
+		"  CASE WHEN every(orig = roundtripped)" +
+		"  THEN javatest.logmessage('INFO', 'java.time.LocalTime passes')" +
+		"  ELSE javatest.logmessage('WARNING', 'java.time.LocalTime fails')" +
+		"  END" +
+		" FROM" +
+		"  (SELECT current_time::time) AS p(orig)," +
+		"  javatest.roundtrip(p, 'java.time.LocalTime')" +
+		"  AS r(roundtripped time)",
+
+		" SELECT" +
+		"  CASE WHEN every(orig = roundtripped)" +
+		"  THEN javatest.logmessage('INFO', 'java.time.OffsetTime passes')" +
+		"  ELSE javatest.logmessage('WARNING', 'java.time.OffsetTime fails')" +
+		"  END" +
+		" FROM" +
+		"  (SELECT current_time::timetz) AS p(orig)," +
+		"  javatest.roundtrip(p, 'java.time.OffsetTime')" +
+		"  AS r(roundtripped timetz)",
+
+		" SELECT" +
+		"  CASE WHEN every(orig = roundtripped)" +
+		"  THEN javatest.logmessage('INFO', 'java.time.LocalDateTime passes')" +
+		"  ELSE javatest.logmessage('WARNING','java.time.LocalDateTime fails')"+
+		"  END" +
+		" FROM" +
+		"  (VALUES" +
+		"   (timestamp '2017-08-21 18:25:29.900005')," +
+		"   (timestamp '1970-03-07 17:37:49.300009')," +
+		"   (timestamp '1919-05-29 13:08:33.600001')" +
+		"  ) AS p(orig)," +
+		"  javatest.roundtrip(p, 'java.time.LocalDateTime')" +
+		"  AS r(roundtripped timestamp)",
+
+		" SELECT" +
+		"  CASE WHEN every(orig = roundtripped)" +
+		"  THEN javatest.logmessage('INFO', 'java.time.OffsetDateTime passes')"+
+		"  ELSE javatest.logmessage(" +
+		"         'WARNING','java.time.OffsetDateTime fails')"+
+		"  END" +
+		" FROM" +
+		"  (VALUES" +
+		"   (timestamptz '2017-08-21 18:25:29.900005Z')," +
+		"   (timestamptz '1970-03-07 17:37:49.300009Z')," +
+		"   (timestamptz '1919-05-29 13:08:33.600001Z')" +
+		"  ) AS p(orig)," +
+		"  javatest.roundtrip(p, 'java.time.OffsetDateTime')" +
+		"  AS r(roundtripped timestamptz)"
+	})
+})
+public class JDBC42_21
+{
+	/**
+	 * Return true if running under a Java specification version at least as
+	 * recent as the argument ('1.6', '1.7', '1.8', '9', '10', '11', ...).
+	 */
+	@Function(schema="javatest", provides="javaSpecificationGE")
+	public static boolean javaSpecificationGE(String want)
+	{
+		String got = System.getProperty("java.specification.version");
+		if ( want.startsWith("1.") )
+			want = want.substring(2);
+		if ( got.startsWith("1.") )
+			got = got.substring(2);
+		return 0 <= Integer.valueOf(got).compareTo(Integer.valueOf(want));
+	}
+}

--- a/pljava-so/src/main/c/ExecutionPlan.c
+++ b/pljava-so/src/main/c/ExecutionPlan.c
@@ -89,7 +89,7 @@ static bool coerceObjects(void* ePlan, jobjectArray jvalues, Datum** valuesPtr, 
 			jobject value = JNI_getObjectArrayElement(jvalues, idx);
 			if(value != 0)
 			{
-				values[idx] = Type_coerceObject(type, value);
+				values[idx] = Type_coerceObjectBridged(type, value);
 				JNI_deleteLocalRef(value);
 			}
 			else

--- a/pljava-so/src/main/c/SQLInputFromTuple.c
+++ b/pljava-so/src/main/c/SQLInputFromTuple.c
@@ -1,8 +1,14 @@
 /*
- * Copyright (c) 2004, 2005, 2006 TADA AB - Taby Sweden
- * Distributed under the terms shown in the file COPYRIGHT
- * found in the root folder of this project or at
- * http://eng.tada.se/osprojects/COPYRIGHT.html
+ * Copyright (c) 2004-2018 Tada AB and other contributors, as listed below.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Tada AB
+ *   Chapman Flack
  *
  * @author Thomas Hallgren
  */
@@ -42,7 +48,7 @@ void SQLInputFromTuple_initialize(void)
 	{
 		{
 		"_getObject",
-	  	"(JJI)Ljava/lang/Object;",
+		"(JJILjava/lang/Class;)Ljava/lang/Object;",
 	  	Java_org_postgresql_pljava_jdbc_SQLInputFromTuple__1getObject
 		},
 		{
@@ -76,10 +82,10 @@ Java_org_postgresql_pljava_jdbc_SQLInputFromTuple__1free(JNIEnv* env, jobject _t
 /*
  * Class:     org_postgresql_pljava_jdbc_SQLInputFromTuple
  * Method:    _getObject
- * Signature: (JJI)Ljava/lang/Object;
+ * Signature: (JJILjava/lang/Class;)Ljava/lang/Object;
  */
 JNIEXPORT jobject JNICALL
-Java_org_postgresql_pljava_jdbc_SQLInputFromTuple__1getObject(JNIEnv* env, jclass clazz, jlong hth, jlong jtd, jint attrNo)
+Java_org_postgresql_pljava_jdbc_SQLInputFromTuple__1getObject(JNIEnv* env, jclass clazz, jlong hth, jlong jtd, jint attrNo, jclass rqcls)
 {
-	return HeapTupleHeader_getObject(env, hth, jtd, attrNo, NULL);
+	return HeapTupleHeader_getObject(env, hth, jtd, attrNo, rqcls);
 }

--- a/pljava-so/src/main/c/SQLInputFromTuple.c
+++ b/pljava-so/src/main/c/SQLInputFromTuple.c
@@ -81,5 +81,5 @@ Java_org_postgresql_pljava_jdbc_SQLInputFromTuple__1free(JNIEnv* env, jobject _t
 JNIEXPORT jobject JNICALL
 Java_org_postgresql_pljava_jdbc_SQLInputFromTuple__1getObject(JNIEnv* env, jclass clazz, jlong hth, jlong jtd, jint attrNo)
 {
-	return HeapTupleHeader_getObject(env, hth, jtd, attrNo);
+	return HeapTupleHeader_getObject(env, hth, jtd, attrNo, NULL);
 }

--- a/pljava-so/src/main/c/type/Composite.c
+++ b/pljava-so/src/main/c/type/Composite.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2016 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2018 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -267,7 +267,7 @@ void Composite_initialize(void)
 	{
 		{
 		"_getObject",
-	  	"(JJI)Ljava/lang/Object;",
+		"(JJILjava/lang/Class;)Ljava/lang/Object;",
 	  	Java_org_postgresql_pljava_jdbc_SingleRowReader__1getObject
 		},
 		{
@@ -329,10 +329,10 @@ Java_org_postgresql_pljava_jdbc_SingleRowReader__1free(JNIEnv* env, jobject _thi
 /*
  * Class:     org_postgresql_pljava_jdbc_SingleRowReader
  * Method:    _getObject
- * Signature: (JJI)Ljava/lang/Object;
+ * Signature: (JJILjava/lang/Class;)Ljava/lang/Object;
  */
 JNIEXPORT jobject JNICALL
-Java_org_postgresql_pljava_jdbc_SingleRowReader__1getObject(JNIEnv* env, jclass clazz, jlong hth, jlong jtd, jint attrNo)
+Java_org_postgresql_pljava_jdbc_SingleRowReader__1getObject(JNIEnv* env, jclass clazz, jlong hth, jlong jtd, jint attrNo, jclass rqcls)
 {
-	return HeapTupleHeader_getObject(env, hth, jtd, attrNo);
+	return HeapTupleHeader_getObject(env, hth, jtd, attrNo, rqcls);
 }

--- a/pljava-so/src/main/c/type/Date.c
+++ b/pljava-so/src/main/c/type/Date.c
@@ -19,6 +19,69 @@ static jclass    s_Date_class;
 static jmethodID s_Date_init;
 static jmethodID s_Date_getTime;
 
+static TypeClass s_LocalDateClass;
+/*
+ * The following statics are specific to Java 8 +, and will be initialized
+ * only on demand (pre-8 application code will have no way to demand them).
+ */
+static jclass    s_LocalDate_class;
+static jmethodID s_LocalDate_ofEpochDay;
+static jmethodID s_LocalDate_toEpochDay;
+
+/*
+ * LocalDate data type. This is introduced with JDBC 4.2 and Java 8. For
+ * backward-compatibility reasons it does not become the default class returned
+ * by getObject() for a PostgreSQL date, but application code in Java 8+ can and
+ * should prefer it, by passing LocalDate.class to getObject. It represents a
+ * purely local, non-zoned, notion of date, which is exactly what PostgreSQL
+ * date represents, so the correspondence is direct, with no need to fudge up
+ * some timezone info just to shoehorn the data into java.sql.Date.
+ */
+
+/*
+ * This only answers true for (same class or) DATEOID.
+ * The obtainer (below) only needs to construct and remember one instance.
+ */
+static bool _LocalDate_canReplaceType(Type self, Type other)
+{
+	TypeClass cls = Type_getClass(other);
+	return Type_getClass(self) == cls  ||  Type_getOid(other) == DATEOID;
+}
+
+static jvalue _LocalDate_coerceDatum(Type self, Datum arg)
+{
+	DateADT pgDate = DatumGetDateADT(arg);
+	jlong days = (jlong)(pgDate + EPOCH_DIFF);
+	jvalue result;
+	result.l = JNI_callStaticObjectMethod(
+		s_LocalDate_class, s_LocalDate_ofEpochDay, days);
+	return result;
+}
+
+static Datum _LocalDate_coerceObject(Type self, jobject date)
+{
+	jlong days =
+		JNI_callLongMethod(date, s_LocalDate_toEpochDay) - EPOCH_DIFF;
+	return DateADTGetDatum((DateADT)(days));
+}
+
+static Type _LocalDate_obtain(Oid typeId)
+{
+	static Type instance = NULL;
+	if ( NULL == instance )
+	{
+		s_LocalDate_class = JNI_newGlobalRef(PgObject_getJavaClass(
+			"java/time/LocalDate"));
+		s_LocalDate_ofEpochDay = PgObject_getStaticJavaMethod(s_LocalDate_class,
+			"ofEpochDay", "(J)Ljava/time/LocalDate;");
+		s_LocalDate_toEpochDay = PgObject_getJavaMethod(s_LocalDate_class,
+			"toEpochDay", "()J");
+
+		instance = TypeClass_allocInstance(s_LocalDateClass, DATEOID);
+	}
+	return instance;
+}
+
 /*
  * Date data type. Postgres will pass and expect number of days since
  * Jan 01 2000. Java uses number of millisecs since midnight Jan 01 1970.
@@ -60,4 +123,13 @@ void Date_initialize(void)
 	s_Date_class = JNI_newGlobalRef(PgObject_getJavaClass("java/sql/Date"));
 	s_Date_init = PgObject_getJavaMethod(s_Date_class, "<init>", "(J)V");
 	s_Date_getTime = PgObject_getJavaMethod(s_Date_class, "getTime",  "()J");
+
+	cls = TypeClass_alloc("type.LocalDate");
+	cls->JNISignature = "Ljava/time/LocalDate;";
+	cls->javaTypeName = "java.time.LocalDate";
+	cls->canReplaceType = _LocalDate_canReplaceType;
+	cls->coerceDatum  = _LocalDate_coerceDatum;
+	cls->coerceObject = _LocalDate_coerceObject;
+	s_LocalDateClass  = cls;
+	Type_registerType2(InvalidOid, "java.time.LocalDate", _LocalDate_obtain);
 }

--- a/pljava-so/src/main/c/type/Date.c
+++ b/pljava-so/src/main/c/type/Date.c
@@ -1,8 +1,14 @@
 /*
- * Copyright (c) 2004, 2005, 2006 TADA AB - Taby Sweden
- * Distributed under the terms shown in the file COPYRIGHT
- * found in the root folder of this project or at
- * http://eng.tada.se/osprojects/COPYRIGHT.html
+ * Copyright (c) 2004-2018 Tada AB and other contributors, as listed below.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Tada AB
+ *   Chapman Flack
  *
  * @author Thomas Hallgren
  */

--- a/pljava-so/src/main/c/type/Oid.c
+++ b/pljava-so/src/main/c/type/Oid.c
@@ -118,12 +118,18 @@ Oid Oid_forSqlType(int sqlType)
 		case java_sql_Types_LONGNVARCHAR:
 		case java_sql_Types_NCLOB:
 		case java_sql_Types_SQLXML:
+			typeId = InvalidOid;	/* Not yet mapped */
+			break;
 
 		/* JDBC 4.2 - conditionalize until only Java 8 and later supported */
 #ifdef	java_sql_Types_REF_CURSOR
-		case java_sql_Types_REF_CURSOR:
 		case java_sql_Types_TIME_WITH_TIMEZONE:
+			typeId = TIMETZOID;
+			break;
 		case java_sql_Types_TIMESTAMP_WITH_TIMEZONE:
+			typeId = TIMESTAMPTZOID;
+			break;
+		case java_sql_Types_REF_CURSOR:
 #endif
 		default:
 			typeId = InvalidOid;	/* Not yet mapped */

--- a/pljava-so/src/main/c/type/Relation.c
+++ b/pljava-so/src/main/c/type/Relation.c
@@ -235,7 +235,7 @@ Java_org_postgresql_pljava_internal_Relation__1modifyTuple(JNIEnv* env, jclass c
 				type = Type_fromOid(typeId, typeMap);
 				value = JNI_getObjectArrayElement(_values, idx);
 				if(value != 0)
-					values[idx] = Type_coerceObject(type, value);
+					values[idx] = Type_coerceObjectBridged(type, value);
 				else
 				{
 					if(nulls == 0)

--- a/pljava-so/src/main/c/type/Time.c
+++ b/pljava-so/src/main/c/type/Time.c
@@ -1,8 +1,14 @@
 /*
- * Copyright (c) 2004, 2005, 2006 TADA AB - Taby Sweden
- * Distributed under the terms shown in the file COPYRIGHT
- * found in the root folder of this project or at
- * http://eng.tada.se/osprojects/COPYRIGHT.html
+ * Copyright (c) 2004-2018 Tada AB and other contributors, as listed below.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Tada AB
+ *   Chapman Flack
  *
  * @author Thomas Hallgren
  */

--- a/pljava-so/src/main/c/type/Time.c
+++ b/pljava-so/src/main/c/type/Time.c
@@ -17,13 +17,94 @@
 #include "pljava/type/Timestamp.h"
 
 /*
- * Time type. Postgres will pass (and expect in return) a local Time.
- * The Java java.sql.Time is UTC time and not a perfect fit. Perhaps
- * a LocalTime object should be added to the Java domain?
+ * Types time and timetz. This compilation unit supplies code for both
+ * PostgreSQL types. The legacy JDBC mapping for both is to java.sql.Time, which
+ * holds an implicit timezone offset and therefore can't be an equally good fit
+ * for both. Also, it loses precision: PostgreSQL maintains microseconds, but
+ * java.sql.Time only holds milliseconds.
+ *
+ * Java 8 and JDBC 4.2 introduce java.time.LocalTime and java.time.OffsetTime,
+ * which directly fit PG's time and timetz, respectively. For compatibility
+ * reasons, the legacy behavior of getObject (with no Class parameter) is
+ * unchanged, and still returns the data weirdly shoehorned into java.sql.Time.
+ * But Java 8 application code can and should use the form of getObject with a
+ * Class parameter to request java.time.LocalTime or java.time.OffsetTime, as
+ * appropriate.
+ *
+ * The legacy shoehorning adjusts the PostgreSQL-maintained time by its
+ * associated offset (in the timetz case), or by the current value of the server
+ * timezone offset (in the time case). Which convention is weirder?
  */
 static jclass    s_Time_class;
 static jmethodID s_Time_init;
 static jmethodID s_Time_getTime;
+
+static TypeClass s_LocalTimeClass;
+static TypeClass s_OffsetTimeClass;
+/*
+ * The following statics are specific to Java 8 +, and will be initialized
+ * only on demand (pre-8 application code will have no way to demand them).
+ */
+static jclass    s_LocalTime_class;
+static jmethodID s_LocalTime_ofNanoOfDay;
+static jmethodID s_LocalTime_toNanoOfDay;
+static jclass    s_OffsetTime_class;
+static jmethodID s_OffsetTime_of;
+static jmethodID s_OffsetTime_toLocalTime;
+static jmethodID s_OffsetTime_getOffset;
+static jclass    s_ZoneOffset_class;
+static jmethodID s_ZoneOffset_ofTotalSeconds;
+static jmethodID s_ZoneOffset_getTotalSeconds;
+
+/*
+ * This only answers true for (same class or) TIMEOID.
+ * The obtainer (below) only needs to construct and remember one instance.
+ */
+static bool _LocalTime_canReplaceType(Type self, Type other)
+{
+	TypeClass cls = Type_getClass(other);
+	return Type_getClass(self) == cls  ||  Type_getOid(other) == TIMEOID;
+}
+
+static jvalue _LocalTime_coerceDatum(Type self, Datum arg)
+{
+	jlong nanos =
+#if PG_VERSION_NUM < 100000
+		(!integerDateTimes) ? (jlong)floor(1e9 * DatumGetFloat8(arg)) :
+#endif
+		1000 * DatumGetInt64(arg);
+	jvalue result;
+	result.l = JNI_callStaticObjectMethod(
+		s_LocalTime_class, s_LocalTime_ofNanoOfDay, nanos);
+	return result;
+}
+
+static Datum _LocalTime_coerceObject(Type self, jobject time)
+{
+	jlong nanos = JNI_callLongMethod(time, s_LocalTime_toNanoOfDay);
+	return
+#if PG_VERSION_NUM < 100000
+		(!integerDateTimes) ? Float8GetDatum(((double)nanos) / 1e9) :
+#endif
+		Int64GetDatum(nanos / 1000);
+}
+
+static Type _LocalTime_obtain(Oid typeId)
+{
+	static Type instance = NULL;
+	if ( NULL == instance )
+	{
+		s_LocalTime_class = JNI_newGlobalRef(PgObject_getJavaClass(
+			"java/time/LocalTime"));
+		s_LocalTime_ofNanoOfDay = PgObject_getStaticJavaMethod(s_LocalTime_class,
+			"ofNanoOfDay", "(J)Ljava/time/LocalTime;");
+		s_LocalTime_toNanoOfDay = PgObject_getJavaMethod(s_LocalTime_class,
+			"toNanoOfDay", "()J");
+
+		instance = TypeClass_allocInstance(s_LocalTimeClass, TIMEOID);
+	}
+	return instance;
+}
 
 static jlong msecsAtMidnight(void)
 {
@@ -168,4 +249,13 @@ void Time_initialize(void)
 	cls->coerceDatum  = _Timetz_coerceDatum;
 	cls->coerceObject = _Timetz_coerceObject;
 	Type_registerType("java.sql.Time", TypeClass_allocInstance(cls, TIMETZOID));
+
+	cls = TypeClass_alloc("type.LocalTime");
+	cls->JNISignature = "Ljava/time/LocalTime;";
+	cls->javaTypeName = "java.time.LocalTime";
+	cls->coerceDatum  = _LocalTime_coerceDatum;
+	cls->coerceObject = _LocalTime_coerceObject;
+	cls->canReplaceType = _LocalTime_canReplaceType;
+	s_LocalTimeClass  = cls;
+	Type_registerType2(InvalidOid, "java.time.LocalTime", _LocalTime_obtain);
 }

--- a/pljava-so/src/main/c/type/Tuple.c
+++ b/pljava-so/src/main/c/type/Tuple.c
@@ -1,8 +1,14 @@
 /*
- * Copyright (c) 2004, 2005, 2006 TADA AB - Taby Sweden
- * Distributed under the terms shown in the file COPYRIGHT
- * found in the root folder of this project or at
- * http://eng.tada.se/osprojects/COPYRIGHT.html
+ * Copyright (c) 2004-2018 Tada AB and other contributors, as listed below.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Tada AB
+ *   Chapman Flack
  *
  * @author Thomas Hallgren
  */
@@ -77,7 +83,7 @@ void Tuple_initialize(void)
 	JNINativeMethod methods[] = {
 		{
 		"_getObject",
-	  	"(JJI)Ljava/lang/Object;",
+		"(JJILjava/lang/Class;)Ljava/lang/Object;",
 	  	Java_org_postgresql_pljava_internal_Tuple__1getObject
 		},
 		{
@@ -99,7 +105,7 @@ void Tuple_initialize(void)
 }
 
 jobject
-Tuple_getObject(TupleDesc tupleDesc, HeapTuple tuple, int index)
+Tuple_getObject(TupleDesc tupleDesc, HeapTuple tuple, int index, jclass rqcls)
 {
 	jobject result = 0;
 	PG_TRY();
@@ -110,7 +116,7 @@ Tuple_getObject(TupleDesc tupleDesc, HeapTuple tuple, int index)
 			bool wasNull = false;
 			Datum binVal = SPI_getbinval(tuple, tupleDesc, (int)index, &wasNull);
 			if(!wasNull)
-				result = Type_coerceDatum(type, binVal).l;
+				result = Type_coerceDatumAs(type, binVal, rqcls).l;
 		}
 	}
 	PG_CATCH();
@@ -128,10 +134,10 @@ Tuple_getObject(TupleDesc tupleDesc, HeapTuple tuple, int index)
 /*
  * Class:     org_postgresql_pljava_internal_Tuple
  * Method:    _getObject
- * Signature: (JJI)Ljava/lang/Object;
+ * Signature: (JJILjava/lang/Class;)Ljava/lang/Object;
  */
 JNIEXPORT jobject JNICALL
-Java_org_postgresql_pljava_internal_Tuple__1getObject(JNIEnv* env, jclass cls, jlong _this, jlong _tupleDesc, jint index)
+Java_org_postgresql_pljava_internal_Tuple__1getObject(JNIEnv* env, jclass cls, jlong _this, jlong _tupleDesc, jint index, jclass rqcls)
 {
 	jobject result = 0;
 	Ptr2Long p2l;
@@ -140,7 +146,7 @@ Java_org_postgresql_pljava_internal_Tuple__1getObject(JNIEnv* env, jclass cls, j
 	BEGIN_NATIVE
 	HeapTuple self = (HeapTuple)p2l.ptrVal;
 	p2l.longVal = _tupleDesc;
-	result = Tuple_getObject((TupleDesc)p2l.ptrVal, self, (int)index);
+	result = Tuple_getObject((TupleDesc)p2l.ptrVal, self, (int)index, rqcls);
 	END_NATIVE
 	return result;
 }

--- a/pljava-so/src/main/c/type/TupleDesc.c
+++ b/pljava-so/src/main/c/type/TupleDesc.c
@@ -239,7 +239,7 @@ Java_org_postgresql_pljava_internal_TupleDesc__1formTuple(JNIEnv* env, jclass cl
 			if(value != 0)
 			{
 				Type type = Type_fromOid(SPI_gettypeid(self, idx + 1), typeMap);
-				values[idx] = Type_coerceObject(type, value);
+				values[idx] = Type_coerceObjectBridged(type, value);
 				nulls[idx] = false;
 			}
 		}

--- a/pljava-so/src/main/c/type/TupleDesc.c
+++ b/pljava-so/src/main/c/type/TupleDesc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2016 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2018 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -57,6 +57,11 @@ jobject TupleDesc_internalCreate(TupleDesc td)
 	return jtd;
 }
 
+/*
+ * Returns NULL if an exception has been thrown for an invalid attribute index
+ * (caller should expeditiously return), otherwise the Type for the column data
+ * (the one representing the boxing Object type, in the primitive case).
+ */
 Type TupleDesc_getColumnType(TupleDesc tupleDesc, int index)
 {
 	Type type;

--- a/pljava-so/src/main/c/type/Type.c
+++ b/pljava-so/src/main/c/type/Type.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2016 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2018 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -219,6 +219,25 @@ bool Type_isOutParameter(Type self)
 jvalue Type_coerceDatum(Type self, Datum value)
 {
 	return self->typeClass->coerceDatum(self, value);
+}
+
+jvalue Type_coerceDatumAs(Type self, Datum value, jclass rqcls)
+{
+	jstring rqcname;
+	char *rqcname0;
+	Type rqtype;
+
+	if ( NULL == rqcls  ||  Type_getJavaClass(self) == rqcls )
+		return Type_coerceDatum(self, value);
+
+	rqcname = JNI_callObjectMethod(rqcls, Class_getName);
+	rqcname0 = String_createNTS(rqcname);
+	JNI_deleteLocalRef(rqcname);
+	rqtype = Type_fromJavaType(self->typeId, rqcname0);
+	pfree(rqcname0);
+	if ( Type_canReplaceType(rqtype, self) )
+		return Type_coerceDatum(rqtype, value);
+	return Type_coerceDatum(self, value);
 }
 
 Datum Type_coerceObject(Type self, jobject object)

--- a/pljava-so/src/main/include/pljava/type/HeapTupleHeader.h
+++ b/pljava-so/src/main/include/pljava/type/HeapTupleHeader.h
@@ -1,8 +1,14 @@
 /*
- * Copyright (c) 2004, 2005, 2006 TADA AB - Taby Sweden
-* Distributed under the terms shown in the file COPYRIGHT
- * found in the root folder of this project or at
- * http://eng.tada.se/osprojects/COPYRIGHT.html
+ * Copyright (c) 2004-2018 Tada AB and other contributors, as listed below.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Tada AB
+ *   Chapman Flack
  *
  * @author Thomas Hallgren
  */
@@ -21,11 +27,15 @@ extern "C" {
  * access to some of the attributes of the HeapTupleHeader structure.
  * 
  * @author Thomas Hallgren
+ *
+ * (As of git commit a4f6c9e, there are uses of this C interface,
+ * but no uses of the Java class.)
  *****************************************************************/
 
 extern jobject HeapTupleHeader_getTupleDesc(HeapTupleHeader ht);
 
-extern jobject HeapTupleHeader_getObject(JNIEnv* env, jlong hth, jlong jtd, jint attrNo);
+extern jobject HeapTupleHeader_getObject(
+	JNIEnv* env, jlong hth, jlong jtd, jint attrNo, jclass rqcls);
 
 extern void HeapTupleHeader_free(JNIEnv* env, jlong hth);
 

--- a/pljava-so/src/main/include/pljava/type/Timestamp.h
+++ b/pljava-so/src/main/include/pljava/type/Timestamp.h
@@ -1,8 +1,14 @@
 /*
- * Copyright (c) 2004, 2005, 2006 TADA AB - Taby Sweden
- * Distributed under the terms shown in the file COPYRIGHT
- * found in the root folder of this project or at
- * http://eng.tada.se/osprojects/COPYRIGHT.html
+ * Copyright (c) 2004-2018 Tada AB and other contributors, as listed below.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Tada AB
+ *   Chapman Flack
  *
  * @author Thomas Hallgren
  */
@@ -27,13 +33,14 @@ extern "C" {
 extern int Timestamp_getCurrentTimeZone(void);
 
 /*
- * Returns the timezone fo the given Timestamp. Comes in two variants.
- * The int64 variant will be used when PL/Java is used with a backend
- * compiled with integer datetimes. The double variant will be used when
- * this is not the case.
+ * Returns the timezone for the given Timestamp. This is an internal function
+ * and only declared here because Date.c uses it, and always this int64 variant,
+ * regardless of whether the backend was compiled with integer datetimes. The
+ * argument is not a PostgreSQL int64 Timestamp, but rather a PostgreSQL int64
+ * Timestamp divided by two. The result is a time zone offset in seconds west
+ * of Greenwich.
  */
 extern int32 Timestamp_getTimeZone_id(int64 t);
-extern int32 Timestamp_getTimeZone_dd(double t);
 
 #ifdef __cplusplus
 }

--- a/pljava-so/src/main/include/pljava/type/Tuple.h
+++ b/pljava-so/src/main/include/pljava/type/Tuple.h
@@ -1,8 +1,14 @@
 /*
- * Copyright (c) 2004, 2005, 2006 TADA AB - Taby Sweden
- * Distributed under the terms shown in the file COPYRIGHT
- * found in the root folder of this project or at
- * http://eng.tada.se/osprojects/COPYRIGHT.html
+ * Copyright (c) 2004-2018 Tada AB and other contributors, as listed below.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Tada AB
+ *   Chapman Flack
  *
  * @author Thomas Hallgren
  */
@@ -31,9 +37,11 @@ extern jobject Tuple_internalCreate(HeapTuple tuple, bool mustCopy);
 extern jobjectArray Tuple_createArray(HeapTuple* tuples, jint size, bool mustCopy);
 
 /*
- * Return a java object at given index from a HeapTuple
+ * Return a java object at given index from a HeapTuple (with a best effort to
+ * produce an object of class rqcls if it is not null).
  */
-extern jobject Tuple_getObject(TupleDesc tupleDesc, HeapTuple tuple, int index);
+extern jobject Tuple_getObject(
+	TupleDesc tupleDesc, HeapTuple tuple, int index, jclass rqcls);
 
 #ifdef __cplusplus
 }

--- a/pljava-so/src/main/include/pljava/type/Type.h
+++ b/pljava-so/src/main/include/pljava/type/Type.h
@@ -79,9 +79,19 @@ extern jvalue Type_coerceDatumAs(Type self, Datum datum, jclass rqcls);
 
 /*
  * Translate a given Object into a Datum accorging to the type represented
- * by this instance.
+ * by this instance. The caller must be certain that 'object' is an instance
+ * of a Java type expected by the coercer for this TypeClass.
  */
 extern Datum Type_coerceObject(Type self, jobject object);
+
+/*
+ * Translate a given Object into a Datum accorging to the type represented
+ * by this instance. The object may be an instance of TypeBridge.Holder holding
+ * an object of an alternate Java class than what the coercer for this TypeClass
+ * expects. Otherwise, it must be an object of the expected class, just as for
+ * Type_coerceObject.
+ */
+extern Datum Type_coerceObjectBridged(Type self, jobject object);
 
 /*
  * Return a Type based on a Postgres Oid. Creates a new type if

--- a/pljava-so/src/main/include/pljava/type/Type.h
+++ b/pljava-so/src/main/include/pljava/type/Type.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2016 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2018 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -63,10 +63,19 @@ extern bool Type_isPrimitive(Type self);
 extern bool Type_canReplaceType(Type self, Type type);
 
 /*
- * Translate a given Datum into a jvalue accorging to the type represented
+ * Translate a given Datum into a jvalue according to the type represented
  * by this instance.
  */
 extern jvalue Type_coerceDatum(Type self, Datum datum);
+
+/*
+ * Translate a given Datum into a jvalue, where the type represented
+ * by this instance is derived from the PG type of the datum, and rqcls, if
+ * not NULL, is the Java class wanted by the caller (JDBC 4.1 feature).
+ * Reduces to Type_coerceDatum if rqcls is NULL, or there is no TypeClass that
+ * can replace this Type and produce the requested class.
+ */
+extern jvalue Type_coerceDatumAs(Type self, Datum datum, jclass rqcls);
 
 /*
  * Translate a given Object into a Datum accorging to the type represented
@@ -237,6 +246,14 @@ extern void Type_closeSRF(Type self, jobject producer);
  * singleton. The only current exception from this is the
  * String since it makes use of functions stored in the
  * Form_pg_type structure.
+ *
+ * In adding JDBC 4.1 support, this is decreed: a TypeObtainer
+ * may return its singleton, if that's what it does, regardless
+ * of whether the Oid stored there matches the one passed to the
+ * obtainer. In other words, it may ignore the typeId argument.
+ * It's often appropriate for the caller to check the returned
+ * type with Type_canReplaceType to determine if it is usable
+ * for the intended purpose.
  */
 typedef Type (*TypeObtainer)(Oid typeId);
 

--- a/pljava/src/main/java/org/postgresql/pljava/internal/Tuple.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/Tuple.java
@@ -1,8 +1,14 @@
 /*
- * Copyright (c) 2004, 2005, 2006 TADA AB - Taby Sweden
- * Distributed under the terms shown in the file COPYRIGHT
- * found in the root folder of this project or at
- * http://eng.tada.se/osprojects/COPYRIGHT.html
+ * Copyright (c) 2004-2018 Tada AB and other contributors, as listed below.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Tada AB
+ *   Chapman Flack
  */
 package org.postgresql.pljava.internal;
 
@@ -24,17 +30,24 @@ public class Tuple extends JavaWrapper
 	/**
 	 * Obtains a value from the underlying native <code>HeapTuple</code>
 	 * structure.
+	 *<p>
+	 * Conversion to a JDBC 4.1 specified class is best effort, if the native
+	 * type system knows how to do so; otherwise, the return value can be
+	 * whatever would have been returned in the legacy case. Caller beware!
 	 * @param tupleDesc The Tuple descriptor for this instance.
 	 * @param index Index of value in the structure (one based).
+	 * @param type Desired Java class of the result, if the JDBC 4.1 version
+	 * of {@code getObject} has been called; null in all the legacy cases.
 	 * @return The value or <code>null</code>.
 	 * @throws SQLException If the underlying native structure has gone stale.
 	 */
-	public Object getObject(TupleDesc tupleDesc, int index)
+	public Object getObject(TupleDesc tupleDesc, int index, Class<?> type)
 	throws SQLException
 	{
 		synchronized(Backend.THREADLOCK)
 		{
-			return _getObject(this.getNativePointer(), tupleDesc.getNativePointer(), index);
+			return _getObject(this.getNativePointer(),
+				tupleDesc.getNativePointer(), index, type);
 		}
 	}
 
@@ -44,6 +57,7 @@ public class Tuple extends JavaWrapper
 	 */
 	protected native void _free(long pointer);
 
-	private static native Object _getObject(long pointer, long tupleDescPointer, int index)
+	private static native Object _getObject(
+		long pointer, long tupleDescPointer, int index, Class<?> type)
 	throws SQLException;
 }

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/AbstractResultSet.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/AbstractResultSet.java
@@ -36,8 +36,8 @@ import java.util.Calendar;
 import java.util.Map;
 
 /**
- * The <code>AbstractResultSet</code> serves as a base class for implementations
- * of the{@link java.sql.ResultSet} interface. All calls using columnNames are
+ * The {@code AbstractResultSet} serves as a base class for implementations
+ * of the {@link java.sql.ResultSet} interface. All calls using columnNames are
  * translated into the corresponding call with index position computed using
  * a call to {@link java.sql.ResultSet#findColumn(String) findColumn}.
  *
@@ -45,18 +45,26 @@ import java.util.Map;
  */
 public abstract class AbstractResultSet implements ResultSet
 {
+	// ************************************************************
+	// Pre-JDBC 4
+	// Getters-by-columnName mapped to getters-by-columnIndex
+	// ************************************************************
+
+	@Override
 	public Array getArray(String columnName)
 	throws SQLException
 	{
 		return this.getArray(this.findColumn(columnName));
 	}
 
+	@Override
 	public InputStream getAsciiStream(String columnName)
 	throws SQLException
 	{
 		return this.getAsciiStream(this.findColumn(columnName));
 	}
 
+	@Override
 	public BigDecimal getBigDecimal(String columnName)
 	throws SQLException
 	{
@@ -66,166 +74,161 @@ public abstract class AbstractResultSet implements ResultSet
 	/**
 	 * @deprecated
 	 */
+	@Override
 	public BigDecimal getBigDecimal(String columnName, int scale)
 	throws SQLException
 	{
 		return this.getBigDecimal(this.findColumn(columnName), scale);
 	}
 
+	@Override
 	public InputStream getBinaryStream(String columnName)
 	throws SQLException
 	{
 		return this.getBinaryStream(this.findColumn(columnName));
 	}
 
+	@Override
 	public Blob getBlob(String columnName)
 	throws SQLException
 	{
 		return this.getBlob(this.findColumn(columnName));
 	}
 
+	@Override
 	public boolean getBoolean(String columnName)
 	throws SQLException
 	{
 		return this.getBoolean(this.findColumn(columnName));
 	}
 
+	@Override
 	public byte getByte(String columnName)
 	throws SQLException
 	{
 		return this.getByte(this.findColumn(columnName));
 	}
 
+	@Override
 	public byte[] getBytes(String columnName)
 	throws SQLException
 	{
 		return this.getBytes(this.findColumn(columnName));
 	}
 
+	@Override
 	public Reader getCharacterStream(String columnName)
 	throws SQLException
 	{
 		return this.getCharacterStream(this.findColumn(columnName));
 	}
 
+	@Override
 	public Clob getClob(String columnName)
 	throws SQLException
 	{
 		return this.getClob(this.findColumn(columnName));
 	}
 
-	public String getCursorName()
-	throws SQLException
-	{
-		return null;
-	}
-
+	@Override
 	public Date getDate(String columnName)
 	throws SQLException
 	{
 		return this.getDate(this.findColumn(columnName));
 	}
 
+	@Override
 	public Date getDate(String columnName, Calendar cal)
 	throws SQLException
 	{
 		return this.getDate(this.findColumn(columnName), cal);
 	}
 
+	@Override
 	public double getDouble(String columnName)
 	throws SQLException
 	{
 		return this.getDouble(this.findColumn(columnName));
 	}
 
+	@Override
 	public float getFloat(String columnName)
 	throws SQLException
 	{
 		return this.getFloat(this.findColumn(columnName));
 	}
 
+	@Override
 	public int getInt(String columnName)
 	throws SQLException
 	{
 		return this.getInt(this.findColumn(columnName));
 	}
 
+	@Override
 	public long getLong(String columnName)
 	throws SQLException
 	{
 		return this.getLong(this.findColumn(columnName));
 	}
 
+	@Override
 	public Object getObject(String columnName)
 	throws SQLException
 	{
 		return this.getObject(this.findColumn(columnName));
 	}
 
+	@Override
 	public Object getObject(String columnName, Map map)
 	throws SQLException
 	{
 		return this.getObject(this.findColumn(columnName), map);
 	}
 
-  public <T> T getObject(int columnIndex, Class<T> type)
-	throws SQLException
-	{
-		final Object obj = getObject( columnIndex );
-    if ( obj.getClass().equals( type ) ) return (T) obj;
-    throw new SQLException( "Cannot convert " + obj.getClass().getName() + " to " + type );
-	}
-
-  public <T> T getObject(String columnName, Class<T> type)
-	throws SQLException
-	{
-		final Object obj = getObject( columnName );
-    if ( obj.getClass().equals( type ) ) return (T) obj;
-    throw new SQLException( "Cannot convert " + obj.getClass().getName() + " to " + type );
-	}
-
+	@Override
 	public Ref getRef(String columnName)
 	throws SQLException
 	{
 		return this.getRef(this.findColumn(columnName));
 	}
 
+	@Override
 	public short getShort(String columnName)
 	throws SQLException
 	{
 		return this.getShort(this.findColumn(columnName));
 	}
 
-    public Statement getStatement()
-    throws SQLException
-    {
-        return null;
-    }
-
+	@Override
 	public String getString(String columnName)
 	throws SQLException
 	{
 		return this.getString(this.findColumn(columnName));
 	}
 
+	@Override
 	public Time getTime(String columnName)
 	throws SQLException
 	{
 		return this.getTime(this.findColumn(columnName));
 	}
 
+	@Override
 	public Time getTime(String columnName, Calendar cal)
 	throws SQLException
 	{
 		return this.getTime(this.findColumn(columnName), cal);
 	}
 
+	@Override
 	public Timestamp getTimestamp(String columnName)
 	throws SQLException
 	{
 		return this.getTimestamp(this.findColumn(columnName));
 	}
 
+	@Override
 	public Timestamp getTimestamp(String columnName, Calendar cal)
 	throws SQLException
 	{
@@ -235,154 +238,210 @@ public abstract class AbstractResultSet implements ResultSet
 	/**
 	 * @deprecated
 	 */
+	@Override
 	public InputStream getUnicodeStream(String columnName)
 	throws SQLException
 	{
 		return this.getUnicodeStream(this.findColumn(columnName));
 	}
 
+	@Override
 	public URL getURL(String columnName)
 	throws SQLException
 	{
 		return this.getURL(this.findColumn(columnName));
 	}
 
+	// ************************************************************
+	// Pre-JDBC 4
+	// Updaters-by-columnName mapped to updaters-by-columnIndex
+	// ************************************************************
+
+	@Override
 	public void updateArray(String columnName, Array x)
 	throws SQLException
 	{
 		this.updateArray(this.findColumn(columnName), x);
 	}
 
+	@Override
 	public void updateAsciiStream(String columnName, InputStream x, int length)
 	throws SQLException
 	{
 		this.updateAsciiStream(this.findColumn(columnName), x, length);
 	}
 
+	@Override
 	public void updateBigDecimal(String columnName, BigDecimal x)
 	throws SQLException
 	{
 		this.updateBigDecimal(this.findColumn(columnName), x);
 	}
 
+	@Override
 	public void updateBinaryStream(String columnName, InputStream x, int length)
 	throws SQLException
 	{
 		this.updateBinaryStream(this.findColumn(columnName), x, length);
 	}
 
+	@Override
 	public void updateBlob(String columnName, Blob x)
 	throws SQLException
 	{
 		this.updateBlob(this.findColumn(columnName), x);
 	}
 
+	@Override
 	public void updateBoolean(String columnName, boolean x)
 	throws SQLException
 	{
 		this.updateBoolean(this.findColumn(columnName), x);
 	}
 
+	@Override
 	public void updateByte(String columnName, byte x)
 	throws SQLException
 	{
 		this.updateByte(this.findColumn(columnName), x);
 	}
 
+	@Override
 	public void updateBytes(String columnName, byte x[])
 	throws SQLException
 	{
 		this.updateBytes(this.findColumn(columnName), x);
 	}
 
+	@Override
 	public void updateCharacterStream(String columnName, Reader x, int length)
 	throws SQLException
 	{
 		this.updateCharacterStream(this.findColumn(columnName), x, length);
 	}
 
+	@Override
 	public void updateClob(String columnName, Clob x)
 	throws SQLException
 	{
 		this.updateClob(this.findColumn(columnName), x);
 	}
 
+	@Override
 	public void updateDate(String columnName, Date x)
 	throws SQLException
 	{
 		this.updateDate(this.findColumn(columnName), x);
 	}
 
+	@Override
 	public void updateDouble(String columnName, double x)
 	throws SQLException
 	{
 		this.updateDouble(this.findColumn(columnName), x);
 	}
 
+	@Override
 	public void updateFloat(String columnName, float x)
 	throws SQLException
 	{
 		this.updateFloat(this.findColumn(columnName), x);
 	}
 
+	@Override
 	public void updateInt(String columnName, int x)
 	throws SQLException
 	{
 		this.updateInt(this.findColumn(columnName), x);
 	}
 
+	@Override
 	public void updateLong(String columnName, long x)
 	throws SQLException
 	{
 		this.updateLong(this.findColumn(columnName), x);
 	}
 
+	@Override
 	public void updateNull(String columnName)
 	throws SQLException
 	{
 		this.updateNull(this.findColumn(columnName));
 	}
 
+	@Override
 	public void updateObject(String columnName, Object x)
 	throws SQLException
 	{
 		this.updateObject(this.findColumn(columnName), x);
 	}
 
+	@Override
 	public void updateObject(String columnName, Object x, int scale)
 	throws SQLException
 	{
 		this.updateObject(this.findColumn(columnName), x, scale);
 	}
 
+	@Override
 	public void updateRef(String columnName, Ref x)
 	throws SQLException
 	{
 		this.updateRef(this.findColumn(columnName), x);
 	}
 
+	@Override
 	public void updateShort(String columnName, short x)
 	throws SQLException
 	{
 		this.updateShort(this.findColumn(columnName), x);
 	}
 
+	@Override
 	public void updateString(String columnName, String x)
 	throws SQLException
 	{
 		this.updateString(this.findColumn(columnName), x);
 	}
 
+	@Override
 	public void updateTime(String columnName, Time x)
 	throws SQLException
 	{
 		this.updateTime(this.findColumn(columnName), x);
 	}
 
+	@Override
 	public void updateTimestamp(String columnName, Timestamp x)
 	throws SQLException
 	{
 		this.updateTimestamp(this.findColumn(columnName), x);
+	}
+
+	// ************************************************************
+	// Pre-JDBC 4
+	// Trivial default implementations for some methods inquiring
+	// ResultSet status.
+	// ************************************************************
+
+	/**
+	 * Returns null if not overridden in a subclass.
+	 */
+	@Override
+	public String getCursorName()
+	throws SQLException
+	{
+		return null;
+	}
+
+	/**
+	 * Returns null if not overridden in a subclass.
+	 */
+	@Override
+	public Statement getStatement()
+	throws SQLException
+	{
+		return null;
 	}
 
 	// ************************************************************
@@ -392,16 +451,18 @@ public abstract class AbstractResultSet implements ResultSet
 	// long as that's an allowed behavior by the JDBC spec.
 	// ************************************************************
 
+	@Override
 	public boolean isWrapperFor(Class<?> iface)
 	throws SQLException
 	{
-	    return iface.isInstance(this);
+		return iface.isInstance(this);
 	}
 
+	@Override
 	public <T> T unwrap(Class<T> iface)
 	throws SQLException
 	{
-	    if ( iface.isInstance(this) )
+		if ( iface.isInstance(this) )
 			return iface.cast(this);
 		throw new SQLFeatureNotSupportedException
 		( this.getClass().getSimpleName()
@@ -413,6 +474,7 @@ public abstract class AbstractResultSet implements ResultSet
 	// Non-implementation of JDBC 4 methods.
 	// ************************************************************
 
+	@Override
 	public void updateNClob(int columnIndex, NClob nClob)
 	throws SQLException
 	{
@@ -421,6 +483,7 @@ public abstract class AbstractResultSet implements ResultSet
 							   "0A000" );
 	}
 
+	@Override
 	public void updateNClob(String columnLabel, NClob nClob)
 	throws SQLException
 	{
@@ -429,6 +492,7 @@ public abstract class AbstractResultSet implements ResultSet
 							   "0A000" );
 	}
 
+	@Override
 	public void updateNClob(int columnIndex, Reader reader)
 	throws SQLException
 	{
@@ -437,6 +501,7 @@ public abstract class AbstractResultSet implements ResultSet
 							   "0A000" );
 	}
 
+	@Override
 	public void updateNClob(int columnIndex, Reader reader, long length)
 	throws SQLException
 	{
@@ -445,6 +510,7 @@ public abstract class AbstractResultSet implements ResultSet
 							   "0A000" );
 	}
 
+	@Override
 	public void updateNClob(String columnLabel, Reader reader)
 	throws SQLException
 	{
@@ -453,6 +519,7 @@ public abstract class AbstractResultSet implements ResultSet
 							   "0A000" );
 	}
 
+	@Override
 	public void updateNClob(String columnLabel, Reader reader, long length)
 	throws SQLException
 	{
@@ -461,6 +528,7 @@ public abstract class AbstractResultSet implements ResultSet
 							   "0A000" );
 	}
 
+	@Override
 	public void updateClob(int columnIndex, Reader reader)
 	throws SQLException
 	{
@@ -468,6 +536,8 @@ public abstract class AbstractResultSet implements ResultSet
 			".updateClob( int, Reader ) not implemented yet.", 
 							   "0A000" );
 	}
+
+	@Override
 	public void updateClob(int columnIndex, Reader reader, long length)
 	throws SQLException
 	{
@@ -476,6 +546,7 @@ public abstract class AbstractResultSet implements ResultSet
 							   "0A000" );
 	}
 
+	@Override
 	public void updateClob(String columnLabel, Reader reader)
 	throws SQLException
 	{
@@ -484,6 +555,7 @@ public abstract class AbstractResultSet implements ResultSet
 							   "0A000" );
 	}
 
+	@Override
 	public void updateClob(String columnLabel, Reader reader, long length)
 	throws SQLException
 	{
@@ -492,6 +564,7 @@ public abstract class AbstractResultSet implements ResultSet
 							   "0A000" );
 	}
 
+	@Override
 	public void updateBlob(int columnIndex, InputStream inputStream)
 	throws SQLException
 	{
@@ -500,6 +573,7 @@ public abstract class AbstractResultSet implements ResultSet
 							   "0A000" );
 	}
 
+	@Override
 	public void updateBlob(int columnIndex, InputStream inputStream, long length)
 	throws SQLException
 	{
@@ -508,7 +582,7 @@ public abstract class AbstractResultSet implements ResultSet
 							   "0A000" );
 	}
 
-
+	@Override
 	public void updateBlob(String columnLabel, InputStream inputStream)
 	throws SQLException
 	{
@@ -517,6 +591,7 @@ public abstract class AbstractResultSet implements ResultSet
 							   "0A000" );
 	}
 
+	@Override
 	public void updateBlob(String columnLabel, InputStream inputStream, long length)
 	throws SQLException
 	{
@@ -525,6 +600,7 @@ public abstract class AbstractResultSet implements ResultSet
 							   "0A000" );
 	}
 
+	@Override
 	public void updateCharacterStream(int columnIndex, Reader x)
 	throws SQLException
 	{
@@ -533,6 +609,7 @@ public abstract class AbstractResultSet implements ResultSet
 							   "0A000" );
 	}
 
+	@Override
 	public void updateCharacterStream(int columnIndex, Reader x, long length)
 	throws SQLException
 	{
@@ -541,6 +618,7 @@ public abstract class AbstractResultSet implements ResultSet
 							   "0A000" );
 	}
 
+	@Override
 	public void updateCharacterStream(String ColumnLabel, Reader x)
 	throws SQLException
 	{
@@ -549,6 +627,7 @@ public abstract class AbstractResultSet implements ResultSet
 							   "0A000" );
 	}
 
+	@Override
 	public void updateCharacterStream(String ColumnLabel, Reader x, long length)
 	throws SQLException
 	{
@@ -557,7 +636,7 @@ public abstract class AbstractResultSet implements ResultSet
 							   "0A000" );
 	}
 
-
+	@Override
 	public void updateBinaryStream(String columnLabel, InputStream x)
 	throws SQLException
 	{
@@ -566,6 +645,7 @@ public abstract class AbstractResultSet implements ResultSet
 							   "0A000" );
 	}
 
+	@Override
 	public void updateBinaryStream(String columnLabel, InputStream x, long length)
 	throws SQLException
 	{
@@ -574,6 +654,7 @@ public abstract class AbstractResultSet implements ResultSet
 							   "0A000" );
 	}
 
+	@Override
 	public void updateBinaryStream(int columnIndex, InputStream x)
 	throws SQLException
 	{
@@ -582,6 +663,7 @@ public abstract class AbstractResultSet implements ResultSet
 							   "0A000" );
 	}
 
+	@Override
 	public void updateBinaryStream(int columnIndex, InputStream x, long length)
 	throws SQLException
 	{
@@ -590,6 +672,7 @@ public abstract class AbstractResultSet implements ResultSet
 							   "0A000" );
 	}
 
+	@Override
 	public void updateAsciiStream(String columnLabel, InputStream x)
 	throws SQLException
 	{
@@ -597,6 +680,7 @@ public abstract class AbstractResultSet implements ResultSet
 			".updateAsciiStream( String, InputStream ) not implemented yet.", "0A000" );
 	}
 
+	@Override
 	public void updateAsciiStream(String columnLabel, InputStream x, long length)
 	throws SQLException
 	{
@@ -604,6 +688,7 @@ public abstract class AbstractResultSet implements ResultSet
 			".updateAsciiStream( String, InputStream, long ) not implemented yet.", "0A000" );
 	}
 
+	@Override
 	public void updateAsciiStream(int columnIndex, InputStream x)
 	throws SQLException
 	{
@@ -612,6 +697,7 @@ public abstract class AbstractResultSet implements ResultSet
 							   "0A000" );
 	}
 
+	@Override
 	public void updateAsciiStream(int columnIndex, InputStream x, long length)
 	throws SQLException
 	{
@@ -620,6 +706,7 @@ public abstract class AbstractResultSet implements ResultSet
 							   "0A000" );
 	}
 
+	@Override
 	public void updateNCharacterStream(String columnLabel, Reader reader)
 	throws SQLException
 	{
@@ -628,6 +715,7 @@ public abstract class AbstractResultSet implements ResultSet
 							   "0A000" );
 	}
 
+	@Override
 	public void updateNCharacterStream(String columnLabel, Reader reader, long length)
 	throws SQLException
 	{
@@ -636,6 +724,7 @@ public abstract class AbstractResultSet implements ResultSet
 							   "0A000" );
 	}
 
+	@Override
 	public void updateNCharacterStream(int columnIndex, Reader reader)
 	throws SQLException
 	{
@@ -644,6 +733,7 @@ public abstract class AbstractResultSet implements ResultSet
 							   "0A000" );
 	}
 
+	@Override
 	public void updateNCharacterStream(int columnIndex, Reader reader, long length)
 	throws SQLException
 	{
@@ -652,6 +742,7 @@ public abstract class AbstractResultSet implements ResultSet
 							   "0A000" );
 	}
 
+	@Override
 	public Reader getNCharacterStream(String columnLabel)
 	throws SQLException
 	{
@@ -660,6 +751,7 @@ public abstract class AbstractResultSet implements ResultSet
 							   "0A000" );
 	}
 
+	@Override
 	public Reader getNCharacterStream(int columnIndex)
 	throws SQLException
 	{
@@ -667,6 +759,7 @@ public abstract class AbstractResultSet implements ResultSet
 			".gett( int ) not implemented yet.", "0A000" );
 	}
 
+	@Override
 	public String getNString(int columnIndex)
 	throws SQLException
 	{
@@ -674,6 +767,7 @@ public abstract class AbstractResultSet implements ResultSet
 			".getNString( int ) not implemented yet.", "0A000" );
 	}
 
+	@Override
 	public String getNString(String columnLabel)
 	throws SQLException
 	{
@@ -682,6 +776,7 @@ public abstract class AbstractResultSet implements ResultSet
 							   "0A000" );
 	}
 
+	@Override
 	public void updateSQLXML(int columnIndex, SQLXML xmlObject)
 	throws SQLException
 	{
@@ -690,6 +785,7 @@ public abstract class AbstractResultSet implements ResultSet
 							   "0A000" );
 	}
 
+	@Override
 	public void updateSQLXML(String columnLabel, SQLXML xmlObject)
 	throws SQLException
 	{
@@ -698,6 +794,7 @@ public abstract class AbstractResultSet implements ResultSet
 							   "0A000" );
 	}
 
+	@Override
 	public SQLXML getSQLXML(int columnIndex)
 	throws SQLException
 	{
@@ -705,6 +802,7 @@ public abstract class AbstractResultSet implements ResultSet
 			".getSQLXML( int ) not implemented yet.", "0A000" );
 	}
 
+	@Override
 	public SQLXML getSQLXML(String columnLabel)
 	throws SQLException
 	{
@@ -712,12 +810,15 @@ public abstract class AbstractResultSet implements ResultSet
 			".getSQLXML( String ) not implemented yet.", "0A000" );
 	}
 
+	@Override
 	public NClob getNClob(String columnLabel)
 	throws SQLException
 	{
 		throw new SQLFeatureNotSupportedException( this.getClass() +
 			".getNClob( String ) not implemented yet.", "0A000" );
 	}
+
+	@Override
 	public NClob getNClob(int columnIndex)
 	throws SQLException
 	{
@@ -725,6 +826,7 @@ public abstract class AbstractResultSet implements ResultSet
 			".getNClob( int ) not implemented yet.", "0A000" );
 	}
 
+	@Override
 	public void updateNString(String columnLabel, String nString)
 	throws SQLException
 	{
@@ -733,6 +835,7 @@ public abstract class AbstractResultSet implements ResultSet
 							   "0A000" );
 	}
 
+	@Override
 	public void updateNString(int columnIndex, String nString)
 	throws SQLException
 	{
@@ -741,6 +844,7 @@ public abstract class AbstractResultSet implements ResultSet
 							   "0A000" );
 	}
 
+	@Override
 	public void updateRowId(int columnIndex, RowId x)
 	throws SQLException
 	{
@@ -749,6 +853,7 @@ public abstract class AbstractResultSet implements ResultSet
 							   "0A000" );
 	}
 
+	@Override
 	public void updateRowId(String columnLabel, RowId x)
 	throws SQLException
 	{
@@ -757,6 +862,7 @@ public abstract class AbstractResultSet implements ResultSet
 							   "0A000" );
 	}
 
+	@Override
 	public RowId getRowId(int columnIndex)
 	throws SQLException
 	{
@@ -764,10 +870,39 @@ public abstract class AbstractResultSet implements ResultSet
 			"getRowId( int ) not implemented yet.", "0A000" );
 	}
 
+	@Override
 	public RowId getRowId(String columnLabel)
 	throws SQLException
 	{
 		throw new SQLFeatureNotSupportedException( this.getClass() +
 			".getRowId( String ) not implemented yet.", "0A000" );
+	}
+
+	// ************************************************************
+	// Implementation of JDBC 4.1 methods. These are half-baked at
+	// the moment: the type parameter isn't able to /influence/
+	// what type is returned, but only to fail if what gets
+	// returned by default isn't that.
+	// Add @Override to these once Java back horizon advances to 7.
+	// ************************************************************
+
+	public <T> T getObject(int columnIndex, Class<T> type)
+	throws SQLException
+	{
+		final Object obj = getObject( columnIndex );
+		if ( type.isInstance(obj) )
+			return type.cast(obj);
+		throw new SQLException( "Cannot convert " + obj.getClass().getName() +
+			" to " + type );
+	}
+
+	public <T> T getObject(String columnName, Class<T> type)
+	throws SQLException
+	{
+		final Object obj = getObject( columnName );
+		if ( type.isInstance(obj) )
+			return type.cast(obj);
+		throw new SQLException( "Cannot convert " + obj.getClass().getName() +
+			" to " + type );
 	}
 }

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/AbstractResultSet.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/AbstractResultSet.java
@@ -879,30 +879,13 @@ public abstract class AbstractResultSet implements ResultSet
 	}
 
 	// ************************************************************
-	// Implementation of JDBC 4.1 methods. These are half-baked at
-	// the moment: the type parameter isn't able to /influence/
-	// what type is returned, but only to fail if what gets
-	// returned by default isn't that.
-	// Add @Override to these once Java back horizon advances to 7.
+	// Implementation of JDBC 4.1 methods.
+	// Add @Override here once Java back horizon advances to 7.
 	// ************************************************************
-
-	public <T> T getObject(int columnIndex, Class<T> type)
-	throws SQLException
-	{
-		final Object obj = getObject( columnIndex );
-		if ( type.isInstance(obj) )
-			return type.cast(obj);
-		throw new SQLException( "Cannot convert " + obj.getClass().getName() +
-			" to " + type );
-	}
 
 	public <T> T getObject(String columnName, Class<T> type)
 	throws SQLException
 	{
-		final Object obj = getObject( columnName );
-		if ( type.isInstance(obj) )
-			return type.cast(obj);
-		throw new SQLException( "Cannot convert " + obj.getClass().getName() +
-			" to " + type );
+		return this.getObject(this.findColumn(columnName), type);
 	}
 }

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/ObjectResultSet.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/ObjectResultSet.java
@@ -1,10 +1,15 @@
 /*
- * Copyright (c) 2004, 2005, 2006 TADA AB - Taby Sweden
- * Copyright (c) 2010 PostgreSQL Global Development Group
+ * Copyright (c) 2004-2018 Tada AB and other contributors, as listed below.
  *
- * Distributed under the terms shown in the file COPYRIGHT
- * found in the root folder of this project or at
- * http://wiki.tada.se/index.php?title=PLJava_License
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Thomas Hallgren
+ *   PostgreSQL Global Development Group
+ *   Chapman Flack
  */
 package org.postgresql.pljava.jdbc;
 
@@ -30,27 +35,76 @@ import java.io.UnsupportedEncodingException;
 
 
 /**
+ * Implements most getters in terms of {@link #getValue}, {@link #getNumber},
+ * or a few other {@code ResultSet} getters that are so implemented, tracks
+ * {@link #wasNull wasNull}, and provides {@link #getObjectValue(int)} as the
+ * chief method for subclasses to implement; turns most updaters into
+ * {@link #updateObject(int,Object)}.
  * @author Thomas Hallgren
  */
 public abstract class ObjectResultSet extends AbstractResultSet
 {
 	private boolean m_wasNull = false;
 
+	/**
+	 * Returns a private value updated by final methods in this class.
+	 */
+	@Override
+	public boolean wasNull()
+	{
+		return m_wasNull;
+	}
 
 	/**
 	 * This is a noop since warnings are not supported.
 	 */
+	@Override
 	public void clearWarnings()
 	throws SQLException
 	{
 	}
 
+	/**
+	 * Returns null if not overridden in a subclass.
+	 */
+	@Override
+	public SQLWarning getWarnings()
+	throws SQLException
+	{
+		return null;
+	}
+
+	/**
+	 * Throws "unsupported" exception if not overridden in a subclass.
+	 * @throws SQLException indicating that this feature is not supported.
+	 */
+	@Override
+	public ResultSetMetaData getMetaData()
+	throws SQLException
+	{
+		throw new UnsupportedFeatureException(
+			"ResultSet meta data is not yet implemented");
+	}
+
+	// ************************************************************
+	// Pre-JDBC 4
+	// Getters-by-columnIndex
+	// ************************************************************
+
+	/**
+	 * Implemented over {@link #getValue getValue}.
+	 */
+	@Override
 	public Array getArray(int columnIndex)
 	throws SQLException
 	{
 		return (Array)this.getValue(columnIndex, Array.class);
 	}
 
+	/**
+	 * Implemented over {@link #getClob(int) getClob}.
+	 */
+	@Override
 	public InputStream getAsciiStream(int columnIndex)
 	throws SQLException
 	{
@@ -58,6 +112,10 @@ public abstract class ObjectResultSet extends AbstractResultSet
 		return (c == null) ? null : c.getAsciiStream();
 	}
 
+	/**
+	 * Implemented over {@link #getValue getValue}.
+	 */
+	@Override
 	public BigDecimal getBigDecimal(int columnIndex)
 	throws SQLException
 	{
@@ -65,14 +123,20 @@ public abstract class ObjectResultSet extends AbstractResultSet
 	}
 
 	/**
+	 * Throws "unsupported" exception.
 	 * @deprecated
 	 */
+	@Override
 	public BigDecimal getBigDecimal(int columnIndex, int scale)
 	throws SQLException
 	{
 		throw new UnsupportedFeatureException("getBigDecimal(int, int)");
 	}
 
+	/**
+	 * Implemented over {@link #getBlob(int) getBlob}.
+	 */
+	@Override
 	public InputStream getBinaryStream(int columnIndex)
 	throws SQLException
 	{
@@ -80,7 +144,10 @@ public abstract class ObjectResultSet extends AbstractResultSet
 		return (b == null) ? null : b.getBinaryStream();
 	}
 
-
+	/**
+	 * Implemented over {@link #getBytes(int) getBytes}.
+	 */
+	@Override
 	public Blob getBlob(int columnIndex)
 	throws SQLException
 	{
@@ -88,6 +155,10 @@ public abstract class ObjectResultSet extends AbstractResultSet
 		return (bytes == null) ? null :  new BlobValue(bytes);
 	}
 
+	/**
+	 * Implemented over {@link #getValue getValue}.
+	 */
+	@Override
 	public boolean getBoolean(int columnIndex)
 	throws SQLException
 	{
@@ -95,6 +166,10 @@ public abstract class ObjectResultSet extends AbstractResultSet
 		return (b == null) ? false : b.booleanValue();
 	}
 
+	/**
+	 * Implemented over {@link #getNumber getNumber}.
+	 */
+	@Override
 	public byte getByte(int columnIndex)
 	throws SQLException
 	{
@@ -102,12 +177,20 @@ public abstract class ObjectResultSet extends AbstractResultSet
 		return (b == null) ? 0 : b.byteValue();
 	}
 
+	/**
+	 * Implemented over {@link #getValue getValue}.
+	 */
+	@Override
 	public byte[] getBytes(int columnIndex)
 	throws SQLException
 	{
 		return (byte[])this.getValue(columnIndex, byte[].class);
 	}
 
+	/**
+	 * Implemented over {@link #getClob(int) getClob}.
+	 */
+	@Override
 	public Reader getCharacterStream(int columnIndex)
 	throws SQLException
 	{
@@ -115,6 +198,10 @@ public abstract class ObjectResultSet extends AbstractResultSet
 		return (c == null) ? null : c.getCharacterStream();
 	}
 
+	/**
+	 * Implemented over {@link #getString(int) getString}.
+	 */
+	@Override
 	public Clob getClob(int columnIndex)
 	throws SQLException
 	{
@@ -122,18 +209,30 @@ public abstract class ObjectResultSet extends AbstractResultSet
 		return (str == null) ? null :  new ClobValue(str);
 	}
 	
+	/**
+	 * Implemented over {@link #getValue getValue}.
+	 */
+	@Override
 	public Date getDate(int columnIndex)
 	throws SQLException
 	{
 		return (Date)this.getValue(columnIndex, Date.class);
 	}
 
+	/**
+	 * Implemented over {@link #getValue(int,Class,Calendar) getValue}.
+	 */
+	@Override
 	public Date getDate(int columnIndex, Calendar cal)
 	throws SQLException
 	{
 		return (Date)this.getValue(columnIndex, Date.class, cal);
 	}
 
+	/**
+	 * Implemented over {@link #getNumber getNumber}.
+	 */
+	@Override
 	public double getDouble(int columnIndex)
 	throws SQLException
 	{
@@ -141,6 +240,10 @@ public abstract class ObjectResultSet extends AbstractResultSet
 		return (d == null) ? 0 : d.doubleValue();
 	}
 
+	/**
+	 * Implemented over {@link #getNumber getNumber}.
+	 */
+	@Override
 	public float getFloat(int columnIndex)
 	throws SQLException
 	{
@@ -148,6 +251,10 @@ public abstract class ObjectResultSet extends AbstractResultSet
 		return (f == null) ? 0 : f.floatValue();
 	}
 
+	/**
+	 * Implemented over {@link #getNumber getNumber}.
+	 */
+	@Override
 	public int getInt(int columnIndex)
 	throws SQLException
 	{
@@ -155,6 +262,10 @@ public abstract class ObjectResultSet extends AbstractResultSet
 		return (i == null) ? 0 : i.intValue();
 	}
 
+	/**
+	 * Implemented over {@link #getNumber getNumber}.
+	 */
+	@Override
 	public long getLong(int columnIndex)
 	throws SQLException
 	{
@@ -163,15 +274,10 @@ public abstract class ObjectResultSet extends AbstractResultSet
 	}
 
 	/**
-	 * ResultSetMetaData is not yet supported.
-	 * @throws SQLException indicating that this feature is not supported.
+	 * Implemented over {@link #getObjectValue(int) getObjectValue}.
+	 * Final because it records {@code wasNull} for use by other methods.
 	 */
-	public ResultSetMetaData getMetaData()
-	throws SQLException
-	{
-		throw new UnsupportedFeatureException("ResultSet meta data is not yet implemented");
-	}
-
+	@Override
 	public final Object getObject(int columnIndex)
 	throws SQLException
 	{
@@ -180,6 +286,11 @@ public abstract class ObjectResultSet extends AbstractResultSet
 		return value;
 	}
 
+	/**
+	 * Implemented over {@link #getObjectValue(int,Map) getObjectValue}.
+	 * Final because it records {@code wasNull} for use by other methods.
+	 */
+	@Override
 	public final Object getObject(int columnIndex, Map map)
 	throws SQLException
 	{
@@ -188,12 +299,20 @@ public abstract class ObjectResultSet extends AbstractResultSet
 		return value;
 	}
 
+	/**
+	 * Implemented over {@link #getValue getValue}.
+	 */
+	@Override
 	public Ref getRef(int columnIndex)
 	throws SQLException
 	{
 		return (Ref)this.getValue(columnIndex, Ref.class);
 	}
 
+	/**
+	 * Implemented over {@link #getNumber getNumber}.
+	 */
+	@Override
 	public short getShort(int columnIndex)
 	throws SQLException
 	{
@@ -201,30 +320,50 @@ public abstract class ObjectResultSet extends AbstractResultSet
 		return (s == null) ? 0 : s.shortValue();
 	}
 
+	/**
+	 * Implemented over {@link #getValue getValue}.
+	 */
+	@Override
 	public String getString(int columnIndex)
 	throws SQLException
 	{
 		return (String)this.getValue(columnIndex, String.class);
 	}
 
+	/**
+	 * Implemented over {@link #getValue getValue}.
+	 */
+	@Override
 	public Time getTime(int columnIndex)
 	throws SQLException
 	{
 		return (Time)this.getValue(columnIndex, Time.class);
 	}
 
+	/**
+	 * Implemented over {@link #getValue(int,Class,Calendar) getValue}.
+	 */
+	@Override
 	public Time getTime(int columnIndex, Calendar cal)
 	throws SQLException
 	{
 		return (Time)this.getValue(columnIndex, Time.class, cal);
 	}
 
+	/**
+	 * Implemented over {@link #getValue getValue}.
+	 */
+	@Override
 	public Timestamp getTimestamp(int columnIndex)
 	throws SQLException
 	{
 		return (Timestamp)this.getValue(columnIndex, Timestamp.class);
 	}
 
+	/**
+	 * Implemented over {@link #getValue(int,Class,Calendar) getValue}.
+	 */
+	@Override
 	public Timestamp getTimestamp(int columnIndex, Calendar cal)
 	throws SQLException
 	{
@@ -232,6 +371,7 @@ public abstract class ObjectResultSet extends AbstractResultSet
 	}
 
 	/**
+	 * Throws "unsupported" exception.
 	 * @deprecated
 	 */
 	public InputStream getUnicodeStream(int columnIndex)
@@ -240,15 +380,13 @@ public abstract class ObjectResultSet extends AbstractResultSet
 		throw new UnsupportedFeatureException("ResultSet.getUnicodeStream");
 	}
 
+	/**
+	 * Implemented over {@link #getValue getValue}.
+	 */
+	@Override
 	public URL getURL(int columnIndex) throws SQLException
 	{
 		return (URL)this.getValue(columnIndex, URL.class);
-	}
-
-	public SQLWarning getWarnings()
-	throws SQLException
-	{
-		return null;
 	}
 
 	/**
@@ -261,144 +399,240 @@ public abstract class ObjectResultSet extends AbstractResultSet
 		throw new UnsupportedFeatureException("Refresh row");
 	}
 
+	// ************************************************************
+	// Pre-JDBC 4
+	// Updaters-by-columnIndex
+	// ************************************************************
+
+	/**
+	 * Implemented over {@link #updateObject updateObject}.
+	 */
+	@Override
 	public void updateArray(int columnIndex, Array x) throws SQLException
 	{
 		this.updateObject(columnIndex, x);
 	}
 
+	/**
+	 * Implemented over {@link ClobValue} and
+	 * {@link #updateObject updateObject}.
+	 */
+	@Override
 	public void updateAsciiStream(int columnIndex, InputStream x, int length)
 	throws SQLException
 	{
 		try
 		{
 			this.updateObject(columnIndex,
-					new ClobValue(new InputStreamReader(x, "US-ASCII"), length));
+				new ClobValue(new InputStreamReader(x, "US-ASCII"), length));
 		}
 		catch(UnsupportedEncodingException e)
 		{
-			throw new SQLException("US-ASCII encoding is not supported by this JVM");
+			throw new SQLException(
+				"US-ASCII encoding is not supported by this JVM");
 		}
 	}
 
+	/**
+	 * Implemented over {@link #updateObject updateObject}.
+	 */
+	@Override
 	public void updateBigDecimal(int columnIndex, BigDecimal x)
 	throws SQLException
 	{
 		this.updateObject(columnIndex, x);
 	}
 
+	/**
+	 * Implemented over {@link BlobValue} and
+	 * {@link #updateBlob updateBlob}.
+	 */
+	@Override
 	public void updateBinaryStream(int columnIndex, InputStream x, int length)
 	throws SQLException
 	{
 		this.updateBlob(columnIndex, (Blob) new BlobValue(x, length));
 	}
 
+	/**
+	 * Implemented over {@link #updateObject updateObject}.
+	 */
+	@Override
 	public void updateBlob(int columnIndex, Blob x)
 	throws SQLException
 	{
 		this.updateObject(columnIndex, x);
 	}
 
+	/**
+	 * Implemented over {@link #updateObject updateObject}.
+	 */
+	@Override
 	public void updateBoolean(int columnIndex, boolean x)
 	throws SQLException
 	{
 		this.updateObject(columnIndex, x ? Boolean.TRUE : Boolean.FALSE);
 	}
 
+	/**
+	 * Implemented over {@link #updateObject updateObject}.
+	 */
+	@Override
 	public void updateByte(int columnIndex, byte x)
 	throws SQLException
 	{
 		this.updateObject(columnIndex, new Byte(x));
 	}
 
+	/**
+	 * Implemented over {@link #updateObject updateObject}.
+	 */
+	@Override
 	public void updateBytes(int columnIndex, byte[] x)
 	throws SQLException
 	{
 		this.updateObject(columnIndex, x);
 	}
 
+	/**
+	 * Implemented over {@link ClobValue} and
+	 * {@link #updateClob updateClob}.
+	 */
+	@Override
 	public void updateCharacterStream(int columnIndex, Reader x, int length)
 	throws SQLException
 	{
 		this.updateClob(columnIndex, (Clob) new ClobValue(x, length));
 	}
 
+	/**
+	 * Implemented over {@link #updateObject updateObject}.
+	 */
+	@Override
 	public void updateClob(int columnIndex, Clob x)
 	throws SQLException
 	{
 		this.updateObject(columnIndex, x);
 	}
 
+	/**
+	 * Implemented over {@link #updateObject updateObject}.
+	 */
+	@Override
 	public void updateDate(int columnIndex, Date x)
 	throws SQLException
 	{
 		this.updateObject(columnIndex, x);
 	}
 
+	/**
+	 * Implemented over {@link #updateObject updateObject}.
+	 */
+	@Override
 	public void updateDouble(int columnIndex, double x)
 	throws SQLException
 	{
 		this.updateObject(columnIndex, new Double(x));
 	}
 
+	/**
+	 * Implemented over {@link #updateObject updateObject}.
+	 */
+	@Override
 	public void updateFloat(int columnIndex, float x)
 	throws SQLException
 	{
 		this.updateObject(columnIndex, new Float(x));
 	}
 
+	/**
+	 * Implemented over {@link #updateObject updateObject}.
+	 */
+	@Override
 	public void updateInt(int columnIndex, int x)
 	throws SQLException
 	{
 		this.updateObject(columnIndex, new Integer(x));
 	}
 
+	/**
+	 * Implemented over {@link #updateObject updateObject}.
+	 */
+	@Override
 	public void updateLong(int columnIndex, long x)
 	throws SQLException
 	{
 		this.updateObject(columnIndex, new Long(x));
 	}
 
+	/**
+	 * Implemented over {@link #updateObject updateObject}.
+	 */
+	@Override
 	public void updateNull(int columnIndex)
 	throws SQLException
 	{
 		this.updateObject(columnIndex, null);
 	}
 
+	/**
+	 * Implemented over {@link #updateObject updateObject}.
+	 */
+	@Override
 	public void updateRef(int columnIndex, Ref x)
 	throws SQLException
 	{
 		this.updateObject(columnIndex, x);
 	}
 
+	/**
+	 * Implemented over {@link #updateObject updateObject}.
+	 */
+	@Override
 	public void updateShort(int columnIndex, short x)
 	throws SQLException
 	{
 		this.updateObject(columnIndex, new Short(x));
 	}
 
+	/**
+	 * Implemented over {@link #updateObject updateObject}.
+	 */
+	@Override
 	public void updateString(int columnIndex, String x)
 	throws SQLException
 	{
 		this.updateObject(columnIndex, x);
 	}
 
+	/**
+	 * Implemented over {@link #updateObject updateObject}.
+	 */
+	@Override
 	public void updateTime(int columnIndex, Time x)
 	throws SQLException
 	{
 		this.updateObject(columnIndex, x);
 	}
 
+	/**
+	 * Implemented over {@link #updateObject updateObject}.
+	 */
+	@Override
 	public void updateTimestamp(int columnIndex, Timestamp x)
 	throws SQLException
 	{
 		this.updateObject(columnIndex, x);
 	}
 
-	public boolean wasNull()
-	{
-		return m_wasNull;
-	}
+	// ************************************************************
+	// Implementation methods
+	// ************************************************************
 
+	/**
+	 * Implemented over {@link #getObjectValue}, tracks {@code wasNull},
+	 * applies {@link SPIConnection#basicNumericCoersion} to {@code cls}.
+	 */
 	protected final Number getNumber(int columnIndex, Class cls)
 	throws SQLException
 	{
@@ -407,26 +641,43 @@ public abstract class ObjectResultSet extends AbstractResultSet
 		return SPIConnection.basicNumericCoersion(cls, value);
 	}
 
+	/**
+	 * Implemented over {@link #getObject},
+	 * applies {@link SPIConnection#basicCoersion} to {@code cls}.
+	 */
 	protected final Object getValue(int columnIndex, Class cls)
 	throws SQLException
 	{
 		return SPIConnection.basicCoersion(cls, this.getObject(columnIndex));
 	}
 
+	/**
+	 * Implemented over {@link #getObject},
+	 * applies {@link SPIConnection#basicCalendricalCoersion} to {@code cls}.
+	 */
 	protected Object getValue(int columnIndex, Class cls, Calendar cal)
 	throws SQLException
 	{
-		return SPIConnection.basicCalendricalCoersion(cls, this.getObject(columnIndex), cal);
+		return SPIConnection.basicCalendricalCoersion(cls,
+			this.getObject(columnIndex), cal);
 	}
 
+	/**
+	 * Implemented over {@link #getObjectValue}, complains if {@code typeMap}
+	 * is non-null.
+	 */
 	protected Object getObjectValue(int columnIndex, Map typeMap)
 	throws SQLException
 	{
 		if(typeMap == null)
 			return this.getObjectValue(columnIndex);
-		throw new UnsupportedFeatureException("Obtaining values using explicit Map");
+		throw new UnsupportedFeatureException(
+			"Obtaining values using explicit Map");
 	}
 
+	/**
+	 * Primary method for subclass to override to retrieve a value.
+	 */
 	protected abstract Object getObjectValue(int columnIndex)
 	throws SQLException;
 }

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/ObjectResultSet.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/ObjectResultSet.java
@@ -640,7 +640,7 @@ public abstract class ObjectResultSet extends AbstractResultSet
 	{
 		Object value = this.getObjectValue(columnIndex, type);
 		m_wasNull = (value == null);
-		if ( type.isInstance(value) )
+		if ( m_wasNull  ||  type.isInstance(value) )
 			return type.cast(value);
 		throw new SQLException("Cannot convert " + value.getClass().getName() +
 			" to " + type.getName());

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/ReadOnlyResultSet.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/ReadOnlyResultSet.java
@@ -1,8 +1,13 @@
 /*
- * Copyright (c) 2004, 2005, 2006 TADA AB - Taby Sweden
- * Distributed under the terms shown in the file COPYRIGHT
- * found in the root folder of this project or at
- * http://eng.tada.se/osprojects/COPYRIGHT.html
+ * Copyright (c) 2004-2018 Tada AB and other contributors, as listed below.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Thomas Hallgren
  */
 package org.postgresql.pljava.jdbc;
 
@@ -11,7 +16,7 @@ import java.sql.SQLException;
 
 
 /**
- * The ReadOnlyResultSet implements all methods that changes the ResultSet
+ * Implements all methods that change the ResultSet
  * in any way as methods that yield an {@link UnsupportedFeatureException}.
  *
  * @author Thomas Hallgren
@@ -21,6 +26,7 @@ public abstract class ReadOnlyResultSet extends ObjectResultSet
 	/**
 	 * Returns {@link ResultSet#CONCUR_READ_ONLY}.
 	 */
+	@Override
 	public int getConcurrency()
 	throws SQLException
 	{
@@ -31,6 +37,7 @@ public abstract class ReadOnlyResultSet extends ObjectResultSet
 	 * This feature is not supported on a <code>ReadOnlyResultSet</code>.
 	 * @throws SQLException indicating that this feature is not supported.
 	 */
+	@Override
 	public void cancelRowUpdates()
 	throws SQLException
 	{
@@ -41,6 +48,7 @@ public abstract class ReadOnlyResultSet extends ObjectResultSet
 	 * This feature is not supported on a <code>ReadOnlyResultSet</code>.
 	 * @throws SQLException indicating that this feature is not supported.
 	 */
+	@Override
 	public void deleteRow()
 	throws SQLException
 	{
@@ -51,6 +59,7 @@ public abstract class ReadOnlyResultSet extends ObjectResultSet
 	 * This feature is not supported on a <code>ReadOnlyResultSet</code>.
 	 * @throws SQLException indicating that this feature is not supported.
 	 */
+	@Override
 	public void insertRow()
 	throws SQLException
 	{
@@ -61,6 +70,7 @@ public abstract class ReadOnlyResultSet extends ObjectResultSet
 	 * This is a no-op since the <code>moveToInsertRow()</code> method is
 	 * unsupported.
 	 */
+	@Override
 	public void moveToCurrentRow()
 	throws SQLException
 	{
@@ -70,6 +80,7 @@ public abstract class ReadOnlyResultSet extends ObjectResultSet
 	 * This feature is not supported on a <code>ReadOnlyResultSet</code>.
 	 * @throws SQLException indicating that this feature is not supported.
 	 */
+	@Override
 	public void moveToInsertRow()
 	throws SQLException
 	{
@@ -80,6 +91,7 @@ public abstract class ReadOnlyResultSet extends ObjectResultSet
 	 * This feature is not supported on a <code>ReadOnlyResultSet</code>.
 	 * @throws SQLException indicating that this feature is not supported.
 	 */
+	@Override
 	public void updateRow()
 	throws SQLException
 	{
@@ -89,6 +101,7 @@ public abstract class ReadOnlyResultSet extends ObjectResultSet
 	/**
 	 * Always returns false.
 	 */
+	@Override
 	public boolean rowDeleted()
 	throws SQLException
 	{
@@ -98,6 +111,7 @@ public abstract class ReadOnlyResultSet extends ObjectResultSet
 	/**
 	 * Always returns false.
 	 */
+	@Override
 	public boolean rowInserted()
 	throws SQLException
 	{
@@ -107,6 +121,7 @@ public abstract class ReadOnlyResultSet extends ObjectResultSet
 	/**
 	 * Always returns false.
 	 */
+	@Override
 	public boolean rowUpdated()
 	throws SQLException
 	{
@@ -117,6 +132,7 @@ public abstract class ReadOnlyResultSet extends ObjectResultSet
 	 * This feature is not supported on a <code>ReadOnlyResultSet</code>.
 	 * @throws SQLException indicating that this feature is not supported.
 	 */
+	@Override
 	public void updateObject(int columnIndex, Object x) throws SQLException
 	{
 		throw readOnlyException();
@@ -126,6 +142,7 @@ public abstract class ReadOnlyResultSet extends ObjectResultSet
 	 * This feature is not supported on a <code>ReadOnlyResultSet</code>.
 	 * @throws SQLException indicating that this feature is not supported.
 	 */
+	@Override
 	public void updateObject(int columnIndex, Object x, int scale)
 	throws SQLException
 	{

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/ResultSetBase.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/ResultSetBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005-2018 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2018 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -17,41 +17,62 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 
 /**
- * A ResultSet base provides methods that are common both for
+ * Provides methods that are common both for
  * a SyntheticResultSet (which is not associated with a
  * statement) and SPIResultSet.
  *
  * @author Filip Hrbek
  */
-abstract class ResultSetBase extends ReadOnlyResultSet
+public abstract class ResultSetBase extends ReadOnlyResultSet
 {
 	private int m_fetchSize;
 	private int m_row;
 
+	/**
+	 * Records a fetch size, and an initial position before the first row.
+	 */
 	ResultSetBase(int fetchSize)
 	{
 		m_fetchSize = fetchSize;
 		m_row = 0;	// First row is 1 so 0 is on undefined position.
 	}
 
+	/**
+	 * Always returns {@link #FETCH_FORWARD} if not overridden.
+	 */
+	@Override
 	public int getFetchDirection()
 	throws SQLException
 	{
 		return FETCH_FORWARD;
 	}
 
+	/**
+	 * Returns the fetch size set by the constructor or with
+	 * {@link #setFetchSize}.
+	 */
+	@Override
 	public final int getFetchSize()
 	throws SQLException
 	{
 		return m_fetchSize;
 	}
 
+	/**
+	 * Returns the row set by the constructor or with
+	 * {@link #setRow}.
+	 */
+	@Override
 	public final int getRow()
 	throws SQLException
 	{
 		return m_row;
 	}
 
+	/**
+	 * Always returns {@link #TYPE_FORWARD_ONLY} if not overridden.
+	 */
+	@Override
 	public int getType()
 	throws SQLException
 	{
@@ -59,9 +80,10 @@ abstract class ResultSetBase extends ReadOnlyResultSet
 	}
 
 	/**
-	 * Cursor positoning is not implemented yet.
+	 * Cursor positioning is not implemented yet.
 	 * @throws SQLException indicating that this feature is not supported.
 	 */
+	@Override
 	public void afterLast()
 	throws SQLException
 	{
@@ -69,15 +91,17 @@ abstract class ResultSetBase extends ReadOnlyResultSet
 	}
 
 	/**
-	 * Cursor positoning is not implemented yet.
+	 * Cursor positioning is not implemented yet.
 	 * @throws SQLException indicating that this feature is not supported.
 	 */
+	@Override
 	public void beforeFirst()
 	throws SQLException
 	{
 		throw new UnsupportedFeatureException("Cursor positioning");
 	}
 
+	@Override
 	public void close()
 	throws SQLException
 	{
@@ -88,21 +112,25 @@ abstract class ResultSetBase extends ReadOnlyResultSet
 	 * Cursor positioning is not implemented yet.
 	 * @throws SQLException indicating that this feature is not supported.
 	 */
+	@Override
 	public boolean first() throws SQLException
 	{
 		throw new UnsupportedFeatureException("Cursor positioning");
 	}
 
+	@Override
 	public boolean isAfterLast() throws SQLException
 	{
 		return m_row < 0;
 	}
 
+	@Override
 	public boolean isBeforeFirst() throws SQLException
 	{
 		return m_row == 0;
 	}
 
+	@Override
 	public boolean isFirst() throws SQLException
 	{
 		return m_row == 1;
@@ -112,6 +140,7 @@ abstract class ResultSetBase extends ReadOnlyResultSet
 	 * Cursor positioning is not implemented yet.
 	 * @throws SQLException indicating that this feature is not supported.
 	 */
+	@Override
 	public boolean last()
 	throws SQLException
 	{
@@ -122,6 +151,7 @@ abstract class ResultSetBase extends ReadOnlyResultSet
 	 * Reverse positioning is not implemented yet.
 	 * @throws SQLException indicating that this feature is not supported.
 	 */
+	@Override
 	public boolean previous()
 	throws SQLException
 	{
@@ -132,6 +162,7 @@ abstract class ResultSetBase extends ReadOnlyResultSet
 	 * Cursor positioning is not implemented yet.
 	 * @throws SQLException indicating that this feature is not supported.
 	 */
+	@Override
 	public boolean absolute(int row)
 	throws SQLException
 	{
@@ -142,6 +173,7 @@ abstract class ResultSetBase extends ReadOnlyResultSet
 	 * Cursor positioning is not implemented yet.
 	 * @throws SQLException indicating that this feature is not supported.
 	 */
+	@Override
 	public boolean relative(int rows)
 	throws SQLException
 	{
@@ -153,6 +185,7 @@ abstract class ResultSetBase extends ReadOnlyResultSet
 	 * @throws SQLException indicating that this feature is not supported
 	 * for other values on <code>direction</code>.
 	 */
+	@Override
 	public void setFetchDirection(int direction)
 	throws SQLException
 	{
@@ -165,6 +198,7 @@ abstract class ResultSetBase extends ReadOnlyResultSet
 	// ************************************************************
 
 
+	@Override
 	public boolean isClosed()
 		throws SQLException
 	{
@@ -184,6 +218,10 @@ abstract class ResultSetBase extends ReadOnlyResultSet
 	// End of implementation of JDBC 4 methods.
 	// ************************************************************
 
+	/**
+	 * Sets the fetch size maintained in this class.
+	 */
+	@Override
 	public void setFetchSize(int fetchSize)
 	throws SQLException
 	{
@@ -192,6 +230,10 @@ abstract class ResultSetBase extends ReadOnlyResultSet
 		m_fetchSize = fetchSize;
 	}
 
+	/**
+	 * Sets the row reported by this class; should probably have
+	 * {@code protected} access.
+	 */
 	final void setRow(int row)
 	{
 		m_row = row;

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/SPIConnection.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/SPIConnection.java
@@ -1025,20 +1025,20 @@ public class SPIConnection implements Connection
 		 */
 		int ttz  = Types.TIME;       // Use these values
 		int tstz = Types.TIMESTAMP;  //         pre-Java 8
-		try
-		{
-			ttz =
-				Types.class.getField("TIME_WITH_TIMEZONE")
-					.getInt(Types.class);
-			tstz =
-				Types.class.getField("TIMESTAMP_WITH_TIMEZONE")
-					.getInt(Types.class);
-		}
-		catch ( NoSuchFieldException nsfe ) { } // ok, not running in Java 8
-		catch ( IllegalAccessException iae )
-		{
-			throw new ExceptionInInitializerError(iae);
-		}
+//		try    COMMENTED OUT FOR BACK-COMPATIBILITY REASONS IN PL/JAVA 1.5.x
+//		{
+//			ttz =
+//				Types.class.getField("TIME_WITH_TIMEZONE")
+//					.getInt(Types.class);
+//			tstz =
+//				Types.class.getField("TIMESTAMP_WITH_TIMEZONE")
+//					.getInt(Types.class);
+//		}
+//		catch ( NoSuchFieldException nsfe ) { } // ok, not running in Java 8
+//		catch ( IllegalAccessException iae )
+//		{
+//			throw new ExceptionInInitializerError(iae);
+//		}
 
 		JDBC_TYPE_NUMBERS = new int[]
 		{

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/SPIConnection.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/SPIConnection.java
@@ -742,7 +742,7 @@ public class SPIConnection implements Connection
 
 	/**
 	 * Convert a PostgreSQL type name to a {@link Types} integer, using the
-	 * {@code JDBC3_TYPE_NAMES}/{@code JDBC_TYPE_NUMBERS} arrays; used in
+	 * {@code JDBC_TYPE_NAMES}/{@code JDBC_TYPE_NUMBERS} arrays; used in
 	 * {@link DatabaseMetaData} and {@link ResultSetMetaData}.
 	 */
     public int getSQLType(String pgTypeName)
@@ -750,8 +750,8 @@ public class SPIConnection implements Connection
         if (pgTypeName == null)
             return Types.OTHER;
 
-        for (int i = 0;i < JDBC3_TYPE_NAMES.length;i++)
-            if (pgTypeName.equals(JDBC3_TYPE_NAMES[i]))
+        for (int i = 0;i < JDBC_TYPE_NAMES.length;i++)
+            if (pgTypeName.equals(JDBC_TYPE_NAMES[i]))
                 return JDBC_TYPE_NUMBERS[i];
 
         return Types.OTHER;
@@ -986,7 +986,7 @@ public class SPIConnection implements Connection
      *
      * Tip: keep these grouped together by the Types. value
      */
-    public static final String JDBC3_TYPE_NAMES[] = {
+    public static final String JDBC_TYPE_NAMES[] = {
                 "int2",
                 "int4", "oid",
                 "int8",

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/SPIConnection.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/SPIConnection.java
@@ -1015,28 +1015,54 @@ public class SPIConnection implements Connection
      *
      * Tip: keep these grouped together by the Types. value
      */
-    public static final int JDBC_TYPE_NUMBERS[] =
-    		{
-                Types.SMALLINT,
-                Types.INTEGER, Types.INTEGER,
-                Types.BIGINT,
-                Types.DOUBLE, Types.DOUBLE,
-                Types.NUMERIC,
-                Types.REAL,
-                Types.DOUBLE,
-                Types.CHAR, Types.CHAR, Types.CHAR, Types.CHAR, Types.CHAR, Types.CHAR,
-                Types.VARCHAR, Types.VARCHAR, Types.VARCHAR, Types.VARCHAR,
-                Types.BINARY,
-                Types.BOOLEAN,
-                Types.BIT,
-                Types.DATE,
-                Types.TIME, Types.TIME,
-                Types.TIMESTAMP, Types.TIMESTAMP, Types.TIMESTAMP,
-                Types.ARRAY, Types.ARRAY, Types.ARRAY, Types.ARRAY, Types.ARRAY,
-                Types.ARRAY, Types.ARRAY, Types.ARRAY, Types.ARRAY, Types.ARRAY,
-                Types.ARRAY, Types.ARRAY, Types.ARRAY, Types.ARRAY, Types.ARRAY,
-                Types.ARRAY
-            };
+    public static final int JDBC_TYPE_NUMBERS[];
+
+	static
+	{
+		/*
+		 * Try to get the JDBC 4.2 / Java 8 TIME*ZONE types reflectively.
+		 * Once the Java back horizon advances to 8, just do this the easy way.
+		 */
+		int ttz  = Types.TIME;       // Use these values
+		int tstz = Types.TIMESTAMP;  //         pre-Java 8
+		try
+		{
+			ttz =
+				Types.class.getField("TIME_WITH_TIMEZONE")
+					.getInt(Types.class);
+			tstz =
+				Types.class.getField("TIMESTAMP_WITH_TIMEZONE")
+					.getInt(Types.class);
+		}
+		catch ( NoSuchFieldException nsfe ) { } // ok, not running in Java 8
+		catch ( IllegalAccessException iae )
+		{
+			throw new ExceptionInInitializerError(iae);
+		}
+
+		JDBC_TYPE_NUMBERS = new int[]
+		{
+			Types.SMALLINT,
+			Types.INTEGER, Types.INTEGER,
+			Types.BIGINT,
+			Types.DOUBLE, Types.DOUBLE,
+			Types.NUMERIC,
+			Types.REAL,
+			Types.DOUBLE,
+			Types.CHAR,Types.CHAR,Types.CHAR,Types.CHAR,Types.CHAR,Types.CHAR,
+			Types.VARCHAR, Types.VARCHAR, Types.VARCHAR, Types.VARCHAR,
+			Types.BINARY,
+			Types.BOOLEAN,
+			Types.BIT,
+			Types.DATE,
+			Types.TIME, ttz,
+			Types.TIMESTAMP, Types.TIMESTAMP, tstz,
+			Types.ARRAY, Types.ARRAY, Types.ARRAY, Types.ARRAY, Types.ARRAY,
+			Types.ARRAY, Types.ARRAY, Types.ARRAY, Types.ARRAY, Types.ARRAY,
+			Types.ARRAY, Types.ARRAY, Types.ARRAY, Types.ARRAY, Types.ARRAY,
+			Types.ARRAY
+        };
+	}
 
 	// ************************************************************
 	// Implementation of JDBC 4 methods. Methods go here if they

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/SPIDatabaseMetaData.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/SPIDatabaseMetaData.java
@@ -2996,7 +2996,7 @@ public class SPIDatabaseMetaData implements DatabaseMetaData
 			+ " end as data_type, pg_catalog.obj_description(t.oid, 'pg_type')  "
 			+ "as remarks, CASE WHEN t.typtype = 'd' then  (select CASE";
 
-		for(int i = 0; i < SPIConnection.JDBC3_TYPE_NAMES.length; i++)
+		for(int i = 0; i < SPIConnection.JDBC_TYPE_NAMES.length; i++)
 		{
 			sql += " when typname = '" + SPIConnection.JDBC_TYPE_NUMBERS[i]
 				+ "' then " + SPIConnection.JDBC_TYPE_NUMBERS[i];

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/SPIResultSet.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/SPIResultSet.java
@@ -54,12 +54,7 @@ public class SPIResultSet extends ResultSetBase
 		m_tableRow = -1;
 	}
 
-	public int getFetchDirection()
-	throws SQLException
-	{
-		return FETCH_FORWARD;
-	}
-
+	@Override
 	public void close()
 	throws SQLException
 	{
@@ -75,11 +70,13 @@ public class SPIResultSet extends ResultSetBase
 		}
 	}
 
+	@Override
 	public boolean isLast() throws SQLException
 	{
 		return m_currentRow != null && this.peekNext() == null;
 	}
 
+	@Override
 	public boolean next()
 	throws SQLException
 	{
@@ -90,24 +87,35 @@ public class SPIResultSet extends ResultSetBase
 		return result;
 	}
 
+	/**
+	 * This method does return the name of the portal, but beware of attempting
+	 * positioned update/delete, because rows are read from the portal in
+	 * {@link #getFetchSize} batches.
+	 */
+	@Override
 	public String getCursorName()
 	throws SQLException
 	{
 		return this.getPortal().getName();
 	}
 
+	@Override
 	public int findColumn(String columnName)
 	throws SQLException
 	{
 		return m_tupleDesc.getColumnIndex(columnName);
 	}
 
+	@Override
 	public Statement getStatement()
 	throws SQLException
 	{
 		return m_statement;
 	}
 
+	/**
+	 * Return the {@code Portal} associated with this {@code ResultSet}.
+	 */
 	protected final Portal getPortal()
 	throws SQLException
 	{
@@ -116,6 +124,10 @@ public class SPIResultSet extends ResultSetBase
 		return m_portal;
 	}
 
+	/**
+	 * Get a(nother) table of {@link #getFetchSize} rows from the
+	 * {@link Portal}.
+	 */
 	protected final TupleTable getTupleTable()
 	throws SQLException
 	{
@@ -153,6 +165,9 @@ public class SPIResultSet extends ResultSetBase
 		return m_table;
 	}
 
+	/**
+	 * Return the {@link Tuple} most recently returned by {@link #next}.
+	 */
 	protected final Tuple getCurrentRow()
 	throws SQLException
 	{
@@ -161,6 +176,10 @@ public class SPIResultSet extends ResultSetBase
 		return m_currentRow;
 	}
 
+	/**
+	 * Get another {@link Tuple} from the {@link TupleTable}, refreshing the
+	 * table as needed.
+	 */
 	protected final Tuple peekNext()
 	throws SQLException
 	{
@@ -173,7 +192,7 @@ public class SPIResultSet extends ResultSetBase
 
 		if(m_tableRow >= table.getCount() - 1)
 		{
-			// Current table is exhaused, get the next
+			// Current table is exhausted, get the next
 			// one.
 			//
 			m_table = null;
@@ -185,12 +204,20 @@ public class SPIResultSet extends ResultSetBase
 		return m_nextRow;
 	}
 
+	/**
+	 * Implemented over {@link Tuple#getObject Tuple.getObject(TupleDesc,int)}.
+	 */
+	@Override // defined in ObjectResultSet
 	protected Object getObjectValue(int columnIndex)
 	throws SQLException
 	{
 		return this.getCurrentRow().getObject(m_tupleDesc, columnIndex);
 	}
 
+	/**
+	 * Returns an {@link SPIResultSetMetaData} instance.
+	 */
+	@Override
 	public ResultSetMetaData getMetaData()
 	throws SQLException
 	{

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/SPIResultSet.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/SPIResultSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2016 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2018 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -205,13 +205,14 @@ public class SPIResultSet extends ResultSetBase
 	}
 
 	/**
-	 * Implemented over {@link Tuple#getObject Tuple.getObject(TupleDesc,int)}.
+	 * Implemented over
+	 * {@link Tuple#getObject Tuple.getObject(TupleDesc,int,Class)}.
 	 */
 	@Override // defined in ObjectResultSet
-	protected Object getObjectValue(int columnIndex)
+	protected Object getObjectValue(int columnIndex, Class<?> type)
 	throws SQLException
 	{
-		return this.getCurrentRow().getObject(m_tupleDesc, columnIndex);
+		return this.getCurrentRow().getObject(m_tupleDesc, columnIndex, type);
 	}
 
 	/**

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/SQLInputFromTuple.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/SQLInputFromTuple.java
@@ -1,10 +1,14 @@
 /*
- * Copyright (c) 2004, 2005, 2006 TADA AB - Taby Sweden
- * Copyright (c) 2010, 2011 PostgreSQL Global Development Group
+ * Copyright (c) 2004-2018 Tada AB and other contributors, as listed below.
  *
- * Distributed under the terms shown in the file COPYRIGHT
- * found in the root folder of this project or at
- * http://wiki.tada.se/index.php?title=PLJava_License
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Tada AB
+ *   Chapman Flack
  */
 package org.postgresql.pljava.jdbc;
 
@@ -32,9 +36,9 @@ import org.postgresql.pljava.internal.JavaWrapper;
 import org.postgresql.pljava.internal.TupleDesc;
 
 /**
- * A single row, updateable ResultSet specially made for triggers. The
- * changes made to this ResultSet are remembered and converted to a
- * SPI_modify_tuple call prior to function return.
+ * Implements the {@code SQLInput} interface for a user-defined type (UDT)
+ * implemented in Java, for the case where a composite type in PostgreSQL is
+ * used as the UDT's representation, so it can be accessed as a PG tuple.
  *
  * @author Thomas Hallgren
  */
@@ -44,6 +48,11 @@ public class SQLInputFromTuple extends JavaWrapper implements SQLInput
 	private final TupleDesc m_tupleDesc;
 	private boolean m_wasNull;
 
+	/**
+	 * Construct an instance, given the (native) pointer to a PG
+	 * {@code HeapTupleHeader}, as well as the TupleDesc (Java object this time)
+	 * describing its structure.
+	 */
 	public SQLInputFromTuple(long heapTupleHeaderPointer, TupleDesc tupleDesc)
 	throws SQLException
 	{
@@ -53,92 +62,151 @@ public class SQLInputFromTuple extends JavaWrapper implements SQLInput
 		m_wasNull = false;
 	}
 
+	/**
+	 * Implemented over {@link #readValue}.
+	 */
+	@Override
 	public Array readArray() throws SQLException
 	{
 		return (Array)this.readValue(Array.class);
 	}
 
+	/**
+	 * Implemented over {@link #readClob}.
+	 */
+	@Override
 	public InputStream readAsciiStream() throws SQLException
 	{
 		Clob c = this.readClob();
 		return (c == null) ? null : c.getAsciiStream();
 	}
 
+	/**
+	 * Implemented over {@link #readValue}.
+	 */
+	@Override
 	public BigDecimal readBigDecimal() throws SQLException
 	{
 		return (BigDecimal)this.readValue(BigDecimal.class);
 	}
 
+	/**
+	 * Implemented over {@link #readBlob}.
+	 */
+	@Override
 	public InputStream readBinaryStream() throws SQLException
 	{
 		Blob b = this.readBlob();
 		return (b == null) ? null : b.getBinaryStream();
 	}
 
+	/**
+	 * Implemented over {@link #readBytes}.
+	 */
+	@Override
 	public Blob readBlob() throws SQLException
 	{
 		byte[] bytes = this.readBytes();
 		return (bytes == null) ? null :  new BlobValue(bytes);
 	}
 
+	/**
+	 * Implemented over {@link #readValue}.
+	 */
+	@Override
 	public boolean readBoolean() throws SQLException
 	{
 		Boolean b = (Boolean)this.readValue(Boolean.class);
 		return (b == null) ? false : b.booleanValue();
 	}
 
+	/**
+	 * Implemented over {@link #readNumber}.
+	 */
+	@Override
 	public byte readByte() throws SQLException
 	{
 		Number b = this.readNumber(byte.class);
 		return (b == null) ? 0 : b.byteValue();
 	}
 
+	/**
+	 * Implemented over {@link #readValue}.
+	 */
+	@Override
 	public byte[] readBytes() throws SQLException
 	{
 		return (byte[])this.readValue(byte[].class);
 	}
 
+	/**
+	 * Implemented over {@link #readClob}.
+	 */
 	public Reader readCharacterStream() throws SQLException
 	{
 		Clob c = this.readClob();
 		return (c == null) ? null : c.getCharacterStream();
 	}
 
+	/**
+	 * Implemented over {@link #readString}.
+	 */
 	public Clob readClob() throws SQLException
 	{
 		String str = this.readString();
 		return (str == null) ? null :  new ClobValue(str);
 	}
 
+	/**
+	 * Implemented over {@link #readValue}.
+	 */
+	@Override
 	public Date readDate() throws SQLException
 	{
 		return (Date)this.readValue(Date.class);
 	}
 
+	/**
+	 * Implemented over {@link #readNumber}.
+	 */
+	@Override
 	public double readDouble() throws SQLException
 	{
 		Number d = this.readNumber(double.class);
 		return (d == null) ? 0 : d.doubleValue();
 	}
 
+	/**
+	 * Implemented over {@link #readNumber}.
+	 */
+	@Override
 	public float readFloat() throws SQLException
 	{
 		Number f = this.readNumber(float.class);
 		return (f == null) ? 0 : f.floatValue();
 	}
 
+	/**
+	 * Implemented over {@link #readNumber}.
+	 */
+	@Override
 	public int readInt() throws SQLException
 	{
 		Number i = this.readNumber(int.class);
 		return (i == null) ? 0 : i.intValue();
 	}
 
+	/**
+	 * Implemented over {@link #readNumber}.
+	 */
+	@Override
 	public long readLong() throws SQLException
 	{
 		Number l = this.readNumber(long.class);
 		return (l == null) ? 0 : l.longValue();
 	}
 
+	@Override
 	public Object readObject() throws SQLException
 	{
 		if(m_index < m_tupleDesc.size())
@@ -146,7 +214,9 @@ public class SQLInputFromTuple extends JavaWrapper implements SQLInput
 			Object v;
 			synchronized(Backend.THREADLOCK)
 			{
-				v = _getObject(this.getNativePointer(), m_tupleDesc.getNativePointer(), ++m_index);
+				v = _getObject(
+					this.getNativePointer(), m_tupleDesc.getNativePointer(),
+					++m_index, null);
 			}
 			m_wasNull = v == null;
 			return v;
@@ -154,56 +224,73 @@ public class SQLInputFromTuple extends JavaWrapper implements SQLInput
 		throw new SQLException("Tuple has no more columns");
 	}
 
+	/**
+	 * Implemented over {@link #readValue}.
+	 */
+	@Override
 	public Ref readRef() throws SQLException
 	{
 		return (Ref)this.readValue(Ref.class);
 	}
 
+	/**
+	 * Implemented over {@link #readNumber}.
+	 */
+	@Override
 	public short readShort() throws SQLException
 	{
 		Number s = this.readNumber(short.class);
 		return (s == null) ? 0 : s.shortValue();
 	}
 
+	/**
+	 * Implemented over {@link #readValue}.
+	 */
+	@Override
 	public String readString() throws SQLException
 	{
 		return (String)this.readValue(String.class);
 	}
 
+	/**
+	 * Implemented over {@link #readValue}.
+	 */
+	@Override
 	public Time readTime() throws SQLException
 	{
 		return (Time)this.readValue(Time.class);
 	}
 
+	/**
+	 * Implemented over {@link #readValue}.
+	 */
+	@Override
 	public Timestamp readTimestamp() throws SQLException
 	{
 		return (Timestamp)this.readValue(Timestamp.class);
 	}
 
+	/**
+	 * Implemented over {@link #readValue}.
+	 */
+	@Override
 	public URL readURL() throws SQLException
 	{
 		return (URL)this.readValue(URL.class);
 	}
 
+	@Override
 	public boolean wasNull() throws SQLException
 	{
 		return m_wasNull;
 	}
 
-	private Number readNumber(Class numberClass) throws SQLException
-	{
-		return SPIConnection.basicNumericCoersion(numberClass, this.readObject());
-	}
-
-	private Object readValue(Class valueClass) throws SQLException
-	{
-		return SPIConnection.basicCoersion(valueClass, this.readObject());
-	}
 	// ************************************************************
 	// Non-implementation of JDBC 4 methods.
 	// ************************************************************
 
-
+	/** Not yet implemented. */
+	@Override
 	public RowId readRowId()
                 throws SQLException
 	{
@@ -213,6 +300,8 @@ public class SQLInputFromTuple extends JavaWrapper implements SQLInput
 			  "0A000" );
 	}
 
+	/** Not yet implemented. */
+	@Override
 	public SQLXML readSQLXML()
 		throws SQLException
 	{
@@ -222,6 +311,8 @@ public class SQLInputFromTuple extends JavaWrapper implements SQLInput
 			  "0A000" );
 	}
 
+	/** Not yet implemented. */
+	@Override
 	public String readNString()
 		throws SQLException
 	{
@@ -232,6 +323,8 @@ public class SQLInputFromTuple extends JavaWrapper implements SQLInput
 		
 	}
 	
+	/** Not yet implemented. */
+	@Override
 	public NClob readNClob()
 	       throws SQLException
 	{
@@ -243,11 +336,56 @@ public class SQLInputFromTuple extends JavaWrapper implements SQLInput
 	}
 
 	// ************************************************************
-	// End of non-implementation of JDBC 4 methods.
+	// Implementation of JDBC 4.2 method.
+	// Add @Override here once Java back horizon advances to 8.
 	// ************************************************************
+
+	public <T> T readObject(Class<T> type) throws SQLException
+	{
+		if(m_index < m_tupleDesc.size())
+		{
+			Object v;
+			synchronized(Backend.THREADLOCK)
+			{
+				v = _getObject(
+					this.getNativePointer(), m_tupleDesc.getNativePointer(),
+					++m_index, type);
+			}
+			m_wasNull = v == null;
+			if ( type.isInstance(v) )
+				return type.cast(v);
+			throw new SQLException("Cannot convert " + v.getClass().getName() +
+				" to " + type.getName());
+		}
+		throw new SQLException("Tuple has no more columns");
+	}
+
+	// ************************************************************
+	// Implementation methods.
+	// ************************************************************
+
+	private Number readNumber(Class numberClass) throws SQLException
+	{
+		return SPIConnection.basicNumericCoersion(
+			numberClass, this.readObject());
+	}
+
+	private Object readValue(Class valueClass) throws SQLException
+	{
+		return SPIConnection.basicCoersion(valueClass, this.readObject());
+	}
 
 	protected native void _free(long pointer);
 
-	private static native Object _getObject(long pointer, long tupleDescPointer, int index)
+	/**
+	 * Underlying method that returns the value of the next attribute.
+	 *<p>
+	 * The signature does not constrain this to return an object of the
+	 * requested class, so it can still be used as before by methods that may do
+	 * additional coercions. When called by {@link #getObject(Class)}, that
+	 * caller enforces the class of the result.
+	 */
+	private static native Object _getObject(
+		long pointer, long tupleDescPointer, int index, Class<?> type)
 	throws SQLException;
 }

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/SQLInputFromTuple.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/SQLInputFromTuple.java
@@ -352,7 +352,7 @@ public class SQLInputFromTuple extends JavaWrapper implements SQLInput
 					++m_index, type);
 			}
 			m_wasNull = v == null;
-			if ( type.isInstance(v) )
+			if ( m_wasNull  ||  type.isInstance(v) )
 				return type.cast(v);
 			throw new SQLException("Cannot convert " + v.getClass().getName() +
 				" to " + type.getName());

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/SQLOutputToTuple.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/SQLOutputToTuple.java
@@ -248,6 +248,7 @@ public class SQLOutputToTuple implements SQLOutput
 	{
 		if(m_index >= m_values.length)
 			throw new SQLException("Tuple cannot take more values");
-		m_values[m_index++] = value;
+		TypeBridge<?>.Holder vAlt = TypeBridge.wrap(value);
+		m_values[m_index++] = null == vAlt ? value : vAlt;
 	}
 }

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/SingleRowReader.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/SingleRowReader.java
@@ -64,12 +64,13 @@ public class SingleRowReader extends SingleRowResultSet
 	}
 
 	@Override // defined in ObjectResultSet
-	protected Object getObjectValue(int columnIndex)
+	protected Object getObjectValue(int columnIndex, Class<?> type)
 	throws SQLException
 	{
 		synchronized(Backend.THREADLOCK)
 		{
-			return _getObject(m_pointer, m_tupleDesc.getNativePointer(), columnIndex);
+			return _getObject(
+				m_pointer, m_tupleDesc.getNativePointer(), columnIndex, type);
 		}
 	}
 
@@ -185,8 +186,14 @@ public class SingleRowReader extends SingleRowResultSet
 		return m_tupleDesc;
 	}
 
+	/*
+	 * Looking for the implementation of the following JNI methods?
+	 * Look in type/Composite.c
+	 */
+
 	protected native void _free(long pointer);
 
-	private static native Object _getObject(long pointer, long tupleDescPointer, int index)
+	private static native Object _getObject(
+		long pointer, long tupleDescPointer, int index, Class<?> type)
 	throws SQLException;
 }

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/SingleRowReader.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/SingleRowReader.java
@@ -1,10 +1,15 @@
 /*
- * Copyright (c) 2004, 2005, 2006 TADA AB - Taby Sweden
+ * Copyright (c) 2004-2018 Tada AB and other contributors, as listed below.
  * Copyright (c) 2010, 2011 PostgreSQL Global Development Group
  *
- * Distributed under the terms shown in the file COPYRIGHT
- * found in the root folder of this project or at
- * http://wiki.tada.se/index.php?title=PLJava_License
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Tada AB
+ *   Chapman Flack
  */
 package org.postgresql.pljava.jdbc;
 
@@ -26,6 +31,14 @@ public class SingleRowReader extends SingleRowResultSet
 	private final TupleDesc m_tupleDesc;
 	private final long m_pointer;
 
+	/**
+	 * Construct a {@code SingleRowReader} from a {@code HeapTupleHeader}
+	 * and a {@link TupleDesc TupleDesc}.
+	 * @param pointer Just the native pointer to a PG {@code HeapTupleHeader};
+	 * the Java class of the same name is uninvolved (it's been dead since
+	 * a4f6c9e).
+	 * @param tupleDesc A {@code TupleDesc}; the Java class this time.
+	 */
 	public SingleRowReader(long pointer, TupleDesc tupleDesc)
 	throws SQLException
 	{
@@ -33,10 +46,15 @@ public class SingleRowReader extends SingleRowResultSet
 		m_tupleDesc = tupleDesc;
 	}
 
+	@Override
 	public void close()
 	{
 	}
 
+	/**
+	 * Frees the {@code HeapTupleHeader}.
+	 */
+	@Override
 	public void finalize()
 	{
 		synchronized(Backend.THREADLOCK)
@@ -45,6 +63,7 @@ public class SingleRowReader extends SingleRowResultSet
 		}
 	}
 
+	@Override // defined in ObjectResultSet
 	protected Object getObjectValue(int columnIndex)
 	throws SQLException
 	{
@@ -160,6 +179,7 @@ public class SingleRowReader extends SingleRowResultSet
 	// End of implementation of JDBC 4 methods.
 	// ************************************************************
 
+	@Override // defined in SingleRowResultSet
 	protected final TupleDesc getTupleDesc()
 	{
 		return m_tupleDesc;

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/SingleRowResultSet.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/SingleRowResultSet.java
@@ -108,7 +108,7 @@ public abstract class SingleRowResultSet extends ObjectResultSet
 	}
 
 	/**
-	 * Will always return <code>false</code> since a <code>SingleRowWriter
+	 * Will always return <code>false</code> since a <code>SingleRowResultSet
 	 * </code> starts on the one and only row.
 	 */
 	public boolean isBeforeFirst() throws SQLException
@@ -234,7 +234,7 @@ public abstract class SingleRowResultSet extends ObjectResultSet
 	}
 
 	/**
-	 * This feature is not supported on a <code>SingleRowWriter</code>.
+	 * This feature is not supported on a <code>SingleRowResultSet</code>.
 	 * @throws SQLException indicating that this feature is not supported.
 	 */
 	public void moveToInsertRow()

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/SingleRowWriter.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/SingleRowWriter.java
@@ -56,7 +56,7 @@ public class SingleRowWriter extends SingleRowResultSet
 	 * specified index, or {@code null} if none has been written.
 	 */
 	@Override // defined in ObjectRresultSet
-	protected Object getObjectValue(int columnIndex)
+	protected Object getObjectValue(int columnIndex, Class<?> type)
 	throws SQLException
 	{
 		if(columnIndex < 1)

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/SingleRowWriter.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/SingleRowWriter.java
@@ -27,6 +27,10 @@ import org.postgresql.pljava.internal.TupleDesc;
 /**
  * A single row, updateable ResultSet, specially made for functions and
  * procedures that returns complex types or sets.
+ *<p>
+ * A {@link TupleDesc} must be passed to the constructor. After values have
+ * been written, the native pointer to a formed {@link Tuple} can be retrieved
+ * using {@link #getTupleAndClear}.
  *
  * @author Thomas Hallgren
  */
@@ -36,6 +40,10 @@ public class SingleRowWriter extends SingleRowResultSet
 	private final Object[] m_values;
 	private Tuple m_tuple;
 
+	/**
+	 * Construct a {@code SingleRowWriter} given a descriptor of the tuple
+	 * structure it should produce.
+	 */
 	public SingleRowWriter(TupleDesc tupleDesc)
 	throws SQLException
 	{
@@ -43,6 +51,11 @@ public class SingleRowWriter extends SingleRowResultSet
 		m_values = new Object[tupleDesc.size()];
 	}
 
+	/**
+	 * Returns the value most recently written in the current tuple at the
+	 * specified index, or {@code null} if none has been written.
+	 */
+	@Override // defined in ObjectRresultSet
 	protected Object getObjectValue(int columnIndex)
 	throws SQLException
 	{
@@ -55,6 +68,7 @@ public class SingleRowWriter extends SingleRowResultSet
 	 * Returns <code>true</code> if the row contains any non <code>null</code>
 	 * values since all values of the row are <code>null</code> initially.
 	 */
+	@Override
 	public boolean rowUpdated()
 	throws SQLException
 	{
@@ -65,6 +79,7 @@ public class SingleRowWriter extends SingleRowResultSet
 		return false;
 	}
 
+	@Override
 	public void updateObject(int columnIndex, Object x)
 	throws SQLException
 	{
@@ -91,6 +106,7 @@ public class SingleRowWriter extends SingleRowResultSet
 		m_values[columnIndex-1] = x;
 	}
 
+	@Override
 	public void cancelRowUpdates()
 	throws SQLException
 	{
@@ -100,6 +116,7 @@ public class SingleRowWriter extends SingleRowResultSet
 	/**
 	 * Cancels all changes but doesn't really close the set.
 	 */
+	@Override
 	public void close()
 	throws SQLException
 	{
@@ -137,6 +154,7 @@ public class SingleRowWriter extends SingleRowResultSet
 		return m_tuple.getNativePointer();
 	}
 
+	@Override // defined in SingleRowResultSet
 	protected final TupleDesc getTupleDesc()
 	{
 		return m_tupleDesc;
@@ -146,6 +164,7 @@ public class SingleRowWriter extends SingleRowResultSet
 	// Implementation of JDBC 4 methods.
 	// ************************************************************
 
+	@Override
 	public boolean isClosed()
 		throws SQLException
 	{

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/SingleRowWriter.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/SingleRowWriter.java
@@ -90,7 +90,8 @@ public class SingleRowWriter extends SingleRowResultSet
 			m_values[columnIndex-1] = x;
 
 		Class c = m_tupleDesc.getColumnClass(columnIndex);
-		if(!c.isInstance(x)
+		TypeBridge<?>.Holder xAlt = TypeBridge.wrap(x);
+		if(null == xAlt  &&  !c.isInstance(x)
 		&& !(c == byte[].class && (x instanceof BlobValue)))
 		{
 			if(Number.class.isAssignableFrom(c))
@@ -103,7 +104,7 @@ public class SingleRowWriter extends SingleRowResultSet
 			else
 				x = SPIConnection.basicCoersion(c, x);
 		}
-		m_values[columnIndex-1] = x;
+		m_values[columnIndex-1] = null == xAlt ? x : xAlt;
 	}
 
 	@Override

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/SyntheticResultSet.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/SyntheticResultSet.java
@@ -8,6 +8,7 @@
  *
  * Contributors:
  *   Filip Hrbek
+ *   Chapman Flack
  */
 package org.postgresql.pljava.jdbc;
 
@@ -94,9 +95,12 @@ public class SyntheticResultSet extends ResultSetBase
 	/**
 	 * Returns exactly the object that was supplied at {@code columnIndex}
 	 * (less one) in the current row.
+	 *<p>
+	 * Ignores the {@code type} argument and returns whatever object is there.
+	 * If it is not what the caller needed, let the caller complain.
 	 */
 	@Override // defined in ObjectResultSet
-	protected Object getObjectValue(int columnIndex)
+	protected Object getObjectValue(int columnIndex, Class<?> type)
 	throws SQLException
 	{
         return getCurrentRow()[columnIndex-1];

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/SyntheticResultSet.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/SyntheticResultSet.java
@@ -1,8 +1,13 @@
 /*
- * Copyright (c) 2004, 2005, 2006 TADA AB - Taby Sweden
- * Distributed under the terms shown in the file COPYRIGHT
- * found in the root folder of this project or at
- * http://eng.tada.se/osprojects/COPYRIGHT.html
+ * Copyright (c) 2004-2018 Tada AB and other contributors, as listed below.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Filip Hrbek
  */
 package org.postgresql.pljava.jdbc;
 
@@ -13,7 +18,8 @@ import java.util.HashMap;
 
 /**
  * A Synthetic ResultSet that provides direct access to data stored
- * in a {@link java.util.ArrayList}. This kind of ResultSet has nothing
+ * in a {@link java.util.ArrayList}; chiefly used to return tabular information
+ * from {@code ...MetaData} objects. This kind of ResultSet has nothing
  * common with any statement.
  *
  * @author Filip Hrbek
@@ -24,6 +30,16 @@ public class SyntheticResultSet extends ResultSetBase
 	private final ArrayList        m_tuples;
     private final HashMap          m_fieldIndexes;
 
+	/**
+	 * Construct a {@code SyntheticResultSet} whose column types are described
+	 * by an array of {@code ResultSetField} instances, and whose rows are
+	 * supplied as an {@code ArrayList} whose elements are themselves arrays of
+	 * {@code Object}.
+	 * @throws SQLException if a non-null reference at index <em>j</em> in any
+	 * 'row' array is an instance of a class that does not satisfy the
+	 * {@link ResultSetField#canContain canContain} method of the
+	 * {@code ResultSetField} instance at index <em>j</em>.
+	 */
 	SyntheticResultSet(ResultSetField[] fields, ArrayList tuples)
 	throws SQLException
 	{
@@ -55,13 +71,15 @@ public class SyntheticResultSet extends ResultSetBase
 		}
 	}
 
-    public void close()
+    @Override
+	public void close()
 	throws SQLException
 	{
     	m_tuples.clear();
 		super.close();
 	}
 
+	@Override
 	public int findColumn(String columnName)
 	throws SQLException
 	{
@@ -73,6 +91,11 @@ public class SyntheticResultSet extends ResultSetBase
         throw new SQLException("No such field: '" + columnName + "'");
 	}
 
+	/**
+	 * Returns exactly the object that was supplied at {@code columnIndex}
+	 * (less one) in the current row.
+	 */
+	@Override // defined in ObjectResultSet
 	protected Object getObjectValue(int columnIndex)
 	throws SQLException
 	{
@@ -88,11 +111,13 @@ public class SyntheticResultSet extends ResultSetBase
 		return (Object[])m_tuples.get(row-1);
 	}
 
+	@Override
 	public boolean isLast() throws SQLException
 	{
 		return this.getRow() == m_tuples.size();
 	}
 
+	@Override
 	public boolean next() throws SQLException
 	{
     	int row = this.getRow();
@@ -104,6 +129,11 @@ public class SyntheticResultSet extends ResultSetBase
 		return false;
 	}
 
+	/**
+	 * Returns metadata describing this {@code SyntheticResultSet}, based on the
+	 * {@link ResultSetField ResultSetField}s supplied to the constructor.
+	 */
+	@Override
 	public ResultSetMetaData getMetaData()
 	throws SQLException
 	{

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/TriggerResultSet.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/TriggerResultSet.java
@@ -1,10 +1,15 @@
 /*
- * Copyright (c) 2004, 2005, 2006 TADA AB - Taby Sweden
+ * Copyright (c) 2004-2018 Tada AB and other contributors, as listed below.
  * Copyright (c) 2010, 2011 PostgreSQL Global Development Group
  *
- * Distributed under the terms shown in the file COPYRIGHT
- * found in the root folder of this project or at
- * http://wiki.tada.se/index.php?title=PLJava_License
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Tada AB
+ *   Chapman Flack
  */
 package org.postgresql.pljava.jdbc;
 
@@ -39,6 +44,7 @@ public class TriggerResultSet extends SingleRowResultSet
 	/**
 	 * Cancel all changes made to the Tuple.
 	 */
+	@Override
 	public void cancelRowUpdates()
 	throws SQLException
 	{
@@ -48,6 +54,7 @@ public class TriggerResultSet extends SingleRowResultSet
 	/**
 	 * Cancels all changes but doesn't really close the set.
 	 */
+	@Override
 	public void close()
 	throws SQLException
 	{
@@ -58,6 +65,7 @@ public class TriggerResultSet extends SingleRowResultSet
 	 * Returns the concurrency for this ResultSet.
 	 * @see java.sql.ResultSet#getConcurrency
 	 */
+	@Override
 	public int getConcurrency() throws SQLException
 	{
 		return m_readOnly ? CONCUR_READ_ONLY : CONCUR_UPDATABLE;
@@ -66,6 +74,7 @@ public class TriggerResultSet extends SingleRowResultSet
 	/**
 	 * Returns <code>true</code> if this row has been updated.
 	 */
+	@Override
 	public boolean rowUpdated()
 	throws SQLException
 	{
@@ -75,6 +84,7 @@ public class TriggerResultSet extends SingleRowResultSet
 	/**
 	 * Store this change for later use
 	 */
+	@Override
 	public void updateObject(int columnIndex, Object x)
 	throws SQLException
 	{
@@ -90,12 +100,14 @@ public class TriggerResultSet extends SingleRowResultSet
 
 	
 	/**
-	 * Return a 2 element array describing the changes that has been made to
-	 * the contained Tuple. The first element is an <code>int[]</code> containing
-	 * the index of each changed value. The second element is an <code>Object[]
-	 * </code> with containing the corresponding values.
+	 * Return a 3 element array describing the changes that have been made to
+	 * the contained Tuple. The first element the original Tuple, the second
+	 * an {@code int[]} containing
+	 * the index of each changed value, and the third an {@code Object[]}
+	 * containing the corresponding values.
 	 * 
-	 * @return The 2 element array or <code>null</code> if no change has been made.
+	 * @return The 3 element array or <code>null</code> if no change has
+	 * been made.
 	 */
 	public Object[] getChangeIndexesAndValues()
 	{
@@ -119,6 +131,13 @@ public class TriggerResultSet extends SingleRowResultSet
 		return new Object[] { m_tuple, indexes, values };
 	}
 
+	/**
+	 * If the value has not been changed, forwards to
+	 * {@link Tuple#getObject(TupleDesc,int) Tuple.getObject}, with the usual
+	 * behavior for type coercion; if it has been changed, returns the exact
+	 * object that was supplied with the change.
+	 */
+	@Override // defined in ObjectResultSet
 	protected Object getObjectValue(int columnIndex)
 	throws SQLException
 	{
@@ -135,6 +154,7 @@ public class TriggerResultSet extends SingleRowResultSet
 		return m_tuple.getObject(this.getTupleDesc(), columnIndex);
 	}
 
+	@Override // defined in SingleRowResultSet
 	protected final TupleDesc getTupleDesc()
 	{
 		return m_tupleDesc;
@@ -146,6 +166,7 @@ public class TriggerResultSet extends SingleRowResultSet
 	// ************************************************************
 
 	
+	@Override
 	public boolean isClosed()
 		throws SQLException
 	{

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/TriggerResultSet.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/TriggerResultSet.java
@@ -126,7 +126,9 @@ public class TriggerResultSet extends SingleRowResultSet
 		for(int idx = 0; idx < top; ++idx)
 		{	
 			indexes[idx] = ((Integer)changes.get(vIdx++)).intValue();
-			values[idx] = changes.get(vIdx++);
+			Object v = changes.get(vIdx++);
+			TypeBridge<?>.Holder vAlt = TypeBridge.wrap(v);
+			values[idx] = null == vAlt ? v : vAlt;
 		}
 		return new Object[] { m_tuple, indexes, values };
 	}

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/TriggerResultSet.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/TriggerResultSet.java
@@ -133,12 +133,15 @@ public class TriggerResultSet extends SingleRowResultSet
 
 	/**
 	 * If the value has not been changed, forwards to
-	 * {@link Tuple#getObject(TupleDesc,int) Tuple.getObject}, with the usual
-	 * behavior for type coercion; if it has been changed, returns the exact
-	 * object that was supplied with the change.
+	 * {@link Tuple#getObject(TupleDesc,int,Class) Tuple.getObject}, with the
+	 * usual behavior for type coercion; if it has been changed, returns the
+	 * exact object that was supplied with the change.
+	 *<p>
+	 * When the caller is the JDBC 4.1 {@link #getObject(int,Class)}, the caller
+	 * will check and complain if the returned object is not of the right class.
 	 */
 	@Override // defined in ObjectResultSet
-	protected Object getObjectValue(int columnIndex)
+	protected Object getObjectValue(int columnIndex, Class<?> type)
 	throws SQLException
 	{
 		// Check if this value has been changed.
@@ -151,7 +154,7 @@ public class TriggerResultSet extends SingleRowResultSet
 				if(columnIndex == ((Integer)changes.get(idx)).intValue())
 					return changes.get(idx + 1);
 		}
-		return m_tuple.getObject(this.getTupleDesc(), columnIndex);
+		return m_tuple.getObject(this.getTupleDesc(), columnIndex, type);
 	}
 
 	@Override // defined in SingleRowResultSet

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/TypeBridge.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/TypeBridge.java
@@ -1,0 +1,273 @@
+/*
+ * Copyright (c) 2018- Tada AB and other contributors, as listed below.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Chapman Flack
+ */
+package org.postgresql.pljava.jdbc;
+
+import static java.util.Collections.addAll;
+import java.util.List;
+import java.util.LinkedList;
+
+/**
+ * Encapsulate some information about Java object classes and their possible
+ * mappings to PostgreSQL types.
+ *<p>
+ * This may be a temporary class that goes away entirely in a future major
+ * release of PL/Java that revamps how type mappings are determined. Or, it may
+ * evolve and take on greater responsibility in a revamped scheme: type mapping
+ * information is, at present, diffused and duplicated a lot of places in
+ * PL/Java, and bringing it into one place would not be a bad thing.
+ *<p>
+ * For now, in the 1.5.x series, this is a simple stopgap so that the few places
+ * in PL/Java where an object type can be passed to PostgreSQL (SingleRowWriter,
+ * TriggerResultSet, SQLOutputToTuple, PreparedStatement) are able to pass an
+ * object that isn't of the class expected by default, and have the right native
+ * conversion get selected. All of those sites currently work by some variant of
+ * putting supplied objects into an Object array or list later passed to the
+ * native code, and when an object will not be of the expected class, what is
+ * stored in the array should be a TypeBridge.Holder for it.
+ */
+public abstract class TypeBridge<S>
+{
+	/**
+	 * Canonical name of the Java class or interface that this TypeBridge
+	 * 'captures'.
+	 *<p>
+	 * Held as a string so that the class does not need to be loaded for a
+	 * TypeBridge to be made for it. There can be TypeBridges for classes that
+	 * not all supported JRE versions provide.
+	 */
+	protected final String m_canonName;
+
+	/**
+	 * Oid of the PostgreSQL type to be associated by default with this Java
+	 * class or interface.
+	 *<p>
+	 * Stored as a simple int here, not a PL/Java Oid object, which I am tempted
+	 * to deprecate.
+	 */
+	protected final int m_defaultOid;
+
+	/**
+	 * If the Java class associated with the TypeBridge <em>is</em> loaded and
+	 * available, it can be cached here.
+	 *<p>
+	 * That will always be the case after a {@link #captures} method has
+	 * returned {@code true}.
+	 */
+	protected Class<S> m_cachedClass;
+
+	/**
+	 * List of TypeBridges to check, in order, for one that 'captures' a given
+	 * class.
+	 *<p>
+	 * This list is populated as TypeBridges are constructed, and whatever code
+	 * calls the factory methods must take responsibility for the order of the
+	 * list, by not constructing one TypeBridge earlier than another one that it
+	 * would capture.
+	 *<p>
+	 * This can't be checked automatically because the classes in question may
+	 * not yet be loaded, or even available.
+	 */
+	private static List<TypeBridge<?>> m_candidates =
+		new LinkedList<TypeBridge<?>>();
+
+	/**
+	 * Return an object wrapped, if it is of any type captured by a known
+	 * TypeBridge.
+	 * @param o An object, representing a value to be presented to PostgreSQL.
+	 * @return A Holder wrapping o, or null if no known TypeBridge captures the
+	 * type of o, or o itself is null.
+	 */
+	public static <T, U extends T> TypeBridge<T>.Holder wrap(U o)
+	{
+		if ( null == o )
+			return null;
+		Class<?> c = o.getClass();
+		for ( TypeBridge tb : m_candidates )
+			if ( tb.captures(c) )
+				return ((TypeBridge<T>)tb).new Holder(o);
+		if ( o instanceof TypeBridge<?>.Holder )
+			throw new IllegalArgumentException("Not valid as argument: " +
+				o.toString());
+		return null;
+	}
+
+	private TypeBridge(String cName, int dfltOid)
+	{
+		if ( null == cName )
+			throw new NullPointerException("TypeBridge cName must be nonnull.");
+		m_canonName = cName;
+		m_defaultOid = dfltOid;
+		m_candidates.add(this);
+	}
+
+	/*
+	 * For now, anyway, these factory methods are private; only native code
+	 * will be calling them.
+	 */
+
+	/**
+	 * Construct a TypeBridge given the canonical name of a Java type that need
+	 * not be loaded, but is known to be a class (not an interface).
+	 */
+	private static <T> TypeBridge<T> ofClass(String cName, int dOid)
+	{
+		return new OfClass<T>(cName, dOid);
+	}
+
+	/**
+	 * Construct a TypeBridge given the canonical name of a Java type that need
+	 * not be loaded, but is known to be an interface (not a class).
+	 */
+	private static <T> TypeBridge<T> ofInterface(String cName, int dOid)
+	{
+		return new OfInterface<T>(cName, dOid);
+	}
+
+	/**
+	 * Construct a TypeBridge directly from a Class object, when available.
+	 */
+	private static <T> TypeBridge<T> of(Class<T> c, int dOid)
+	{
+		String cn = c.getCanonicalName();
+		TypeBridge tb =
+			c.isInterface() ? ofInterface(cn, dOid) : ofClass(cn, dOid);
+		tb.m_cachedClass = c;
+		return tb;
+	}
+
+	/**
+	 * Determine whether this TypeBridge 'captures' a given Class.
+	 *<p>
+	 * If the class this TypeBridge represents has already been loaded and is
+	 * cached here, the test is a simple {@code isAssignableFrom}. Otherwise,
+	 * the test is conducted by climbing the superclasses or superinterfaces, as
+	 * appropriate, of the passed Class, comparing canonical names. If a match
+	 * is found, the winning Class object is cached before returning
+	 * {@code true}.
+	 */
+	public final boolean captures(Class<?> c)
+	{
+		if ( null != m_cachedClass )
+			return m_cachedClass.isAssignableFrom(c);
+		return virtuallyCaptures(c);
+	}
+
+	/**
+	 * Method the two subclasses implement to conduct the "Class-less"
+	 * superclass or superinterface check, respectively.
+	 */
+	protected abstract boolean virtuallyCaptures(Class<?> c);
+
+	/**
+	 * TypeBridge subclass representing a class (not an interface).
+	 *<p>
+	 * Its {@code virtuallyCaptures} method simply climbs the superclass chain.
+	 */
+	final static class OfClass<S> extends TypeBridge<S>
+	{
+		private OfClass(String cn, int oid) { super(cn, oid); }
+
+		@Override
+		protected boolean virtuallyCaptures(Class<?> c)
+		{
+			for ( ; null != c ; c = c.getSuperclass() )
+			{
+				if ( ! m_canonName.equals(c.getCanonicalName()) )
+					continue;
+				m_cachedClass = (Class<S>)c;
+				return true;
+			}
+			return false;
+		}
+	}
+
+	/**
+	 * TypeBridge subclass representing an interface (not a class).
+	 *<p>
+	 * Its {@code virtuallyCaptures} method climbs the superinterfaces,
+	 * breadth first.
+	 */
+	final static class OfInterface<S> extends TypeBridge<S>
+	{
+		private OfInterface(String cn, int oid) { super(cn, oid); }
+
+		@Override
+		protected boolean virtuallyCaptures(Class<?> c)
+		{
+			List<Class<?>> q = new LinkedList<Class<?>>();
+			q.add(c);
+
+			while ( 0 < q.size() )
+			{
+				c = q.remove(0);
+
+				if ( ! c.isInterface() )
+				{
+					addAll(q, c.getInterfaces());
+					c = c.getSuperclass();
+					if ( null != c )
+						q.add(c);
+					continue;
+				}
+
+				if ( m_canonName.equals(c.getCanonicalName()) )
+				{
+					m_cachedClass = (Class<S>)c;
+					return true;
+				}
+				addAll(q, c.getInterfaces());
+			}
+			return false;
+		}
+	}
+
+	/**
+	 * Class that holds an object reference being passed from Java to PG, when
+	 * the object is of one of the known classes that were not accepted by
+	 * PL/Java's JDBC driver before PL/Java 1.5.1.
+	 *<p>
+	 * When a native-code Object-to-Datum coercer encounters a Holder instead of
+	 * an object of the normally-expected class for the PostgreSQL type, it can
+	 * retrieve the class, classname, default PG type oid, and the payload
+	 * object itself, from the Holder, and obtain and apply a different coercer
+	 * appropriate to the class.
+	 */
+	public final class Holder
+	{
+		private final S m_payload;
+
+		private Holder(S o)
+		{
+			m_payload = o;
+		}
+
+		public Class<S> bridgedClass()
+		{
+			return m_cachedClass;
+		}
+
+		public String className()
+		{
+			return m_canonName;
+		}
+
+		public S payload()
+		{
+			return m_payload;
+		}
+
+		public int defaultOid()
+		{
+			return m_defaultOid;
+		}
+	}
+}


### PR DESCRIPTION
Java 8 introduces the much improved set of date/time classes in the `java.time` package specified by JSR 310. JDBC 4.2 (the version in Java 8) allows those as alternate Java class mappings of the SQL types `date`, `time` (with and without timezone), and `timestamp` (with/without timezone).

These new types are a much better fit to the corresponding PostgreSQL types than the original JDBC `java.sql.Date`, `java.sql.Time`, and `java.sql.Timestamp` classes. (For one thing, those old classes do not distinguish between a value with or without a timezone, and they all have an implicit timezone under the hood, which makes for unnatural, inefficient, and sometimes surprising mappings from the SQL types.)

To avoid a breaking change, JDBC 4.2 does not modify what any of the pre-existing JDBC API does by default. The `getDate`, `getTime`, and `getTimestamp` methods on a `ResultSet` still return the same `java.sql` types, for example, and so does `getObject` in the form that does not specify a class. Instead, it takes advantage of the general purpose `ResultSet.getObject` methods that take a `Class` parameter (added in JDBC 4.1), and likewise the `SQLInput.readObject` method with a `Class` parameter (overlooked in 4.1 but added in 4.2), so a caller can request a `java.time` class by passing the right `Class` parameter:

* for `date`, pass `java.time.LocalDate.class`
* for `time`, pass `java.time.LocalTime.class`
* for `time with time zone`, pass `java.time.OffsetTime.class`
* for `timestamp`, pass `java.time.LocalDateTime`
* for `timestamp with time zone`, pass `java.time.OffsetDateTime`

The `java.time` types can also be used as parameter and return types of PL/Java functions without special effort (the generated function declarations will make the right conversions happen), and passed to the setter methods of prepared statements, writable result sets (for triggers or composite-returning functions), and `SQLOutput` for UDTs.

Any code developed for PL/Java and Java 8 or newer is strongly encouraged to use these types for date/time manipulations, as they represent the PostgreSQL types with such improved fidelity.

The bulk of the work in this pull request was to implement the general JDBC 4.1/4.2 features necessary to offer the new types in a backward-compatible way, and that will simplify future addition of similar new mappings, and even of mappings that have been in JDBC since 4.0 but missing from PL/Java (SQLXML, for example).

Addresses issue #137.