### PR TITLE
Support the JDBC 4.0 SQLXML type.

### DIFF
--- a/pljava-api/src/main/java/org/postgresql/pljava/sqlgen/DDRProcessor.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/sqlgen/DDRProcessor.java
@@ -2200,6 +2200,7 @@ hunt:	for ( ExecutableElement ee : ees )
 			this.addMap(Timestamp.class, "timestamp");
 			this.addMap(Time.class, "time");
 			this.addMap(java.sql.Date.class, "date");
+			this.addMap(java.sql.SQLXML.class, "xml");
 			this.addMap(BigInteger.class, "numeric");
 			this.addMap(BigDecimal.class, "numeric");
 			this.addMap(ResultSet.class, "record");

--- a/pljava-api/src/main/java/org/postgresql/pljava/sqlgen/DDRProcessor.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/sqlgen/DDRProcessor.java
@@ -1613,6 +1613,8 @@ hunt:	for ( ExecutableElement ee : ees )
 
 		void appendAS( StringBuilder sb)
 		{
+			if ( ! ( complexViaInOut || setof || trigger ) )
+				sb.append( func.getReturnType()).append( '=');
 			Element e = func.getEnclosingElement();
 			if ( ! e.getKind().equals( ElementKind.CLASS) )
 				msg( Kind.ERROR, func,

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/PassXML.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/PassXML.java
@@ -60,6 +60,7 @@ import javax.xml.transform.stax.StAXSource;
 import org.postgresql.pljava.annotation.Function;
 import org.postgresql.pljava.annotation.MappedUDT;
 import org.postgresql.pljava.annotation.SQLAction;
+import org.postgresql.pljava.annotation.SQLType;
 
 import static org.postgresql.pljava.example.LoggerTest.logMessage;
 
@@ -111,6 +112,32 @@ public class PassXML implements SQLData
 			return null;
 		}
 		return echoSQLXML(sx, howin, howout);
+	}
+
+	/**
+	 * Echo an XML parameter back, but with parameter and return types of
+	 * PostgreSQL {@code text}.
+	 *<p>
+	 * The other version of this method needs a conditional implementor tag
+	 * because it cannot be declared in a PostgreSQL instance that was built
+	 * without [@code libxml} support and the PostgreSQL {@code XML} type.
+	 * But this version can, simply by mapping the {@code SQLXML} parameter
+	 * and return types to the SQL {@code text} type. The Java code is no
+	 * different.
+	 *<p>
+	 * Note that it's possible for both declarations to coexist in PostgreSQL
+	 * (because as far as it is concerned, their signatures are different), but
+	 * these two Java methods cannot have the same name (because they differ
+	 * only in annotations, not in the declared Java types). So, this one needs
+	 * a slightly tweaked name, and a {@code name} attribute in the annotation
+	 * so PostgreSQL sees the right name.
+	 */
+	@Function(schema="javatest", name="echoXMLParameter", type="text")
+	public static SQLXML echoXMLParameter_(
+		@SQLType("text") SQLXML sx, int howin, int howout)
+	throws SQLException
+	{
+		return echoXMLParameter(sx, howin, howout);
 	}
 
 	/**

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/PassXML.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/PassXML.java
@@ -188,6 +188,36 @@ public class PassXML implements SQLData
 	}
 
 	/**
+	 * Just like {@link bounceXMLParameter} but with parameter and return typed
+	 * as {@code text}, and so usable on a PostgreSQL instance lacking the XML
+	 * type.
+	 */
+	@Function(schema="javatest", type="text", name="bounceXMLParameter")
+	public static SQLXML bounceXMLParameter_(@SQLType("text") SQLXML sx)
+	throws SQLException
+	{
+		return sx;
+	}
+
+	/**
+	 * Just like {@link bounceXMLParameter} but with the parameter typed as
+	 * {@code text} and the return type left as XML, so functions as a cast.
+	 *<p>
+	 * Slower than the other cases, because it must verify that the input really
+	 * is XML before blindly calling it a PostgreSQL XML type. But the speed
+	 * compares respectably to PostgreSQL's own CAST(text AS xml), at least for
+	 * larger values; I am seeing Java pull ahead right around 32kB of XML data
+	 * and beat PG by a factor of 2 or better at sizes of 1 or 2 MB.
+	 * Unsurprisingly, PG has the clear advantage when values are very short.
+	 */
+	@Function(schema="javatest", implementor="postgresql_xml")
+	public static SQLXML castTextXML(@SQLType("text") SQLXML sx)
+	throws SQLException
+	{
+		return sx;
+	}
+
+	/**
 	 * Precompile an XSL transform {@code source} and save it (for the
 	 * current session) as {@code name}.
 	 *<p>

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/PassXML.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/PassXML.java
@@ -228,9 +228,14 @@ public class PassXML implements SQLData
 	 * {@link TransformerFactory#newTemplates newTemplates()} seems to require
 	 * {@link Function.Trust#UNSANDBOXED Trust.UNSANDBOXED}, at least for the
 	 * XSLTC transform compiler in newer JREs.
+	 *<p>
+	 * If you wish this <strong>unsandboxed</strong> function to be installed,
+	 * set the PostgreSQL variable {@code pljava.implementors} to a list with
+	 * {@code pg_xml_unsandboxed} as an added entry, before installing the
+	 * examples jar.
 	 */
 	@Function(schema="javatest", trust=Function.Trust.UNSANDBOXED,
-			  implementor="postgresql_xml")
+			  implementor="pg_xml_unsandboxed")
 	public static void prepareXMLTransform(String name, SQLXML source, int how)
 	throws SQLException
 	{

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/PassXML.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/PassXML.java
@@ -84,6 +84,16 @@ public class PassXML
 	}
 
 	/**
+	 * "Echo" an XML parameter not by creating a new writable {@code SQLXML}
+	 * object at all, but simply returning the passed-in readable one untouched.
+	 */
+	@Function(schema="javatest")
+	public static SQLXML bounceXMLParameter(SQLXML sx) throws SQLException
+	{
+		return sx;
+	}
+
+	/**
 	 * Precompile an XSL transform {@code source} and save it (for the
 	 * current session) as {@code name}.
 	 *<p>

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/PassXML.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/PassXML.java
@@ -479,7 +479,7 @@ public class PassXML implements SQLData
 	@Override
 	public void writeSQL(SQLOutput stream) throws SQLException
 	{
-		stream.writeSQLXML(m_value); // this is not expected to work yet
+		stream.writeSQLXML(m_value);
 	}
 
 	/*
@@ -489,12 +489,18 @@ public class PassXML implements SQLData
 	public static SQLXML xmlFromComposite() throws SQLException
 	{
 		Connection c = DriverManager.getConnection("jdbc:default:connection");
-		Statement s = c.createStatement();
-		ResultSet r = s.executeQuery(
-			"SELECT CAST(ROW(XMLELEMENT(NAME a)) AS javatest.onexml)");
+		PreparedStatement ps =
+			c.prepareStatement("SELECT CAST(? AS javatest.onexml)");
+		SQLXML x = c.createSQLXML();
+		x.setString("<a/>");
+		PassXML obj = new PassXML();
+		obj.m_value = x;
+		obj.m_typeName = "javatest.onexml";
+		ps.setObject(1, obj);
+		ResultSet r = ps.executeQuery();
 		r.next();
-		PassXML obj = r.getObject(1, PassXML.class);
-		s.close();
+		obj = r.getObject(1, PassXML.class);
+		ps.close();
 		return obj.m_value;
 	}
 }

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/PassXML.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/PassXML.java
@@ -379,6 +379,16 @@ public class PassXML implements SQLData
 	}
 
 	/**
+	 * Low-level XML echo where the Java parameter and return type are String.
+	 */
+	@Function(schema="javatest", implementor="postgresql_xml", type="xml")
+	public static String lowLevelXMLEcho(@SQLType("xml") String x)
+	throws SQLException
+	{
+		return x;
+	}
+
+	/**
 	 * Create some XML, pass it to a {@code SELECT ?} prepared statement,
 	 * retrieve it from the result set, and return it via the out-parameter
 	 * result set of this {@code RECORD}-returning function.

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/PassXML.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/PassXML.java
@@ -19,8 +19,12 @@ import java.io.Reader;
 import java.io.StringReader;
 import java.io.StringWriter;
 
+import java.util.Map;
+import java.util.HashMap;
+
 import javax.xml.transform.Result;
 import javax.xml.transform.Source;
+import javax.xml.transform.Templates;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
@@ -38,6 +42,8 @@ public class PassXML
 	static SQLXML s_sx;
 
 	static TransformerFactory s_tf = TransformerFactory.newInstance();
+
+	static Map<String,Templates> s_tpls = new HashMap<String,Templates>();
 
 	/**
 	 * Echo an XML parameter back as a string, exercising seven different ways
@@ -61,37 +67,73 @@ public class PassXML
 		return echoSQLXML(sx, how);
 	}
 
-	private static String echoSQLXML(SQLXML sx, int how) throws SQLException
+	/**
+	 * Precompile an XSL transform {@code source} and save it (for the
+	 * current session) as {@code name}.
+	 *<p>
+	 * Each value of {@code how}, 1-7, selects a different way of presenting
+	 * the {@code SQLXML} object to the XSL processor.
+	 *<p>
+	 * Preparing a transform with
+	 * {@link TransformerFactoory.newTemplates newTemplates()} seems to require
+	 * {@link Function.Trust.UNSANDBOXED Trust.UNSANDBOXED}, at least for the
+	 * XSLTC transform compiler in newer JREs.
+	 */
+	@Function(schema="javatest", trust=Function.Trust.UNSANDBOXED)
+	public static void prepareXMLTransform(String name, SQLXML source, int how)
+	throws SQLException
 	{
-		Source src;
-
-		switch ( how )
+		try
 		{
-			case 1:
-				src = new StreamSource(sx.getBinaryStream());
-				break;
-			case 2:
-				src = new StreamSource(sx.getCharacterStream());
-				break;
-			case 3:
-				src = new StreamSource(new StringReader(sx.getString()));
-				break;
-			case 4:
-				src = sx.getSource(DOMSource.class);
-				break;
-			case 5:
-				src = sx.getSource(SAXSource.class);
-				break;
-			case 6:
-				src = sx.getSource(StAXSource.class);
-				break;
-			case 7:
-				src = sx.getSource(StreamSource.class);
-				break;
-			default:
-				throw new SQLDataException("how should be 1-7", "22003");
+			s_tpls.put(name, s_tf.newTemplates(sxToSource(source, how)));
+		}
+		catch ( TransformerException te )
+		{
+			throw new SQLException("XML transformation failed", te);
+		}
+	}
+
+	@Function(schema="javatest")
+	public static String transformXML(
+		String transformName, SQLXML source, int how)
+	throws SQLException
+	{
+		Templates tpl = s_tpls.get(transformName);
+		Source src = sxToSource(source, how);
+		StringWriter sw = new StringWriter();
+		Result rlt = new StreamResult(sw);
+
+		try
+		{
+			Transformer t = tpl.newTransformer();
+			t.transform(src, rlt);
+		}
+		catch ( TransformerException te )
+		{
+			throw new SQLException("XML transformation failed", te);
 		}
 
+		return sw.toString();
+	}
+
+	private static Source sxToSource(SQLXML sx, int how) throws SQLException
+	{
+		switch ( how )
+		{
+			case  1: return new StreamSource(sx.getBinaryStream());
+			case  2: return new StreamSource(sx.getCharacterStream());
+			case  3: return new StreamSource(new StringReader(sx.getString()));
+			case  4: return     sx.getSource(DOMSource.class);
+			case  5: return     sx.getSource(SAXSource.class);
+			case  6: return     sx.getSource(StAXSource.class);
+			case  7: return     sx.getSource(StreamSource.class);
+			default: throw new SQLDataException("how should be 1-7", "22003");
+		}
+	}
+
+	private static String echoSQLXML(SQLXML sx, int how) throws SQLException
+	{
+		Source src = sxToSource(sx, how);
 		StringWriter sw = new StringWriter();
 		Result rlt = new StreamResult(sw);
 

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/PassXML.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/PassXML.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2018- Tada AB and other contributors, as listed below.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Chapman Flack
+ */
+package org.postgresql.pljava.example.annotation;
+
+import java.sql.SQLDataException;
+import java.sql.SQLException;
+import java.sql.SQLXML;
+
+import java.io.Reader;
+import java.io.StringReader;
+import java.io.StringWriter;
+
+import javax.xml.transform.Result;
+import javax.xml.transform.Source;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+
+import javax.xml.transform.stream.StreamResult;
+import javax.xml.transform.stream.StreamSource;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.sax.SAXSource;
+import javax.xml.transform.stax.StAXSource;
+
+import org.postgresql.pljava.annotation.Function;
+
+public class PassXML
+{
+	static SQLXML s_sx;
+
+	static TransformerFactory s_tf = TransformerFactory.newInstance();
+
+	/**
+	 * Echo an XML parameter back as a string, exercising seven different ways
+	 * (how => 1-7) of reading an SQLXML object.
+	 *<p>
+	 * If how => 0, the XML parameter is simply saved in a static. It can be
+	 * read in a subsequent call with sx => null, but only in the same
+	 * transaction.
+	 */
+	@Function(schema="javatest")
+	public static String echoXMLParameter(SQLXML sx, int how)
+	throws SQLException
+	{
+		if ( null == sx )
+			sx = s_sx;
+		if ( 0 == how )
+		{
+			s_sx = sx;
+			return "(saved)";
+		}
+		return echoSQLXML(sx, how);
+	}
+
+	private static String echoSQLXML(SQLXML sx, int how) throws SQLException
+	{
+		Source src;
+
+		switch ( how )
+		{
+			case 1:
+				src = new StreamSource(sx.getBinaryStream());
+				break;
+			case 2:
+				src = new StreamSource(sx.getCharacterStream());
+				break;
+			case 3:
+				src = new StreamSource(new StringReader(sx.getString()));
+				break;
+			case 4:
+				src = sx.getSource(DOMSource.class);
+				break;
+			case 5:
+				src = sx.getSource(SAXSource.class);
+				break;
+			case 6:
+				src = sx.getSource(StAXSource.class);
+				break;
+			case 7:
+				src = sx.getSource(StreamSource.class);
+				break;
+			default:
+				throw new SQLDataException("how should be 1-7", "22003");
+		}
+
+		StringWriter sw = new StringWriter();
+		Result rlt = new StreamResult(sw);
+
+		try
+		{
+			Transformer t = s_tf.newTransformer();
+			t.transform(src, rlt);
+		}
+		catch ( TransformerException te )
+		{
+			throw new SQLException("XML transformation failed", te);
+		}
+
+		return sw.toString();
+	}
+}

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/PassXML.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/PassXML.java
@@ -13,9 +13,12 @@ package org.postgresql.pljava.example.annotation;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 import java.sql.SQLDataException;
 import java.sql.SQLException;
 import java.sql.SQLXML;
+import java.sql.Types;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -241,6 +244,27 @@ public class PassXML
 				"IOException in lowLevelXMLEcho", "58030", e);
 		}
 		return rx;
+	}
+
+	/**
+	 * Create some XML, pass it to a {@code SELECT ?} prepared statement,
+	 * retrieve it from the result set, and return it via the out-parameter
+	 * result set of this {@code RECORD}-returning function.
+	 */
+	@Function(schema="javatest", type="RECORD")
+	public static boolean xmlInStmtAndRS(ResultSet out) throws SQLException
+	{
+		Connection c = DriverManager.getConnection("jdbc:default:connection");
+		SQLXML x = c.createSQLXML();
+		x.setString("<a/>");
+		PreparedStatement ps = c.prepareStatement("SELECT ?");
+		ps.setObject(1, x, Types.SQLXML);
+		ResultSet rs = ps.executeQuery();
+		rs.next();
+		x = rs.getObject(1, SQLXML.class);
+		ps.close();
+		out.updateObject(1, x);
+		return true;
 	}
 
 	private static Source sxToSource(SQLXML sx, int how) throws SQLException

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/PassXML.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/PassXML.java
@@ -60,6 +60,8 @@ import javax.xml.transform.stax.StAXSource;
 import org.postgresql.pljava.annotation.Function;
 import org.postgresql.pljava.annotation.MappedUDT;
 
+import static org.postgresql.pljava.example.LoggerTest.logMessage;
+
 /**
  * Class illustrating use of {@link SQLXML} to operate on XML data.
  *<p>
@@ -275,6 +277,9 @@ public class PassXML implements SQLData
 		ps.setObject(1, x, Types.SQLXML);
 		ResultSet rs = ps.executeQuery();
 		rs.next();
+		if ( Types.SQLXML != rs.getMetaData().getColumnType(1) )
+			logMessage("WARNING",
+				"ResultSetMetaData.getColumnType() misreports SQLXML");
 		x = rs.getObject(1, SQLXML.class);
 		ps.close();
 		out.updateObject(1, x);

--- a/pljava-so/src/main/c/Backend.c
+++ b/pljava-so/src/main/c/Backend.c
@@ -34,6 +34,7 @@
 #include <unistd.h>
 
 #include "org_postgresql_pljava_internal_Backend.h"
+#include "pljava/DualState.h"
 #include "pljava/Invocation.h"
 #include "pljava/InstallHelper.h"
 #include "pljava/Function.h"
@@ -832,6 +833,7 @@ static void initPLJavaClasses(void)
 	Invocation_initialize();
 	Exception_initialize2();
 	SPI_initialize();
+	pljava_DualState_initialize();
 	Type_initialize();
 	Function_initialize();
 	Session_initialize();

--- a/pljava-so/src/main/c/DualState.c
+++ b/pljava-so/src/main/c/DualState.c
@@ -16,6 +16,12 @@
 
 #include "pljava/PgObject.h"
 #include "pljava/JNICalls.h"
+
+/*
+ * Includes for objects dependent on DualState, so they can be initialized here
+ */
+#include "pljava/VarlenaWrapper.h"
+
 static jclass s_DualState_class;
 
 static jmethodID s_DualState_resourceOwnerRelease;
@@ -71,6 +77,11 @@ void pljava_DualState_initialize(void)
 	JNI_deleteLocalRef(clazz);
 
 	RegisterResourceReleaseCallback(resourceReleaseCB, NULL);
+
+	/*
+	 * Call initialize() methods of known classes built upon DualState.
+	 */
+	pljava_VarlenaWrapper_initialize();
 }
 
 static void resourceReleaseCB(ResourceReleasePhase phase,

--- a/pljava-so/src/main/c/DualState.c
+++ b/pljava-so/src/main/c/DualState.c
@@ -112,7 +112,16 @@ static void resourceReleaseCB(ResourceReleasePhase phase,
 	StaticAssertStmt(sizeof p2l.ptrVal <= sizeof p2l.longVal,
 					 "Pointer will not fit in long on this platform");
 
-	if ( RESOURCE_RELEASE_AFTER_LOCKS != phase )
+	/*
+	 * The way ResourceOwnerRelease is implemented, callbacks to loadable
+	 * modules (like us!) happen /after/ all of the built-in releasey actions
+	 * for a particular phase. So, by looking for RESOURCE_RELEASE_LOCKS here,
+	 * we actually end up executing after all the built-in lock-related stuff
+	 * has been released, but before any of the built-in stuff released in the
+	 * RESOURCE_RELEASE_AFTER_LOCKS phase. Which, at least for the currently
+	 * implemented DualState subclasses, is about the right time.
+	 */
+	if ( RESOURCE_RELEASE_LOCKS != phase )
 		return;
 
 	p2l.longVal = 0L;

--- a/pljava-so/src/main/c/DualState.c
+++ b/pljava-so/src/main/c/DualState.c
@@ -12,6 +12,7 @@
  */
 
 #include "org_postgresql_pljava_internal_DualState_SinglePfree.h"
+#include "org_postgresql_pljava_internal_DualState_SingleMemContextDelete.h"
 #include "pljava/DualState.h"
 
 #include "pljava/PgObject.h"
@@ -48,12 +49,22 @@ void pljava_DualState_initialize(void)
 	jclass clazz;
 	jmethodID ctor;
 
-	JNINativeMethod methods[] =
+	JNINativeMethod singlePfreeMethods[] =
 	{
 		{
 		"_pfree",
 		"(J)V",
 		Java_org_postgresql_pljava_internal_DualState_00024SinglePfree__1pfree
+		},
+		{ 0, 0, 0 }
+	};
+
+	JNINativeMethod singleMemContextDeleteMethods[] =
+	{
+		{
+		"_memContextDelete",
+		"(J)V",
+		Java_org_postgresql_pljava_internal_DualState_00024SingleMemContextDelete__1memContextDelete
 		},
 		{ 0, 0, 0 }
 	};
@@ -73,7 +84,12 @@ void pljava_DualState_initialize(void)
 
 	clazz = (jclass)PgObject_getJavaClass(
 		"org/postgresql/pljava/internal/DualState$SinglePfree");
-	PgObject_registerNatives2(clazz, methods);
+	PgObject_registerNatives2(clazz, singlePfreeMethods);
+	JNI_deleteLocalRef(clazz);
+
+	clazz = (jclass)PgObject_getJavaClass(
+		"org/postgresql/pljava/internal/DualState$SingleMemContextDelete");
+	PgObject_registerNatives2(clazz, singleMemContextDeleteMethods);
 	JNI_deleteLocalRef(clazz);
 
 	RegisterResourceReleaseCallback(resourceReleaseCB, NULL);
@@ -123,5 +139,23 @@ Java_org_postgresql_pljava_internal_DualState_00024SinglePfree__1pfree(
 	Ptr2Long p2l;
 	p2l.longVal = pointer;
 	pfree(p2l.ptrVal);
+	END_NATIVE
+}
+
+
+
+/*
+ * Class:     org_postgresql_pljava_internal_DualState_SingleMemContextDelete
+ * Method:    _memContextDelete
+ * Signature: (J)V
+ */
+JNIEXPORT void JNICALL
+Java_org_postgresql_pljava_internal_DualState_00024SingleMemContextDelete__1memContextDelete(
+	JNIEnv* env, jobject _this, jlong pointer)
+{
+	BEGIN_NATIVE_NO_ERRCHECK
+	Ptr2Long p2l;
+	p2l.longVal = pointer;
+	MemoryContextDelete(p2l.ptrVal);
 	END_NATIVE
 }

--- a/pljava-so/src/main/c/DualState.c
+++ b/pljava-so/src/main/c/DualState.c
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2018 Tada AB and other contributors, as listed below.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Chapman Flack
+ */
+
+#include "pljava/DualState.h"
+
+#include "pljava/PgObject.h"
+#include "pljava/JNICalls.h"
+static jclass s_DualState_class;
+
+static jmethodID s_DualState_resourceOwnerRelease;
+static jmethodID s_DualState_cleanEnqueuedInstances;
+
+static jobject s_DualState_key;
+
+static void resourceReleaseCB(ResourceReleasePhase phase,
+							  bool isCommit, bool isTopLevel, void *arg);
+
+jobject pljava_DualState_key(void)
+{
+	return s_DualState_key;
+}
+
+void pljava_DualState_cleanEnqueuedInstances(void)
+{
+	JNI_callStaticVoidMethodLocked(s_DualState_class,
+								   s_DualState_cleanEnqueuedInstances);
+}
+
+void pljava_DualState_initialize(void)
+{
+	jclass clazz;
+	jmethodID ctor;
+
+	s_DualState_class = (jclass)JNI_newGlobalRef(PgObject_getJavaClass(
+		"org/postgresql/pljava/internal/DualState"));
+
+	s_DualState_resourceOwnerRelease = PgObject_getStaticJavaMethod(
+		s_DualState_class, "resourceOwnerRelease", "(J)V");
+	s_DualState_cleanEnqueuedInstances = PgObject_getStaticJavaMethod(
+		s_DualState_class, "cleanEnqueuedInstances", "()V");
+
+	clazz = (jclass)PgObject_getJavaClass(
+		"org/postgresql/pljava/internal/DualState$Key");
+	ctor = PgObject_getJavaMethod(clazz, "<init>", "()V");
+	s_DualState_key = JNI_newGlobalRef(JNI_newObject(clazz, ctor));
+	JNI_deleteLocalRef(clazz);
+
+	RegisterResourceReleaseCallback(resourceReleaseCB, NULL);
+}
+
+static void resourceReleaseCB(ResourceReleasePhase phase,
+							  bool isCommit, bool isTopLevel, void *arg)
+{
+	Ptr2Long p2l;
+
+	/*
+	 * This static assertion does not need to be in every file
+	 * that uses Ptr2Long, but it should be somewhere once, so here it is.
+	 */
+	StaticAssertStmt(sizeof p2l.ptrVal <= sizeof p2l.longVal,
+					 "Pointer will not fit in long on this platform");
+
+	if ( RESOURCE_RELEASE_AFTER_LOCKS != phase )
+		return;
+
+	p2l.longVal = 0L;
+	p2l.ptrVal = CurrentResourceOwner;
+	JNI_callStaticVoidMethodLocked(s_DualState_class,
+								   s_DualState_resourceOwnerRelease,
+								   p2l.longVal);
+}

--- a/pljava-so/src/main/c/DualState.c
+++ b/pljava-so/src/main/c/DualState.c
@@ -7,9 +7,11 @@
  * http://opensource.org/licenses/BSD-3-Clause
  *
  * Contributors:
+ *   Thomas Hallgren
  *   Chapman Flack
  */
 
+#include "org_postgresql_pljava_internal_DualState_SinglePfree.h"
 #include "pljava/DualState.h"
 
 #include "pljava/PgObject.h"
@@ -40,9 +42,18 @@ void pljava_DualState_initialize(void)
 	jclass clazz;
 	jmethodID ctor;
 
+	JNINativeMethod methods[] =
+	{
+		{
+		"_pfree",
+		"(J)V",
+		Java_org_postgresql_pljava_internal_DualState_00024SinglePfree__1pfree
+		},
+		{ 0, 0, 0 }
+	};
+
 	s_DualState_class = (jclass)JNI_newGlobalRef(PgObject_getJavaClass(
 		"org/postgresql/pljava/internal/DualState"));
-
 	s_DualState_resourceOwnerRelease = PgObject_getStaticJavaMethod(
 		s_DualState_class, "resourceOwnerRelease", "(J)V");
 	s_DualState_cleanEnqueuedInstances = PgObject_getStaticJavaMethod(
@@ -52,6 +63,11 @@ void pljava_DualState_initialize(void)
 		"org/postgresql/pljava/internal/DualState$Key");
 	ctor = PgObject_getJavaMethod(clazz, "<init>", "()V");
 	s_DualState_key = JNI_newGlobalRef(JNI_newObject(clazz, ctor));
+	JNI_deleteLocalRef(clazz);
+
+	clazz = (jclass)PgObject_getJavaClass(
+		"org/postgresql/pljava/internal/DualState$SinglePfree");
+	PgObject_registerNatives2(clazz, methods);
 	JNI_deleteLocalRef(clazz);
 
 	RegisterResourceReleaseCallback(resourceReleaseCB, NULL);
@@ -77,4 +93,24 @@ static void resourceReleaseCB(ResourceReleasePhase phase,
 	JNI_callStaticVoidMethodLocked(s_DualState_class,
 								   s_DualState_resourceOwnerRelease,
 								   p2l.longVal);
+}
+
+
+
+/*
+ * Class:     org_postgresql_pljava_internal_DualState_SinglePfree
+ * Method:    _pfree
+ * Signature: (J)V
+ *
+ * Cadged from JavaWrapper.c
+ */
+JNIEXPORT void JNICALL
+Java_org_postgresql_pljava_internal_DualState_00024SinglePfree__1pfree(
+	JNIEnv* env, jobject _this, jlong pointer)
+{
+	BEGIN_NATIVE_NO_ERRCHECK
+	Ptr2Long p2l;
+	p2l.longVal = pointer;
+	pfree(p2l.ptrVal);
+	END_NATIVE
 }

--- a/pljava-so/src/main/c/Invocation.c
+++ b/pljava-so/src/main/c/Invocation.c
@@ -15,6 +15,7 @@
 #include "pljava/PgObject.h"
 #include "pljava/JNICalls.h"
 #include "pljava/Backend.h"
+#include "pljava/DualState.h"
 
 #define LOCAL_FRAME_SIZE 128
 
@@ -173,6 +174,11 @@ void Invocation_popInvocation(bool wasException)
 			JNI_callVoidMethod(currentInvocation->invocation, s_Invocation_onExit);
 		JNI_deleteGlobalRef(currentInvocation->invocation);
 	}
+
+	/*
+	 * Check for any DualState objects that became unreachable and can be freed.
+	 */
+	pljava_DualState_cleanEnqueuedInstances();
 
 	if(currentInvocation->hasConnected)
 		SPI_finish();

--- a/pljava-so/src/main/c/JNICalls.c
+++ b/pljava-so/src/main/c/JNICalls.c
@@ -321,6 +321,25 @@ jlong JNI_callLongMethodV(jobject object, jmethodID methodID, va_list args)
 	return result;
 }
 
+jlong JNI_callLongMethodLocked(jobject object, jmethodID methodID, ...)
+{
+	jlong result;
+	va_list args;
+	va_start(args, methodID);
+	result = JNI_callLongMethodLockedV(object, methodID, args);
+	va_end(args);
+	return result;
+}
+
+jlong JNI_callLongMethodLockedV(jobject object, jmethodID methodID, va_list args)
+{
+	jlong result;
+	BEGIN_CALL_MONITOR_HELD
+	result = (*env)->CallLongMethodV(env, object, methodID, args);
+	END_CALL_MONITOR_HELD
+	return result;
+}
+
 jshort JNI_callShortMethod(jobject object, jmethodID methodID, ...)
 {
 	jshort result;

--- a/pljava-so/src/main/c/JNICalls.c
+++ b/pljava-so/src/main/c/JNICalls.c
@@ -529,6 +529,21 @@ void JNI_callStaticVoidMethodV(jclass clazz, jmethodID methodID, va_list args)
 	END_CALL
 }
 
+void JNI_callStaticVoidMethodLocked(jclass clazz, jmethodID methodID, ...)
+{
+	va_list args;
+	va_start(args, methodID);
+	JNI_callStaticVoidMethodLockedV(clazz, methodID, args);
+	va_end(args);
+}
+
+void JNI_callStaticVoidMethodLockedV(jclass clazz, jmethodID methodID, va_list args)
+{
+	BEGIN_CALL_MONITOR_HELD
+	(*env)->CallStaticVoidMethodV(env, clazz, methodID, args);
+	END_CALL_MONITOR_HELD
+}
+
 void JNI_callVoidMethod(jobject object, jmethodID methodID, ...)
 {
 	va_list args;
@@ -1073,6 +1088,25 @@ jobject JNI_newObjectV(jclass clazz, jmethodID ctor, va_list args)
 	BEGIN_CALL
 	result = (*env)->NewObjectV(env, clazz, ctor, args);
 	END_CALL
+	return result;
+}
+
+jobject JNI_newObjectLocked(jclass clazz, jmethodID ctor, ...)
+{
+	jobject result;
+	va_list args;
+	va_start(args, ctor);
+	result = JNI_newObjectLockedV(clazz, ctor, args);
+	va_end(args);
+	return result;
+}
+
+jobject JNI_newObjectLockedV(jclass clazz, jmethodID ctor, va_list args)
+{
+	jobject result;
+	BEGIN_CALL_MONITOR_HELD
+	result = (*env)->NewObjectV(env, clazz, ctor, args);
+	END_CALL_MONITOR_HELD
 	return result;
 }
 

--- a/pljava-so/src/main/c/VarlenaWrapper.c
+++ b/pljava-so/src/main/c/VarlenaWrapper.c
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2018 Tada AB and other contributors, as listed below.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Thomas Hallgren
+ *   Chapman Flack
+ */
+
+#include "pljava/VarlenaWrapper.h"
+#include "pljava/DualState.h"
+
+#include "pljava/PgObject.h"
+#include "pljava/JNICalls.h"
+
+static jclass s_VarlenaWrapper_Input_class;
+
+static jmethodID s_VarlenaWrapper_Input_init;
+
+jobject pljava_VarlenaWrapper_Input(Datum d, MemoryContext mc, ResourceOwner ro)
+{
+	jobject vr;
+	jobject dbb;
+	MemoryContext prevcxt;
+	struct varlena *copy;
+	Ptr2Long p2lro;
+	Ptr2Long p2ldatum;
+
+	prevcxt = MemoryContextSwitchTo(mc);
+	copy = PG_DETOAST_DATUM_COPY(d);
+	MemoryContextSwitchTo(prevcxt);
+
+	p2lro.longVal = 0L;
+	p2ldatum.longVal = 0L;
+
+	p2lro.ptrVal = ro;
+	p2ldatum.ptrVal = copy;
+
+	dbb = JNI_newDirectByteBuffer(VARDATA(copy), VARSIZE_ANY_EXHDR(copy));
+
+	vr = JNI_newObjectLocked(s_VarlenaWrapper_Input_class,
+		s_VarlenaWrapper_Input_init, pljava_DualState_key(),
+		p2lro.longVal, p2ldatum.longVal, dbb);
+	JNI_deleteLocalRef(dbb);
+
+	return vr;
+}
+
+void pljava_VarlenaWrapper_initialize(void)
+{
+	s_VarlenaWrapper_Input_class =
+		(jclass)JNI_newGlobalRef(PgObject_getJavaClass(
+			"org/postgresql/pljava/internal/VarlenaWrapper$Input"));
+
+	s_VarlenaWrapper_Input_init = PgObject_getJavaMethod(
+		s_VarlenaWrapper_Input_class, "<init>",
+		"(Lorg/postgresql/pljava/internal/DualState$Key;"
+		"JJLjava/nio/ByteBuffer;)V");
+}

--- a/pljava-so/src/main/c/VarlenaWrapper.c
+++ b/pljava-so/src/main/c/VarlenaWrapper.c
@@ -11,16 +11,70 @@
  *   Chapman Flack
  */
 
+#include "org_postgresql_pljava_internal_VarlenaWrapper_Output_State.h"
 #include "pljava/VarlenaWrapper.h"
 #include "pljava/DualState.h"
 
 #include "pljava/PgObject.h"
 #include "pljava/JNICalls.h"
 
+#define INITIALSIZE 1024
+
 static jclass s_VarlenaWrapper_Input_class;
+static jclass s_VarlenaWrapper_Output_class;
 
 static jmethodID s_VarlenaWrapper_Input_init;
 
+static jmethodID s_VarlenaWrapper_Output_init;
+static jmethodID s_VarlenaWrapper_Output_adopt;
+
+/*
+ * For VarlenaWrapper.Output, define a dead-simple "expanded object" format
+ * consisting of linked allocated blocks, so if a long value is being written,
+ * it does not have to get repeatedly reallocated and copied. The "expanded
+ * object" form is a valid sort of PostgreSQL Datum, and can be passed around
+ * in that form, and reparented between memory contexts with different
+ * lifetimes; when a time comes that PostgreSQL needs it in a 'flattened'
+ * form, it will use these 'methods' to flatten it, and that's when the one
+ * final reallocation and copy will happen.
+ */
+static Size VOS_get_flat_size(ExpandedObjectHeader *eohptr);
+static void VOS_flatten_into(ExpandedObjectHeader *eohptr,
+		void *result, Size allocated_size);
+
+static const ExpandedObjectMethods VOS_methods =
+{
+	VOS_get_flat_size,
+	VOS_flatten_into
+};
+
+typedef struct ExpandedVarlenaOutputStreamNode ExpandedVarlenaOutputStreamNode;
+
+struct ExpandedVarlenaOutputStreamNode
+{
+	ExpandedVarlenaOutputStreamNode *next;
+	Size size;
+};
+
+typedef struct ExpandedVarlenaOutputStreamHeader
+{
+	ExpandedObjectHeader hdr;
+	ExpandedVarlenaOutputStreamNode *tail;
+	Size total_size;
+} ExpandedVarlenaOutputStreamHeader;
+
+
+
+/*
+ * Create and return a VarlenaWrapper.Input allowing Java to read the content
+ * of an existing Datum d, which must be a varlena type (assumed, not checked
+ * here).
+ *
+ * The datum will be copied (detoasting if need be) into the memory context mc,
+ * and the VarlenaWrapper will be associated with the ResourceOwner ro, which
+ * determines its lifespan. The ResourceOwner needs to be one that will be
+ * released no later than the memory context itself.
+ */
 jobject pljava_VarlenaWrapper_Input(Datum d, MemoryContext mc, ResourceOwner ro)
 {
 	jobject vr;
@@ -50,14 +104,189 @@ jobject pljava_VarlenaWrapper_Input(Datum d, MemoryContext mc, ResourceOwner ro)
 	return vr;
 }
 
+/*
+ * Create and return a VarlenaWrapper.Output, initially empty, into which Java
+ * can write.
+ *
+ * The datum will be assembled in the memory context mc, and the VarlenaWrapper
+ * will be associated with the ResourceOwner ro, which determines its lifespan.
+ * The ResourceOwner needs to be one that will be released no later than
+ * the memory context itself.
+ *
+ * After Java has written the content, native code can obtain the Datum by
+ * calling pljava_VarlenaWrapper_Output_adopt().
+ */
+jobject pljava_VarlenaWrapper_Output(MemoryContext parent, ResourceOwner ro)
+{
+	ExpandedVarlenaOutputStreamHeader *evosh;
+	jobject vos;
+	jobject dbb;
+	MemoryContext mc;
+	Ptr2Long p2lro;
+	Ptr2Long p2lcxt;
+	Ptr2Long p2ldatum;
+
+	mc = AllocSetContextCreate(parent, "PL/Java VarlenaWrapper.Output",
+		 ALLOCSET_START_SMALL_SIZES);
+	/*
+	 * Allocate an initial chunk sized to contain the expanded V.O.S. header,
+	 * plus the header and data for one node to hold INITIALSIZE data bytes.
+	 */
+	evosh = MemoryContextAlloc(mc,
+		sizeof *evosh + sizeof *(evosh->tail) + INITIALSIZE);
+	/*
+	 * Initialize the expanded object header and its pointer to the first node.
+	 */
+	EOH_init_header(&(evosh->hdr), &VOS_methods, mc);
+	evosh->total_size = VARHDRSZ;
+	evosh->tail = (ExpandedVarlenaOutputStreamNode *)(evosh + 1);
+	/*
+	 * Initialize that first node.
+	 */
+	evosh->tail->next = evosh->tail;
+	/* evosh->tail->size will be filled in by _nextBuffer() later */
+
+	p2lro.longVal = 0L;
+	p2lcxt.longVal = 0L;
+	p2ldatum.longVal = 0L;
+
+	p2lro.ptrVal = ro;
+	p2lcxt.ptrVal = mc;
+	p2ldatum.ptrVal = DatumGetPointer(EOHPGetRWDatum(&(evosh->hdr)));
+
+	/*
+	 * The data bytes begin right after the node header struct.
+	 */
+	dbb = JNI_newDirectByteBuffer(evosh->tail + 1, INITIALSIZE);
+
+	vos = JNI_newObjectLocked(s_VarlenaWrapper_Output_class,
+			s_VarlenaWrapper_Output_init, pljava_DualState_key(),
+			p2lro.longVal, p2lcxt.longVal, p2ldatum.longVal, dbb);
+	JNI_deleteLocalRef(dbb);
+
+	return vos;
+}
+
+/*
+ * Adopt a VarlenaWrapper.Output after Java code has written and closed it.
+ * The wrapper will no longer be accessible from Java.
+ */
+Datum pljava_VarlenaWrapper_Output_adopt(jobject vlos)
+{
+	Ptr2Long p2l;
+
+	p2l.longVal = JNI_callLongMethodLocked(vlos, s_VarlenaWrapper_Output_adopt);
+	return PointerGetDatum(p2l.ptrVal);
+}
+
+static Size VOS_get_flat_size(ExpandedObjectHeader *eohptr)
+{
+	ExpandedVarlenaOutputStreamHeader *evosh =
+		(ExpandedVarlenaOutputStreamHeader *)eohptr;
+	return evosh->total_size;
+}
+
+static void VOS_flatten_into(ExpandedObjectHeader *eohptr,
+		void *result, Size allocated_size)
+{
+	ExpandedVarlenaOutputStreamHeader *evosh =
+		(ExpandedVarlenaOutputStreamHeader *)eohptr;
+	ExpandedVarlenaOutputStreamNode *node = evosh->tail;
+
+	Assert(allocated_size == evosh->total_size);
+	SET_VARSIZE(result, allocated_size);
+	result = VARDATA(result);
+
+	do
+	{
+		node = node->next;
+		memcpy(result, node + 1, node->size);
+		result = (char *)result + node->size;
+	}
+	while ( node != evosh->tail );
+}
+
 void pljava_VarlenaWrapper_initialize(void)
 {
+	jclass clazz;
+	JNINativeMethod methods[] =
+	{
+		{
+		"_nextBuffer",
+		"(JII)Ljava/nio/ByteBuffer;",
+		Java_org_postgresql_pljava_internal_VarlenaWrapper_00024Output_00024State__1nextBuffer
+		},
+		{ 0, 0, 0 }
+	};
+
 	s_VarlenaWrapper_Input_class =
 		(jclass)JNI_newGlobalRef(PgObject_getJavaClass(
 			"org/postgresql/pljava/internal/VarlenaWrapper$Input"));
+	s_VarlenaWrapper_Output_class =
+		(jclass)JNI_newGlobalRef(PgObject_getJavaClass(
+			"org/postgresql/pljava/internal/VarlenaWrapper$Output"));
 
 	s_VarlenaWrapper_Input_init = PgObject_getJavaMethod(
 		s_VarlenaWrapper_Input_class, "<init>",
 		"(Lorg/postgresql/pljava/internal/DualState$Key;"
 		"JJLjava/nio/ByteBuffer;)V");
+
+	s_VarlenaWrapper_Output_init = PgObject_getJavaMethod(
+		s_VarlenaWrapper_Output_class, "<init>",
+		"(Lorg/postgresql/pljava/internal/DualState$Key;"
+		"JJJLjava/nio/ByteBuffer;)V");
+
+	s_VarlenaWrapper_Output_adopt = PgObject_getJavaMethod(
+		s_VarlenaWrapper_Output_class, "adopt", "()J");
+
+	clazz = (jclass)JNI_newGlobalRef(PgObject_getJavaClass(
+			"org/postgresql/pljava/internal/VarlenaWrapper$Output$State"));
+	PgObject_registerNatives2(clazz, methods);
+	JNI_deleteLocalRef(clazz);
+}
+
+/*
+ * Class:     org_postgresql_pljava_internal_VarlenaWrapper_Output_State
+ * Method:    _nextBuffer
+ * Signature: (JII)Ljava/nio/ByteBuffer;
+ */
+JNIEXPORT jobject JNICALL
+Java_org_postgresql_pljava_internal_VarlenaWrapper_00024Output_00024State__1nextBuffer
+  (JNIEnv *env, jobject _this,
+   jlong varlenaPtr, jint currentBufPosition, jint desiredCapacity)
+{
+	ExpandedVarlenaOutputStreamHeader *evosh;
+	ExpandedVarlenaOutputStreamNode *node;
+	Ptr2Long p2l;
+	Datum d;
+	jobject dbb;
+
+	p2l.longVal = varlenaPtr;
+	d = PointerGetDatum(p2l.ptrVal);
+
+	evosh = (ExpandedVarlenaOutputStreamHeader *)DatumGetEOHP(d);
+	evosh->tail->size  = currentBufPosition;
+	evosh->total_size += currentBufPosition;
+
+	if ( 0 == desiredCapacity )
+		return NULL;
+
+	BEGIN_NATIVE
+	/*
+	 * This adjustment of desiredCapacity is arbitrary and amenable to
+	 * performance experimentation. For initial signs of life, ignore the
+	 * desiredCapacity hint completely and use a hardwired size.
+	 */
+	desiredCapacity = 8180;
+
+	node = (ExpandedVarlenaOutputStreamNode *)
+			MemoryContextAlloc(evosh->hdr.eoh_context, desiredCapacity);
+	node->next = evosh->tail->next;
+	evosh->tail->next = node;
+	evosh->tail = node;
+
+	dbb = JNI_newDirectByteBuffer(node + 1, desiredCapacity - sizeof *node);
+	END_NATIVE
+
+	return dbb;
 }

--- a/pljava-so/src/main/c/type/Oid.c
+++ b/pljava-so/src/main/c/type/Oid.c
@@ -110,14 +110,18 @@ Oid Oid_forSqlType(int sqlType)
 		case java_sql_Types_STRUCT:
 		case java_sql_Types_ARRAY:
 		case java_sql_Types_REF:
+			typeId = InvalidOid;	/* Not yet mapped */
+			break;
 
 		/* JDBC 4.0 - present in Java 6 and later, no need to conditionalize */
+		case java_sql_Types_SQLXML:
+			typeId = XMLOID;
+			break;
 		case java_sql_Types_ROWID:
 		case java_sql_Types_NCHAR:
 		case java_sql_Types_NVARCHAR:
 		case java_sql_Types_LONGNVARCHAR:
 		case java_sql_Types_NCLOB:
-		case java_sql_Types_SQLXML:
 
 		/* JDBC 4.2 - conditionalize until only Java 8 and later supported */
 #ifdef	java_sql_Types_REF_CURSOR

--- a/pljava-so/src/main/c/type/Oid.c
+++ b/pljava-so/src/main/c/type/Oid.c
@@ -115,7 +115,11 @@ Oid Oid_forSqlType(int sqlType)
 
 		/* JDBC 4.0 - present in Java 6 and later, no need to conditionalize */
 		case java_sql_Types_SQLXML:
+#ifdef	XMLOID					/* but PG can have been built without libxml */
 			typeId = XMLOID;
+#else
+			typeId = InvalidOid;
+#endif
 			break;
 		case java_sql_Types_ROWID:
 		case java_sql_Types_NCHAR:

--- a/pljava-so/src/main/c/type/Oid.c
+++ b/pljava-so/src/main/c/type/Oid.c
@@ -32,6 +32,14 @@ static jobject   s_OidOid;
 jobject Oid_create(Oid oid)
 {
 	jobject joid;
+	/*
+	 * This is a natural place to have a StaticAssertStmt making sure the
+	 * ubiquitous PG type 'Oid' fits in a jint. If it is ever removed from here
+	 * or this code goes away, it should go someplace else. If it ever produces
+	 * an error, don't assume the only things that need fixing will be in this
+	 * file or nearby....
+	 */
+	StaticAssertStmt(sizeof(Oid) <= sizeof(jint), "Oid wider than jint?!");
 	if(OidIsValid(oid))
 		joid = JNI_newObject(s_Oid_class, s_Oid_init, oid);
 	else

--- a/pljava-so/src/main/c/type/Portal.c
+++ b/pljava-so/src/main/c/type/Portal.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2016 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2018 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -18,6 +18,7 @@
 
 #include "org_postgresql_pljava_internal_Portal.h"
 #include "pljava/Backend.h"
+#include "pljava/DualState.h"
 #include "pljava/Exception.h"
 #include "pljava/Invocation.h"
 #include "pljava/HashMap.h"
@@ -189,6 +190,16 @@ Java_org_postgresql_pljava_internal_Portal__1fetch(JNIEnv* env, jclass clazz, jl
 		Ptr2Long p2l;
 		STACK_BASE_VARS
 		STACK_BASE_PUSH(threadId)
+
+		/*
+		 * One call to cleanEnqueued... is made in Invocation_popInvocation,
+		 * when any PL/Java function returns to PostgreSQL. But what of a
+		 * PL/Java function that loops through a lot of data before returning?
+		 * It could be important to call cleanEnqueued... from some other
+		 * strategically-chosen places, and this seems a good one. We get here
+		 * every fetchSize (default 1000? See SPIStatement) rows retrieved.
+		 */
+		pljava_DualState_cleanEnqueuedInstances();
 
 		p2l.longVal = _this;
 		PG_TRY();

--- a/pljava-so/src/main/c/type/SQLXMLImpl.c
+++ b/pljava-so/src/main/c/type/SQLXMLImpl.c
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2018 Tada AB and other contributors, as listed below.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Chapman Flack
+ */
+#include <postgres.h>
+
+#include "pljava/type/Type_priv.h"
+#include "pljava/VarlenaWrapper.h"
+
+static jclass    s_SQLXML_Readable_class;
+static jmethodID s_SQLXML_Readable_init;
+
+static jvalue _SQLXML_coerceDatum(Type self, Datum arg)
+{
+	jvalue result;
+	jobject vwi = pljava_VarlenaWrapper_Input(
+		arg, TopTransactionContext, TopTransactionResourceOwner);
+	result.l = JNI_newObject(
+		s_SQLXML_Readable_class, s_SQLXML_Readable_init, vwi);
+	JNI_deleteLocalRef(vwi);
+	return result;
+}
+
+static Datum _SQLXML_coerceObject(Type self, jobject sqlxml)
+{
+	return 0; /* haven't got that direction yet */
+}
+
+/* Make this datatype available to the postgres system.
+ */
+extern void pljava_SQLXMLImpl_initialize(void);
+void pljava_SQLXMLImpl_initialize(void)
+{
+	TypeClass cls = TypeClass_alloc("type.SQLXML");
+	cls->JNISignature = "Ljava/sql/SQLXML;";
+	cls->javaTypeName = "java.sql.SQLXML";
+	cls->coerceDatum  = _SQLXML_coerceDatum;
+	cls->coerceObject = _SQLXML_coerceObject;
+	Type_registerType("java.sql.SQLXML", TypeClass_allocInstance(cls, XMLOID));
+
+	s_SQLXML_Readable_class = JNI_newGlobalRef(PgObject_getJavaClass(
+		"org/postgresql/pljava/jdbc/SQLXMLImpl$Readable"));
+	s_SQLXML_Readable_init = PgObject_getJavaMethod(s_SQLXML_Readable_class,
+		"<init>", "(Lorg/postgresql/pljava/internal/VarlenaWrapper$Input;)V");
+}

--- a/pljava-so/src/main/c/type/SQLXMLImpl.c
+++ b/pljava-so/src/main/c/type/SQLXMLImpl.c
@@ -18,6 +18,7 @@ static jclass    s_SQLXML_Readable_class;
 static jmethodID s_SQLXML_Readable_init;
 static jclass    s_SQLXML_Writable_class;
 static jmethodID s_SQLXML_Writable_init;
+static jmethodID s_SQLXML_Writable_adopt;
 
 static jvalue _SQLXML_coerceDatum(Type self, Datum arg)
 {
@@ -32,7 +33,10 @@ static jvalue _SQLXML_coerceDatum(Type self, Datum arg)
 
 static Datum _SQLXML_coerceObject(Type self, jobject sqlxml)
 {
-	return 0; /* haven't got that direction yet */
+	jobject vwo = JNI_callObjectMethodLocked(sqlxml, s_SQLXML_Writable_adopt);
+	Datum d = pljava_VarlenaWrapper_Output_adopt(vwo);
+	JNI_deleteLocalRef(vwo);
+	return TransferExpandedObject(d, CurrentMemoryContext);
 }
 
 /* Make this datatype available to the postgres system.
@@ -56,4 +60,6 @@ void pljava_SQLXMLImpl_initialize(void)
 		"org/postgresql/pljava/jdbc/SQLXMLImpl$Writable"));
 	s_SQLXML_Writable_init = PgObject_getJavaMethod(s_SQLXML_Writable_class,
 		"<init>", "(Lorg/postgresql/pljava/internal/VarlenaWrapper$Output;)V");
+	s_SQLXML_Writable_adopt = PgObject_getJavaMethod(s_SQLXML_Writable_class,
+		"adopt", "()Lorg/postgresql/pljava/internal/VarlenaWrapper$Output;");
 }

--- a/pljava-so/src/main/c/type/SQLXMLImpl.c
+++ b/pljava-so/src/main/c/type/SQLXMLImpl.c
@@ -11,6 +11,8 @@
  */
 #include <postgres.h>
 
+#include "org_postgresql_pljava_jdbc_SQLXMLImpl.h"
+
 #include "pljava/type/Type_priv.h"
 #include "pljava/VarlenaWrapper.h"
 
@@ -44,6 +46,17 @@ static Datum _SQLXML_coerceObject(Type self, jobject sqlxml)
 extern void pljava_SQLXMLImpl_initialize(void);
 void pljava_SQLXMLImpl_initialize(void)
 {
+	jclass clazz;
+	JNINativeMethod methods[] =
+	{
+		{
+		"_newWritable",
+		"()Ljava/sql/SQLXML;",
+		Java_org_postgresql_pljava_jdbc_SQLXMLImpl__1newWritable
+		},
+		{ 0, 0, 0 }
+	};
+
 	TypeClass cls = TypeClass_alloc("type.SQLXML");
 	cls->JNISignature = "Ljava/sql/SQLXML;";
 	cls->javaTypeName = "java.sql.SQLXML";
@@ -62,4 +75,28 @@ void pljava_SQLXMLImpl_initialize(void)
 		"<init>", "(Lorg/postgresql/pljava/internal/VarlenaWrapper$Output;)V");
 	s_SQLXML_Writable_adopt = PgObject_getJavaMethod(s_SQLXML_Writable_class,
 		"adopt", "()Lorg/postgresql/pljava/internal/VarlenaWrapper$Output;");
+
+	clazz = PgObject_getJavaClass("org/postgresql/pljava/jdbc/SQLXMLImpl");
+	PgObject_registerNatives2(clazz, methods);
+	JNI_deleteLocalRef(clazz);
+}
+
+/*
+ * Class:     org_postgresql_pljava_jdbc_SQLXMLImpl
+ * Method:    _newWritable
+ * Signature: ()Ljava/sql/SQLXML;
+ */
+JNIEXPORT jobject JNICALL
+Java_org_postgresql_pljava_jdbc_SQLXMLImpl__1newWritable
+	(JNIEnv *env, jclass sqlxml_class)
+{
+	jobject sqlxml;
+	jobject vwo;
+	BEGIN_NATIVE
+	vwo = pljava_VarlenaWrapper_Output(
+			TopTransactionContext, TopTransactionResourceOwner);
+	sqlxml = JNI_newObjectLocked(
+			s_SQLXML_Writable_class, s_SQLXML_Writable_init, vwo);
+	END_NATIVE
+	return sqlxml;
 }

--- a/pljava-so/src/main/c/type/SQLXMLImpl.c
+++ b/pljava-so/src/main/c/type/SQLXMLImpl.c
@@ -16,6 +16,8 @@
 
 static jclass    s_SQLXML_Readable_class;
 static jmethodID s_SQLXML_Readable_init;
+static jclass    s_SQLXML_Writable_class;
+static jmethodID s_SQLXML_Writable_init;
 
 static jvalue _SQLXML_coerceDatum(Type self, Datum arg)
 {
@@ -49,4 +51,9 @@ void pljava_SQLXMLImpl_initialize(void)
 		"org/postgresql/pljava/jdbc/SQLXMLImpl$Readable"));
 	s_SQLXML_Readable_init = PgObject_getJavaMethod(s_SQLXML_Readable_class,
 		"<init>", "(Lorg/postgresql/pljava/internal/VarlenaWrapper$Input;)V");
+
+	s_SQLXML_Writable_class = JNI_newGlobalRef(PgObject_getJavaClass(
+		"org/postgresql/pljava/jdbc/SQLXMLImpl$Writable"));
+	s_SQLXML_Writable_init = PgObject_getJavaMethod(s_SQLXML_Writable_class,
+		"<init>", "(Lorg/postgresql/pljava/internal/VarlenaWrapper$Output;)V");
 }

--- a/pljava-so/src/main/c/type/SQLXMLImpl.c
+++ b/pljava-so/src/main/c/type/SQLXMLImpl.c
@@ -16,12 +16,18 @@
 #include "pljava/type/Type_priv.h"
 #include "pljava/VarlenaWrapper.h"
 
+static TypeClass s_SQLXMLClass;
 static jclass    s_SQLXML_class;
 static jmethodID s_SQLXML_adopt;
 static jclass    s_SQLXML_Readable_class;
 static jmethodID s_SQLXML_Readable_init;
 static jclass    s_SQLXML_Writable_class;
 static jmethodID s_SQLXML_Writable_init;
+
+static bool   _SQLXML_canReplaceType(Type self, Type other);
+static jvalue _SQLXML_coerceDatum(Type self, Datum arg);
+static Datum  _SQLXML_coerceObject(Type self, jobject sqlxml);
+static Type   _SQLXML_obtain(Oid typeId);
 
 /*
  * It is possible to install PL/Java in a PostgreSQL instance that was built
@@ -43,15 +49,16 @@ static jvalue _SQLXML_coerceDatum(Type self, Datum arg)
 	jvalue result;
 	jobject vwi = pljava_VarlenaWrapper_Input(
 		arg, TopTransactionContext, TopTransactionResourceOwner);
-	result.l = JNI_newObject(
-		s_SQLXML_Readable_class, s_SQLXML_Readable_init, vwi);
+	result.l = JNI_newObject(s_SQLXML_Readable_class, s_SQLXML_Readable_init,
+		vwi, Type_getOid(self));
 	JNI_deleteLocalRef(vwi);
 	return result;
 }
 
 static Datum _SQLXML_coerceObject(Type self, jobject sqlxml)
 {
-	jobject vw = JNI_callObjectMethodLocked(sqlxml, s_SQLXML_adopt);
+	jobject vw = JNI_callObjectMethodLocked(
+		sqlxml, s_SQLXML_adopt, Type_getOid(self));
 	Datum d = pljava_VarlenaWrapper_adopt(vw);
 	JNI_deleteLocalRef(vw);
 #if PG_VERSION_NUM >= 90500
@@ -66,6 +73,33 @@ static Datum _SQLXML_coerceObject(Type self, jobject sqlxml)
 		d = PointerGetDatum(PG_DETOAST_DATUM_COPY(d));
 #endif
 	return d;
+}
+
+/*
+ * A Type can be 'registered' two ways. In one case, a single instance can be
+ * created with TypeClass_allocInstance(2)? and assigned a fixed Oid, and that
+ * instance then passed to Type_registerType along with the Java name.
+ *
+ * The other way is not to allocate any Type instance up front, but instead
+ * to call Type_registerType2, passing just the type's canonical Oid, the Java
+ * name, and an 'obtainer' function, like this one.
+ *
+ * The difference appears when this TypeClass has a _canReplaceType function
+ * that allows it to serve more than one PostgreSQL type (as, indeed, SQLXML
+ * now does and can). With the first registration style, the same Type instance
+ * will be used for any of the PostgreSQL types accepted by the _canReplaceType
+ * function. With the second style, the obtainer will be called to produce a
+ * distinct Type instance (sharing the same TypeClass) for each one, recording
+ * its own PostgreSQL Oid.
+ *
+ * SQLXML has a need to run a content verifier when 'bouncing' a readable
+ * instance back to PostgreSQL, and ideally only to do so when the Oids at
+ * create and adopt time are different, so it cannot make do with the singleton
+ * type instance, and needs to use Type_registerType2 with an obtainer.
+ */
+static Type _SQLXML_obtain(Oid typeId)
+{
+	return TypeClass_allocInstance(s_SQLXMLClass, typeId);
 }
 
 /* Make this datatype available to the postgres system.
@@ -90,26 +124,26 @@ void pljava_SQLXMLImpl_initialize(void)
 	cls->canReplaceType = _SQLXML_canReplaceType;
 	cls->coerceDatum  = _SQLXML_coerceDatum;
 	cls->coerceObject = _SQLXML_coerceObject;
-	Type_registerType(
-		"java.sql.SQLXML",
-		TypeClass_allocInstance(
-			cls,
+	s_SQLXMLClass = cls;
+
+	Type_registerType2(
 #ifdef XMLOID		/* it is possible to build PG without libxml */
 			XMLOID
 #else
 			InvalidOid
 #endif
-	));
+		, "java.sql.SQLXML", _SQLXML_obtain
+	);
 
 	s_SQLXML_class = JNI_newGlobalRef(PgObject_getJavaClass(
 		"org/postgresql/pljava/jdbc/SQLXMLImpl"));
 	s_SQLXML_adopt = PgObject_getJavaMethod(s_SQLXML_class,
-		"adopt", "()Lorg/postgresql/pljava/internal/VarlenaWrapper;");
+		"adopt", "(I)Lorg/postgresql/pljava/internal/VarlenaWrapper;");
 
 	s_SQLXML_Readable_class = JNI_newGlobalRef(PgObject_getJavaClass(
 		"org/postgresql/pljava/jdbc/SQLXMLImpl$Readable"));
 	s_SQLXML_Readable_init = PgObject_getJavaMethod(s_SQLXML_Readable_class,
-		"<init>", "(Lorg/postgresql/pljava/internal/VarlenaWrapper$Input;)V");
+		"<init>", "(Lorg/postgresql/pljava/internal/VarlenaWrapper$Input;I)V");
 
 	s_SQLXML_Writable_class = JNI_newGlobalRef(PgObject_getJavaClass(
 		"org/postgresql/pljava/jdbc/SQLXMLImpl$Writable"));

--- a/pljava-so/src/main/c/type/Type.c
+++ b/pljava-so/src/main/c/type/Type.c
@@ -736,6 +736,8 @@ extern void TupleTable_initialize(void);
 
 extern void Composite_initialize(void);
 
+extern void pljava_SQLXMLImpl_initialize(void);
+
 extern void Type_initialize(void);
 void Type_initialize(void)
 {
@@ -778,6 +780,7 @@ void Type_initialize(void)
 	TupleTable_initialize();
 
 	Composite_initialize();
+	pljava_SQLXMLImpl_initialize();
 
 	s_Map_class = JNI_newGlobalRef(PgObject_getJavaClass("java/util/Map"));
 	s_Map_get = PgObject_getJavaMethod(s_Map_class, "get", "(Ljava/lang/Object;)Ljava/lang/Object;");

--- a/pljava-so/src/main/include/pljava/DualState.h
+++ b/pljava-so/src/main/include/pljava/DualState.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2018 Tada AB and other contributors, as listed below.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Chapman Flack
+ */
+#ifndef __pljava_DualState_h
+#define __pljava_DualState_h
+
+#include <postgres.h>
+#include <utils/resowner.h>
+
+#include "pljava/pljava.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern jobject pljava_DualState_key(void);
+
+extern void pljava_DualState_cleanEnqueuedInstances(void);
+
+extern void pljava_DualState_initialize(void);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/pljava-so/src/main/include/pljava/JNICalls.h
+++ b/pljava-so/src/main/include/pljava/JNICalls.h
@@ -68,15 +68,21 @@ extern jclass    NoSuchMethodError_class;
  * whole time. They are used in String.c for character set coding conversions,
  * which may frequently call Java methods that are never expected to have any
  * reason to block or reenter the backend.
+ * Also, they can be used with DualState and related objects, to be sure certain
+ * methods or constructors are called on a thread that holds the native lock.
  */
 extern jobject      JNI_callObjectMethodLocked(jobject object, jmethodID methodID, ...);
 extern jobject      JNI_callObjectMethodLockedV(jobject object, jmethodID methodID, va_list args);
 extern jobject      JNI_callStaticObjectMethodLocked(jclass clazz, jmethodID methodID, ...);
 extern jobject      JNI_callStaticObjectMethodLockedV(jclass clazz, jmethodID methodID, va_list args);
+extern void         JNI_callStaticVoidMethodLocked(jclass clazz, jmethodID methodID, ...);
+extern void         JNI_callStaticVoidMethodLockedV(jclass clazz, jmethodID methodID, va_list args);
 extern jint         JNI_callIntMethodLocked(jobject object, jmethodID methodID, ...);
 extern jint         JNI_callIntMethodLockedV(jobject object, jmethodID methodID, va_list args);
 extern void         JNI_callVoidMethodLocked(jobject object, jmethodID methodID, ...);
 extern void         JNI_callVoidMethodLockedV(jobject object, jmethodID methodID, va_list args);
+extern jobject      JNI_newObjectLocked(jclass clazz, jmethodID ctor, ...);
+extern jobject      JNI_newObjectLockedV(jclass clazz, jmethodID ctor, va_list args);
 
 /*
  * Misc JNIEnv mappings. See <jni.h> for more info.

--- a/pljava-so/src/main/include/pljava/JNICalls.h
+++ b/pljava-so/src/main/include/pljava/JNICalls.h
@@ -79,6 +79,8 @@ extern void         JNI_callStaticVoidMethodLocked(jclass clazz, jmethodID metho
 extern void         JNI_callStaticVoidMethodLockedV(jclass clazz, jmethodID methodID, va_list args);
 extern jint         JNI_callIntMethodLocked(jobject object, jmethodID methodID, ...);
 extern jint         JNI_callIntMethodLockedV(jobject object, jmethodID methodID, va_list args);
+extern jlong        JNI_callLongMethodLocked(jobject object, jmethodID methodID, ...);
+extern jlong        JNI_callLongMethodLockedV(jobject object, jmethodID methodID, va_list args);
 extern void         JNI_callVoidMethodLocked(jobject object, jmethodID methodID, ...);
 extern void         JNI_callVoidMethodLockedV(jobject object, jmethodID methodID, va_list args);
 extern jobject      JNI_newObjectLocked(jclass clazz, jmethodID ctor, ...);

--- a/pljava-so/src/main/include/pljava/VarlenaWrapper.h
+++ b/pljava-so/src/main/include/pljava/VarlenaWrapper.h
@@ -26,7 +26,7 @@ extern jobject pljava_VarlenaWrapper_Input(
 
 extern jobject pljava_VarlenaWrapper_Output(MemoryContext mc, ResourceOwner ro);
 
-extern Datum pljava_VarlenaWrapper_Output_adopt(jobject vlos);
+extern Datum pljava_VarlenaWrapper_adopt(jobject vlos);
 
 extern void pljava_VarlenaWrapper_initialize(void);
 

--- a/pljava-so/src/main/include/pljava/VarlenaWrapper.h
+++ b/pljava-so/src/main/include/pljava/VarlenaWrapper.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2018 Tada AB and other contributors, as listed below.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Chapman Flack
+ */
+#ifndef __pljava_VarlenaWrapper_h
+#define __pljava_VarlenaWrapper_h
+
+#include <postgres.h>
+#include <utils/resowner.h>
+
+#include "pljava/pljava.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern jobject pljava_VarlenaWrapper_Input(
+	Datum d, MemoryContext mc, ResourceOwner ro);
+
+extern void pljava_VarlenaWrapper_initialize(void);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/pljava-so/src/main/include/pljava/VarlenaWrapper.h
+++ b/pljava-so/src/main/include/pljava/VarlenaWrapper.h
@@ -24,6 +24,10 @@ extern "C" {
 extern jobject pljava_VarlenaWrapper_Input(
 	Datum d, MemoryContext mc, ResourceOwner ro);
 
+extern jobject pljava_VarlenaWrapper_Output(MemoryContext mc, ResourceOwner ro);
+
+extern Datum pljava_VarlenaWrapper_Output_adopt(jobject vlos);
+
 extern void pljava_VarlenaWrapper_initialize(void);
 
 #ifdef __cplusplus

--- a/pljava/src/main/java/org/postgresql/pljava/internal/ByteBufferInputStream.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/ByteBufferInputStream.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright (c) 2018 Tada AB and other contributors, as listed below.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Chapman Flack
+ */
+package org.postgresql.pljava.internal;
+
+import java.io.InputStream;
+import java.io.IOException;
+
+import java.nio.ByteBuffer;
+import java.nio.InvalidMarkException;
+
+/**
+ * Wrap a readable {@link ByteBuffer} as an {@link InputStream}.
+ *<p>
+ * An implementing class must provide a {@link #buffer} method that returns the
+ * {@code ByteBuffer}, and the method is responsible for knowing when the memory
+ * region windowed by the {@code ByteBuffer} is no longer to be accessed, and
+ * throwing an exception in that case.
+ *<p>
+ * The implementing class must supply an object that the {@code InputStream}
+ * operations will be {@code synchronized} on, and that must be the same object
+ * on which any operations that affect the byte buffer's accessibility will
+ * synchronize.
+ */
+public abstract class ByteBufferInputStream extends InputStream
+{
+	/**
+	 * The object on which the {@code InputStream} operations will synchronize.
+	 *<p>
+	 * Must be the same object, if any, that operations affecting the byte
+	 * buffer's accessibility synchronize on, and may be of any type useful to
+	 * the implementing class.
+	 * <strong>Every implementing subclass must assign something to
+	 * {@code m_state} when created, and then leave it alone as if it were
+	 * {@code final}.</strong>
+	 */
+	protected Object m_state;
+
+	/**
+	 * Whether this stream is open; initially true.
+	 */
+	protected boolean m_open;
+
+	/**
+	 * Construct an instance, given an object on which to synchronize.
+	 *<p>
+	 * Does not require a parameter to initialize {@link m_state} (because if an
+	 * implementing subclass needs to create a state object with a reference to
+	 * this, Java's restriction on referencing this prior to calling a
+	 * superclass constructor could be triggered).
+	 *<p>
+	 * <strong>Every implementing subclass must assign something to
+	 * {@code m_state} when created, and then leave it alone as if it were
+	 * {@code final}.</strong>
+	 */
+	protected ByteBufferInputStream()
+	{
+		m_open = true;
+	}
+
+	/**
+	 * Return the {@link ByteBuffer} being wrapped, or throw an exception if the
+	 * memory windowed by the buffer should no longer be accessed.
+	 *<p>
+	 * The monitor on {@link #m_state} is held when this method is called.
+	 *<p>
+	 * This method also should throw an exception if {@link #m_open} is false.
+	 * It is called everywhere that should happen, so it is the perfect place
+	 * for the test, and allows the implementing class to use a customized
+	 * message in the exception.
+	 */
+	protected abstract ByteBuffer buffer() throws IOException;
+
+	@Override
+	public int read() throws IOException
+	{
+		synchronized ( m_state )
+		{
+			ByteBuffer src = buffer();
+			if ( 0 < src.remaining() )
+				return src.get();
+			return -1;
+		}
+	}
+
+	@Override
+	public int read(byte[] b, int off, int len) throws IOException
+	{
+		synchronized ( m_state )
+		{
+			ByteBuffer src = buffer();
+			int has = src.remaining();
+			if ( len > has )
+			{
+				if ( 0 == has )
+					return -1;
+				len = has;
+			}
+			src.get(b, off, len);
+			return len;
+		}
+	}
+
+	@Override
+	public long skip(long n) throws IOException
+	{
+		synchronized ( m_state )
+		{
+			ByteBuffer src = buffer();
+			int has = src.remaining();
+			if ( n > has )
+				n = has;
+			src.position(src.position() + (int)n);
+			return n;
+		}
+	}
+
+	@Override
+	public int available() throws IOException
+	{
+		synchronized ( m_state )
+		{
+			return buffer().remaining();
+		}
+	}
+
+	@Override
+	public void close() throws IOException
+	{
+		synchronized ( m_state )
+		{
+			if ( ! m_open )
+				return;
+			m_open = false;
+		}
+	}
+
+	@Override
+	public void mark(int readlimit)
+	{
+		synchronized ( m_state )
+		{
+			if ( ! m_open )
+				return;
+			try
+			{
+				buffer().mark();
+			}
+			catch ( IOException e )
+			{
+				/*
+				 * The contract is for mark to throw no checked exception.
+				 * An exception caught here probably means the state's no longer
+				 * live, which will be signaled to the caller if another,
+				 * throwing, method is then called. If not, no harm no foul.
+				 */
+			}
+		}
+	}
+
+	@Override
+	public void reset() throws IOException
+	{
+		synchronized ( m_state )
+		{
+			if ( ! m_open )
+				return;
+			try
+			{
+				buffer().reset();
+			}
+			catch ( InvalidMarkException e )
+			{
+				throw new IOException("reset attempted when mark not set");
+			}
+		}
+	}
+
+	/**
+	 * Return {@code true}; this class does support {@code mark} and
+	 * {@code reset}.
+	 */
+	@Override
+	public boolean markSupported()
+	{
+		return true;
+	}
+}

--- a/pljava/src/main/java/org/postgresql/pljava/internal/DualState.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/DualState.java
@@ -231,6 +231,13 @@ public abstract class DualState<T> extends WeakReference<T>
 		}
 	}
 
+	@Override
+	public String toString()
+	{
+		return String.format("DualState owner:%x %s", m_resourceOwner,
+			nativeStateIsValid() ? "fresh" : "stale");
+	}
+
 	/**
 	 * Called only from native code by the {@code ResourceOwner} callback when a
 	 * resource owner is being released. Must identify the live instances that
@@ -315,6 +322,12 @@ public abstract class DualState<T> extends WeakReference<T>
 		{
 			super(cookie, referent, resourceOwner);
 			m_pointer = pfreeTarget;
+		}
+
+		@Override
+		public String toString()
+		{
+			return String.format("%s pfree(%x)", super.toString(), m_pointer);
 		}
 
 		/**

--- a/pljava/src/main/java/org/postgresql/pljava/internal/DualState.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/DualState.java
@@ -103,6 +103,13 @@ public abstract class DualState<T> extends WeakReference<T>
 	 */
 	private final long m_resourceOwner;
 
+	protected static void checkCookie(Key cookie)
+	{
+		if ( ! Key.class.isInstance(cookie) )
+			throw new UnsupportedOperationException(
+				"Operation on DualState instance without cookie");
+	}
+
 	/**
 	 * Construct a {@code DualState} instance with a reference to the Java
 	 * object whose state it represents.
@@ -123,9 +130,7 @@ public abstract class DualState<T> extends WeakReference<T>
 	{
 		super(referent, s_releasedInstances);
 
-		if ( ! (cookie instanceof Key) )
-			throw new UnsupportedOperationException(
-				"Constructing DualState instance without cookie");
+		checkCookie(cookie);
 
 		m_resourceOwner = resourceOwner;
 		s_liveInstances.add(this);

--- a/pljava/src/main/java/org/postgresql/pljava/internal/DualState.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/DualState.java
@@ -1,0 +1,304 @@
+/*
+ * Copyright (c) 2018 Tada AB and other contributors, as listed below.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Chapman Flack
+ */
+package org.postgresql.pljava.internal;
+
+import java.lang.ref.ReferenceQueue;
+import java.lang.ref.WeakReference;
+
+import java.sql.SQLException;
+
+import java.util.Deque;
+import java.util.Iterator;
+import java.util.concurrent.LinkedBlockingDeque;
+
+/**
+ * Base class for object state with corresponding Java and native components.
+ *<p>
+ * A {@code DualState} object connects some state that exists in the JVM
+ * as well as some native/PostgreSQL resources. It will 'belong' to some Java
+ * object that holds a strong reference to it, and this state object is,
+ * in turn, a {@link WeakReference} to that object. Java state may be held in
+ * that object (if it needs only to be freed by the garbage collector when
+ * unreachable), or in this object if it needs some more specific cleanup.
+ * Native state will be referred to by this object.
+ *<p>
+ * These interesting events are possible in the life cycle of a
+ * {@code DualState} object:
+ * <ul>
+ * <li>It is explicitly closed by the Java code using it. It, and any associated
+ * native state, should be released.</li>
+ * <li>It is found unreachable by the Java garbage collector. Again, any
+ * associated state should be released.</li>
+ * <li>Its associated native state is released or invalidated (such as by exit
+ * of a corresponding context). If the object is still reachable from Java, it
+ * must be marked to throw an exception for any future attempted access to its
+ * native state.</li>
+ * </ul>
+ *<p>
+ * The introduction of this class represents <em>yet another</em> pattern
+ * within PL/Java for objects that combine Java and native state. It is meant
+ * to be general (and documented) enough to support future gradual migration of
+ * other existing patterns to it.
+ *<p>
+ * A parameter to the {@code DualState} constructor is a {@code ResourceOwner},
+ * a PostgreSQL implementation concept introduced in PG 8.0. Instances will be
+ * called at their {@link #nativeStateReleased nativeStateReleased} methods
+ * when the corresponding {@code ResourceOwner} is released in PostgreSQL.
+ *<p>
+ * Instances will be enqueued on a {@link ReferenceQueue} when found by the Java
+ * garbage collector to be unreachable. The
+ * {@link #cleanEnqueuedInstances cleanEnqueuedInstances} static method will
+ * call those instances at their
+ * {@link #javaStateUnreachable javaStateUnreachable} methods if the weak
+ * reference has already been cleared by the garbage collector. The method
+ * should clean up any lingering native state.
+ *<p>
+ * As the native cleanup is likely to involve calls into PostgreSQL, to reduce
+ * thread contention, {@code cleanEnqueuedInstances} should be called in one or
+ * more likely places from a thread already known to be entering/exiting Java
+ * from/to PostgreSQL.
+ *<p>
+ * If convenient, explicit close actions from Java can be handled similarly,
+ * by having the close method call {@link #enqueue enqueue}, and providing a
+ * {@link #javaStateReleased javaStateReleased} method, which will be called by
+ * {@code cleanEnqueuedInstances} if the weak reference is nonnull, indicating
+ * the instance was enqueued explicitly rather than by the garbage collector.
+ */
+public abstract class DualState<T> extends WeakReference<T>
+{
+	/**
+	 * {@code DualState} objects Java no longer needs.
+	 *<p>
+	 * They will turn up on this queue (with referent already set null) if
+	 * the garbage collector has determined them to be unreachable. They can
+	 * also arrive here (with referent <em>not</em> yet set null) if some Java
+	 * method (such as a {@code close} or {@code free} has called
+	 * {@code enqueue}; whether the referent is null allows the cases to be
+	 * distinguished.
+	 *<p>
+	 * The queue is only processed by a private method called from native code
+	 * in selected places where it makes sense to do so.
+	 */
+	private static ReferenceQueue<Object> s_releasedInstances =
+		new ReferenceQueue<Object>();
+
+	/**
+	 * All instances are added to this collection upon creation.
+	 */
+	private static Deque<DualState> s_liveInstances =
+		new LinkedBlockingDeque<DualState>();
+
+	/**
+	 * Pointer value of the {@code ResourceOwner} this instance belongs to,
+	 * if any.
+	 */
+	private final long m_resourceOwner;
+
+	/**
+	 * Construct a {@code DualState} instance with a reference to the Java
+	 * object whose state it represents.
+	 *<p>
+	 * Subclass constructors must accept a <em>cookie</em> parameter from the
+	 * native caller, and pass it along to superclass constructors. That allows
+	 * some confidence that constructor parameters representing native values
+	 * are for real, and also that the construction is taking place on a thread
+	 * holding the native lock, keeping the concurrency story simple.
+	 * @param cookie Capability held by native code to invoke {@code DualState}
+	 * constructors.
+	 * @param referent The Java object whose state this instance represents.
+	 * @param resourceOwner Pointer value of the native {@code ResourceOwner}
+	 * whose release callback will indicate that this object's native state is
+	 * no longer valid.
+	 */
+	protected DualState(Key cookie, T referent, long resourceOwner)
+	{
+		super(referent, s_releasedInstances);
+
+		if ( ! (cookie instanceof Key) )
+			throw new UnsupportedOperationException(
+				"Constructing DualState instance without cookie");
+
+		m_resourceOwner = resourceOwner;
+		s_liveInstances.add(this);
+	}
+
+	/**
+	 * Return {@code true} if the native state is still valid. An abstract
+	 * method so it can be tailored to whatever native state is maintained
+	 * by an implementing class.
+	 */
+	protected abstract boolean nativeStateIsValid();
+
+	/**
+	 * Method that will be called when the associated {@code ResourceOwner}
+	 * is released, indicating that the native portion of the state
+	 * is no longer valid. The implementing class should clean up
+	 * whatever is appropriate to that event, and must ensure that
+	 * {@code nativeStateIsValid} will thereafter return {@code false}.
+	 *<p>
+	 * This object's monitor will always be held when this method is called
+	 * during resource owner release. The class whose state this is must
+	 * synchronize and hold this object's monitor for the duration of any
+	 * operation that could refer to the native state.
+	 */
+	protected abstract void nativeStateReleased();
+
+	/**
+	 * Method that will be called when the Java garbage collector has determined
+	 * the referent object is no longer strongly reachable. This default
+	 * implementation does nothing; a subclass should override it to do any
+	 * cleanup, or release of native resources, that may be required.
+	 *<p>
+	 * It is not necessary for this method to remove the instance from the
+	 * {@code liveInstances} collection; that will have been done just before
+	 * this method is called.
+	 */
+	protected void javaStateUnreachable()
+	{
+	}
+
+	/**
+	 * Method that can be called to indicate that Java code has explicitly
+	 * released the instance (for example, through calling a {@code close}
+	 * method on the referent object). This can be handled two ways:
+	 *<ul>
+	 * <li>A {@code close} or similar method calls this directly. This instance
+	 * must be removed from the {@code liveInstances} collection. This default
+	 * implementation does so.
+	 * <li>A {@code close} or similar method simply calls
+	 * {@link #enqueue enqueue} instead of this method. This method will be
+	 * called when the queue is processed, the next time native code calls
+	 * {@link #clearEnqueuedInstances clearEnqueuedInstances}. For that case,
+	 * this method should be overridden to do whatever other cleanup is in
+	 * order, but <em>not</em> remove the instance from {@code liveInstances},
+	 * which will have happened just before this method is called.
+	 *</ul>
+	 */
+	protected void javaStateReleased()
+	{
+		s_liveInstances.remove(this);
+	}
+
+	/**
+	 * Throw an {@code SQLException} with a specified message and SQLSTATE code
+	 * if {@code nativeStateIsValid} returns {@code false}.
+	 */
+	public void assertNativeStateIsValid(String message, String sqlState)
+	throws SQLException
+	{
+		if ( ! nativeStateIsValid() )
+			throw new SQLException(message, sqlState);
+	}
+
+	/**
+	 * Throw an {@code SQLException} with a specified message and SQLSTATE code
+	 * of 55000 "object not in prerequisite state" if {@code nativeStateIsValid}
+	 * returns {@code false}.
+	 */
+	public void assertNativeStateIsValid(String message)
+	throws SQLException
+	{
+		assertNativeStateIsValid(message, "55000");
+	}
+
+	/**
+	 * Throw an {@code SQLException} with a default message and SQLSTATE code
+	 * of 55000 "object not in prerequisite state" if {@code nativeStateIsValid}
+	 * returns {@code false}.
+	 */
+	public void assertNativeStateIsValid()
+	throws SQLException
+	{
+		if ( ! nativeStateIsValid() )
+		{
+			Object referent = get();
+			String message;
+			if ( null != referent )
+				message = referent.getClass().getName();
+			else
+				message = getClass().getName();
+			message += " used beyond its PostgreSQL lifetime";
+			throw new SQLException(message, "55000");
+		}
+	}
+
+	/**
+	 * Called only from native code by the {@code ResourceOwner} callback when a
+	 * resource owner is being released. Must identify the live instances that
+	 * have been registered to that owner, if any, and call their
+	 * {@link #nativeStateReleased nativeStateReleased} methods.
+	 * @param resourceOwner Pointer value identifying the resource owner being
+	 * released. Calls can be received for resource owners to which no instances
+	 * here have been registered.
+	 */
+	private static void resourceOwnerRelease(long resourceOwner)
+	{
+		for ( Iterator<DualState> i = s_liveInstances.iterator();
+			  i.hasNext(); )
+		{
+			DualState s = i.next();
+			if ( s.m_resourceOwner == resourceOwner )
+			{
+				i.remove();
+				synchronized ( s )
+				{
+					s.nativeStateReleased();
+				}
+			}
+		}
+	}
+
+	/**
+	 * Called only from native code, at points where checking the
+	 * freed/unreachable objects queue would be useful. Calls the
+	 * {@link #javaStateUnreachable javaStateUnreachable} method for instances
+	 * that were cleared and enqueued by the garbage collector; calls the
+	 * {@link #javaStateReleased javaStateReleased} method for instances that
+	 * have not yet been garbage collected, but were enqueued by Java code
+	 * explicitly calling {@link #enqueue enqueue}.
+	 */
+	private static void cleanEnqueuedInstances()
+	{
+		DualState s;
+		while ( null != (s = (DualState)s_releasedInstances.poll()) )
+		{
+			s_liveInstances.remove(s);
+			try
+			{
+				if ( null == s.get() )
+					s.javaStateUnreachable();
+				else
+					s.javaStateReleased();
+			}
+			catch ( Throwable t ) { } /* JDK 9 Cleaner ignores exceptions, so */
+		}
+	}
+
+	/**
+	 * Magic cookie needed as a constructor parameter to confirm that
+	 * {@code DualState} subclass instances are being constructed from
+	 * native code.
+	 */
+	public static final class Key
+	{
+		private static boolean constructed = false;
+		private Key()
+		{
+			synchronized ( Key.class )
+			{
+				if ( constructed )
+					throw new IllegalStateException("Duplicate DualState.Key");
+				constructed = true;
+			}
+		}
+	}
+}

--- a/pljava/src/main/java/org/postgresql/pljava/internal/DualState.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/DualState.java
@@ -301,4 +301,90 @@ public abstract class DualState<T> extends WeakReference<T>
 			}
 		}
 	}
+
+	/**
+	 * A {@code DualState} subclass whose only native resource releasing action
+	 * needed is {@code pfree} of a single pointer.
+	 */
+	public static abstract class SinglePfree<T> extends DualState<T>
+	{
+		private volatile long m_pointer;
+
+		protected SinglePfree(
+			Key cookie, T referent, long resourceOwner, long pfreeTarget)
+		{
+			super(cookie, referent, resourceOwner);
+			m_pointer = pfreeTarget;
+		}
+
+		/**
+		 * For this class, the native state is valid whenever the wrapped
+		 * pointer is not null.
+		 */
+		@Override
+		protected boolean nativeStateIsValid()
+		{
+			return 0 != m_pointer;
+		}
+
+		/**
+		 * When the native state is released, the wrapped pointer is nulled
+		 * to indicate the state is no longer valid; no {@code pfree} call is
+		 * made, on the assumption that the resource owner's release will be
+		 * followed by wholesale release of the containing memory context
+		 * anyway.
+		 */
+		@Override
+		protected void nativeStateReleased()
+		{
+			m_pointer = 0;
+		}
+
+		/**
+		 * When the Java state is released, the wrapped pointer is nulled to
+		 * indicate the state is no longer valid, <em>and</em> a {@code pfree}
+		 * call is made so the native memory is released without having to wait
+		 * for release of its containing context.
+		 *<p>
+		 * This overrides the inherited default, which would have removed this
+		 * instance from the live instances collection. Users of this class
+		 * should not call this method directly, but simply call
+		 * {@link #enqueue enqueue}, and let the reclamation happen when the
+		 * queue is processed.
+		 */
+		@Override
+		protected void javaStateReleased()
+		{
+			synchronized(Backend.THREADLOCK)
+			{
+				long p = m_pointer;
+				m_pointer = 0;
+				if ( 0 != p )
+					_pfree(p);
+			}
+		}
+
+		/**
+		 * This override simply calls
+		 * {@link #javaStateReleased javaStateReleased}, so there is no
+		 * difference in the effect of the Java object being explicitly
+		 * released, or found unreachable by the garbage collector.
+		 */
+		@Override
+		protected void javaStateUnreachable()
+		{
+			javaStateReleased();
+		}
+
+		/**
+		 * Allows a subclass to obtain the wrapped pointer value.
+		 */
+		protected long getPointer() throws SQLException
+		{
+			assertNativeStateIsValid();
+			return m_pointer;
+		}
+
+		private native void _pfree(long pointer);
+	}
 }

--- a/pljava/src/main/java/org/postgresql/pljava/internal/DualState.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/DualState.java
@@ -103,6 +103,9 @@ public abstract class DualState<T> extends WeakReference<T>
 	 */
 	private final long m_resourceOwner;
 
+	/**
+	 * Check that a cookie is valid, throwing an unchecked exception otherwise.
+	 */
 	protected static void checkCookie(Key cookie)
 	{
 		if ( ! Key.class.isInstance(cookie) )
@@ -182,7 +185,7 @@ public abstract class DualState<T> extends WeakReference<T>
 	 * <li>A {@code close} or similar method simply calls
 	 * {@link #enqueue enqueue} instead of this method. This method will be
 	 * called when the queue is processed, the next time native code calls
-	 * {@link #clearEnqueuedInstances clearEnqueuedInstances}. For that case,
+	 * {@link #cleanEnqueuedInstances cleanEnqueuedInstances}. For that case,
 	 * this method should be overridden to do whatever other cleanup is in
 	 * order, but <em>not</em> remove the instance from {@code liveInstances},
 	 * which will have happened just before this method is called.
@@ -236,10 +239,47 @@ public abstract class DualState<T> extends WeakReference<T>
 		}
 	}
 
+	/**
+	 * Produce a string describing this state object in a way useful for
+	 * debugging, with such information as the associated {@code ResourceOwner}
+	 * and whether the state is fresh or stale.
+	 *<p>
+	 * This method calls {@link #toString(Object)} passing {@code this}.
+	 * Subclasses are encouraged to override that method with versions that add
+	 * subclass-specific details.
+	 * @return Description of this state object.
+	 */
 	@Override
 	public String toString()
 	{
-		return String.format("DualState owner:%x %s", m_resourceOwner,
+		return toString(this);
+	}
+
+	/**
+	 * Produce a string with such details of this object as might be useful for
+	 * debugging, starting with an abbreviated form of the class name of the
+	 * supplied object.
+	 *<p>
+	 * Subclasses are encouraged to override this and then call it, via super,
+	 * passing the object unchanged, and then append additional
+	 * subclass-specific details to the result.
+	 *<p>
+	 * Because the recursion ends here, this one actually does construct the
+	 * abbreviated form of the class name of the object, and use it at the start
+	 * of the returned string.
+	 * @param o An object whose class name (abbreviated by stripping the package
+	 * prefix) will be used at the start of the string. Passing {@code null} is
+	 * the same as passing {@code this}.
+	 * @return Description of this state object, prefixed with the abbreviated
+	 * class name of the passed object.
+	 */
+	public String toString(Object o)
+	{
+		Class<?> c = (null == o ? this : o).getClass();
+		String cn = c.getCanonicalName();
+		int pnl = c.getPackage().getName().length();
+		return String.format("%s owner:%x %s",
+			cn.substring(1 + pnl), m_resourceOwner,
 			nativeStateIsValid() ? "fresh" : "stale");
 	}
 
@@ -330,9 +370,9 @@ public abstract class DualState<T> extends WeakReference<T>
 		}
 
 		@Override
-		public String toString()
+		public String toString(Object o)
 		{
-			return String.format("%s pfree(%x)", super.toString(), m_pointer);
+			return String.format("%s pfree(%x)", super.toString(o), m_pointer);
 		}
 
 		/**
@@ -410,7 +450,7 @@ public abstract class DualState<T> extends WeakReference<T>
 	 * A {@code DualState} subclass whose only native resource releasing action
 	 * needed is {@code MemoryContextDelete} of a single context.
 	 *<p>
-	 * This class may get called at the {@code nativeStateReleased) entry, not
+	 * This class may get called at the {@code nativeStateReleased} entry, not
 	 * only if the native state is actually being released, but if it is being
 	 * 'claimed' by native code for its own purposes. The effect is the same
 	 * as far as Java is concerned; the object is no longer accessible, and the
@@ -428,10 +468,10 @@ public abstract class DualState<T> extends WeakReference<T>
 		}
 
 		@Override
-		public String toString()
+		public String toString(Object o)
 		{
-			return String.format("%s MemoryContextDelete(%x)", super.toString(),
-								 m_context);
+			return String.format("%s MemoryContextDelete(%x)",
+				super.toString(o), m_context);
 		}
 
 		/**

--- a/pljava/src/main/java/org/postgresql/pljava/internal/InstallHelper.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/InstallHelper.java
@@ -12,6 +12,7 @@
 package org.postgresql.pljava.internal;
 
 import java.io.InputStream;
+import java.nio.charset.Charset;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.DriverManager;
@@ -100,6 +101,21 @@ public class InstallHelper
 		System.clearProperty(orderKey);
 		System.clearProperty(orderKey + ".scalar");
 		System.clearProperty(orderKey + ".mirror");
+
+		String encodingKey = "org.postgresql.server.encoding";
+		String encName = System.getProperty(encodingKey);
+		if ( null == encName )
+			encName = Backend.getConfigOption( "server_encoding");
+		try
+		{
+			Charset cs = Charset.forName(encName);
+			org.postgresql.pljava.internal.Session.s_serverCharset = cs; // poke
+			System.setProperty(encodingKey, cs.name());
+		}
+		catch ( IllegalArgumentException iae )
+		{
+			System.clearProperty(encodingKey);
+		}
 
 		/*
 		 * Construct the strings announcing the versions in use.

--- a/pljava/src/main/java/org/postgresql/pljava/internal/MarkableSequenceInputStream.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/MarkableSequenceInputStream.java
@@ -1,4 +1,4 @@
-package org.postgresql.pljava.jdbc;
+package org.postgresql.pljava.internal;
 
 import java.io.InputStream;
 import java.io.SequenceInputStream;

--- a/pljava/src/main/java/org/postgresql/pljava/internal/Session.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/Session.java
@@ -6,6 +6,8 @@
  */
 package org.postgresql.pljava.internal;
 
+import java.nio.charset.Charset;
+
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -27,6 +29,31 @@ import org.postgresql.pljava.jdbc.SQLUtils;
 public class Session implements org.postgresql.pljava.Session
 {
 	private final TransactionalMap m_attributes = new TransactionalMap(new HashMap());
+
+	/**
+	 * The Java charset corresponding to the server encoding, or null if none
+	 * such was found. Put here by InstallHelper via package access at startup.
+	 */
+	static Charset s_serverCharset;
+
+	/**
+	 * A static method (not part of the API-exposed Session interface) by which
+	 * pljava implementation classes can get hold of the server charset without
+	 * the indirection of getting a Session instance. If there turns out to be
+	 * demand for client code to obtain it through the API, an interface method
+	 * {@code serverCharset} can easily be added later.
+	 * @return The Java Charset corresponding to the server's encoding, or null
+	 * if no matching Java charset was found. That can happen if a corresponding
+	 * Java charset really does exist but is not successfully found using the
+	 * name reported by PostgreSQL. That can be worked around by giving the
+	 * right name explicitly as the system property
+	 * {@code org.postgresql.server.encoding} in {@code pljava.vmoptions} for
+	 * the affected database (or cluster-wide, if the same encoding is used).
+	 */
+	public static Charset implServerCharset()
+	{
+		return s_serverCharset;
+	}
 
 	/**
 	 * Adds the specified listener to the list of listeners that will

--- a/pljava/src/main/java/org/postgresql/pljava/internal/VarlenaWrapper.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/VarlenaWrapper.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2018 Tada AB and other contributors, as listed below.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Chapman Flack
+ */
+package org.postgresql.pljava.internal;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import java.nio.ByteBuffer;
+
+import java.sql.SQLException;
+
+public interface VarlenaWrapper
+{
+	/**
+	 * A class by which Java reads the content of a varlena as an InputStream.
+	 *
+	 * Associated with a {@code ResourceOwner} to bound the lifetime of
+	 * the native reference; the chosen resource owner must be one that will be
+	 * released no later than the memory context containing the varlena.
+	 */
+	public static class Input extends InputStream
+	{
+		private State m_state;
+		private boolean m_open = true;
+
+		/**
+		 * Construct a {@code VarlenaWrapper.Input}.
+		 * @param cookie Capability held by native code.
+		 * @param resourceOwner Resource owner whose release will indicate that the
+		 * underlying varlena is no longer valid.
+		 * @param varlenaPtr Pointer value to the underlying varlena, to be
+		 * {@code pfree}d when Java code closes or reclaims this object.
+		 * @param buf Readable direct {@code ByteBuffer} constructed over the
+		 * varlena's data bytes.
+		 */
+		private Input(DualState.Key cookie, long resourceOwner,
+			long varlenaPtr, ByteBuffer buf)
+		{
+			m_state = new State(
+				cookie, this, resourceOwner, varlenaPtr, buf.asReadOnlyBuffer());
+		}
+
+		private ByteBuffer buf() throws IOException
+		{
+			if ( ! m_open )
+				throw new IOException("Read from closed VarlenaWrapper");
+			try
+			{
+				return m_state.buffer();
+			}
+			catch ( SQLException sqe )
+			{
+				throw new IOException("Read from varlena failed", sqe);
+			}
+		}
+
+		@Override
+		public int read() throws IOException
+		{
+			synchronized ( m_state )
+			{
+				ByteBuffer src = buf();
+				if ( 0 < src.remaining() )
+					return src.get();
+				return -1;
+			}
+		}
+
+		@Override
+		public int read(byte[] b, int off, int len) throws IOException
+		{
+			synchronized ( m_state )
+			{
+				ByteBuffer src = buf();
+				int has = src.remaining();
+				if ( len > has )
+				{
+					if ( 0 == has )
+						return -1;
+					len = has;
+				}
+				src.get(b, off, len);
+				return len;
+			}
+		}
+
+		@Override
+		public long skip(long n) throws IOException
+		{
+			synchronized ( m_state )
+			{
+				ByteBuffer src = buf();
+				int has = src.remaining();
+				if ( n > has )
+					n = has;
+				src.position(src.position() + (int)n);
+				return n;
+			}
+		}
+
+		@Override
+		public int available() throws IOException
+		{
+			synchronized ( m_state )
+			{
+				return buf().remaining();
+			}
+		}
+
+		@Override
+		public void close() throws IOException
+		{
+			synchronized ( m_state )
+			{
+				if ( ! m_open )
+					return;
+				m_open = false;
+				m_state.enqueue();
+			}
+		}
+
+
+
+		private static class State extends DualState.SinglePfree<Input>
+		{
+			private ByteBuffer m_buf;
+
+			private State(
+				DualState.Key cookie, Input vr, long resourceOwner,
+				long varlenaPtr, ByteBuffer buf)
+			{
+				super(cookie, vr, resourceOwner, varlenaPtr);
+				m_buf = buf;
+			}
+
+			private ByteBuffer buffer() throws SQLException
+			{
+				assertNativeStateIsValid();
+				return m_buf;
+			}
+
+			@Override
+			protected void nativeStateReleased()
+			{
+				m_buf = null;
+				super.nativeStateReleased();
+			}
+
+			@Override
+			protected void javaStateReleased()
+			{
+				m_buf = null;
+				super.javaStateReleased();
+			}
+		}
+	}
+}

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/AbstractResultSet.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/AbstractResultSet.java
@@ -168,22 +168,6 @@ public abstract class AbstractResultSet implements ResultSet
 		return this.getObject(this.findColumn(columnName), map);
 	}
 
-  public <T> T getObject(int columnIndex, Class<T> type)
-	throws SQLException
-	{
-		final Object obj = getObject( columnIndex );
-    if ( obj.getClass().equals( type ) ) return (T) obj;
-    throw new SQLException( "Cannot convert " + obj.getClass().getName() + " to " + type );
-	}
-
-  public <T> T getObject(String columnName, Class<T> type)
-	throws SQLException
-	{
-		final Object obj = getObject( columnName );
-    if ( obj.getClass().equals( type ) ) return (T) obj;
-    throw new SQLException( "Cannot convert " + obj.getClass().getName() + " to " + type );
-	}
-
 	public Ref getRef(String columnName)
 	throws SQLException
 	{
@@ -769,5 +753,32 @@ public abstract class AbstractResultSet implements ResultSet
 	{
 		throw new SQLFeatureNotSupportedException( this.getClass() +
 			".getRowId( String ) not implemented yet.", "0A000" );
+	}
+
+	// ************************************************************
+	// Implementation of JDBC 4.1 methods. These are half-baked at
+	// the moment: the type parameter isn't able to /influence/
+	// what type is returned, but only to fail if what gets
+	// returned by default isn't that.
+	// ************************************************************
+
+	public <T> T getObject(int columnIndex, Class<T> type)
+	throws SQLException
+	{
+		final Object obj = getObject( columnIndex );
+		if ( type.isInstance(obj) )
+			return type.cast(obj);
+		throw new SQLException( "Cannot convert " + obj.getClass().getName() +
+			" to " + type );
+	}
+
+	public <T> T getObject(String columnName, Class<T> type)
+	throws SQLException
+	{
+		final Object obj = getObject( columnName );
+		if ( type.isInstance(obj) )
+			return type.cast(obj);
+		throw new SQLException( "Cannot convert " + obj.getClass().getName() +
+			" to " + type );
 	}
 }

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/AbstractResultSet.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/AbstractResultSet.java
@@ -393,6 +393,30 @@ public abstract class AbstractResultSet implements ResultSet
 		  "0A000" );
 	}
 
+	public void updateSQLXML(int columnIndex, SQLXML xmlObject)
+	throws SQLException
+	{
+		updateObject(columnIndex, xmlObject);
+	}
+
+	public void updateSQLXML(String columnLabel, SQLXML xmlObject)
+	throws SQLException
+	{
+		updateObject(columnLabel, xmlObject);
+	}
+
+	public SQLXML getSQLXML(int columnIndex)
+	throws SQLException
+	{
+		return (SQLXML)getObject(columnIndex);
+	}
+
+	public SQLXML getSQLXML(String columnLabel)
+	throws SQLException
+	{
+		return (SQLXML)getObject(columnLabel);
+	}
+
 	// ************************************************************
 	// Non-implementation of JDBC 4 methods.
 	// ************************************************************
@@ -664,36 +688,6 @@ public abstract class AbstractResultSet implements ResultSet
 		throw new SQLFeatureNotSupportedException( this.getClass() +
 			".getNString( String ) not implemented yet.", 
 							   "0A000" );
-	}
-
-	public void updateSQLXML(int columnIndex, SQLXML xmlObject)
-	throws SQLException
-	{
-		throw new SQLFeatureNotSupportedException( this.getClass() +
-			".updateSQLXML( int, SQLXML ) not implemented yet.", 
-							   "0A000" );
-	}
-
-	public void updateSQLXML(String columnLabel, SQLXML xmlObject)
-	throws SQLException
-	{
-		throw new SQLFeatureNotSupportedException( this.getClass() +
-			".updateSQLXML( String, SQLXML ) not implemented yet.",
-							   "0A000" );
-	}
-
-	public SQLXML getSQLXML(int columnIndex)
-	throws SQLException
-	{
-		throw new SQLFeatureNotSupportedException( this.getClass() +
-			".getSQLXML( int ) not implemented yet.", "0A000" );
-	}
-
-	public SQLXML getSQLXML(String columnLabel)
-	throws SQLException
-	{
-		throw new SQLFeatureNotSupportedException( this.getClass() +
-			".getSQLXML( String ) not implemented yet.", "0A000" );
 	}
 
 	public NClob getNClob(String columnLabel)

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/MarkableSequenceInputStream.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/MarkableSequenceInputStream.java
@@ -4,6 +4,15 @@ import java.io.InputStream;
 import java.io.SequenceInputStream;
 import java.io.IOException;
 
+import java.lang.reflect.UndeclaredThrowableException;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.ListIterator;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CancellationException;
+
 /**
  * Version of {@link SequenceInputStream} that supports
  * {@code mark} and {@code reset}, to the extent its constituent input streams
@@ -27,9 +36,19 @@ import java.io.IOException;
  */
 public class MarkableSequenceInputStream extends InputStream
 {
-	private InputStream[] m_streams;
-	private int m_activeStream;
-	private int m_markedStream;
+	/**
+	 * A sentinel value, needed because a {@code BlockingQueue} does not allow
+	 * a null value to be enqueued.
+	 */
+	public static final InputStream NO_MORE = new InputStream()
+	{
+		@Override public int read() { return -1; }
+	};
+
+	private boolean m_closed = false;
+	private InputStream m_markedStream = null;
+
+	private ListIterator<InputStream> m_streams;
 	private int m_readlimit_orig;
 	private int m_readlimit_curr;
 	private boolean m_markSupported;
@@ -47,47 +66,77 @@ public class MarkableSequenceInputStream extends InputStream
 	{
 		if ( null == streams )
 			throw new NullPointerException("MarkableSequenceInputStream(null)");
+		LinkedList<InputStream> isl = new LinkedList<InputStream>();
 		for ( InputStream s : streams )
+		{
 			if ( null == s )
 				throw new NullPointerException(
 					"MarkableSequenceInputStream(..., null, ...)");
-
-		m_streams = streams;
-		m_activeStream = 0;		/* -1 will mean closed */
-		m_markedStream = -1;	/* -1 will mean no mark has been set */
+			isl.add(s);
+		}
+		m_streams =  isl.listIterator();
 	}
 
+	/**
+	 * A {@code MarkableSequenceInputStream} that will receive streams to read,
+	 * in order, over a {@code BlockingQueue}.
+	 *<p>
+	 * The thread supplying the queue should enqueue the value {@link #NO_MORE}
+	 * following the last actual {@code InputStream} to read. (The sentinel is
+	 * needed because a {@code BlockingQueue} does not allow null values.)
+	 * @param queue Source of input streams to read.
+	 * @throws NullPointerException if {@code queue} is {@code null}.
+	 */
+	public MarkableSequenceInputStream(BlockingQueue<InputStream> queue)
+	{
+		m_streams =
+			new FetchingListIterator(
+				new LinkedList<InputStream>(), queue, NO_MORE);
+	}
+
+	/*
+	 * This method depends on an invariant: the iterator's next() method, when
+	 * called here, will return the current, active stream. Each consumer method
+	 * is responsible for preserving that invariant by calling previous() once
+	 * after obtaining, but not hitting EOF on, a stream from next().
+	 */
 	private InputStream currentStream() throws IOException
 	{
-		if ( -1 == m_activeStream )
+		if ( m_closed )
 			throw new IOException("I/O on closed InputStream");
-		if ( m_streams.length == m_activeStream )
-			return null;
-		return m_streams[m_activeStream];
+		if ( m_streams.hasNext() )
+			return m_streams.next();
+		return null;
 	}
 
+	/*
+	 * The invariant here is that a "current" stream was recently obtained, and
+	 * can be re-obtained with previous(). This should not be called unless
+	 * there is nothing left to read from that stream.
+	 */
 	private InputStream nextStream() throws IOException
 	{
-		assert m_streams.length > m_activeStream;
-		assert -1 == m_streams[m_activeStream].read();
-
-		if ( -1 == m_markedStream )
+		if ( null == m_markedStream )
 		{
-			m_streams[m_activeStream].close();
-			m_streams[m_activeStream++] = null;
+			m_streams.previous().close();
+			assert ! m_streams.hasPrevious();
+			m_streams.remove();
+			if ( m_streams.hasNext() )
+				return m_streams.next();
 		}
-		else if ( m_streams.length > ++m_activeStream )
-			m_streams[m_activeStream].mark(m_readlimit_curr);
-
-		if ( m_streams.length == m_activeStream )
-			return null;
-		return m_streams[m_activeStream];
+		else if ( m_streams.hasNext() )
+		{
+			InputStream is = m_streams.next();
+			is.mark(m_readlimit_curr);
+			return is;
+		}
+		return null;
 	}
 
 	private void decrementLimit(long bytes)
 	{
 		assert 0 < bytes;
-		if ( -1 == m_markedStream )
+		if ( null == m_markedStream )
 			return;
 		if ( bytes < m_readlimit_curr )
 		{
@@ -108,6 +157,7 @@ public class MarkableSequenceInputStream extends InputStream
 				if ( -1 != c )
 				{
 					decrementLimit(1);
+					m_streams.previous(); /* maintain "current" invariant */
 					return c;
 				}
 			}
@@ -126,6 +176,7 @@ public class MarkableSequenceInputStream extends InputStream
 				if ( -1 != rslt )
 				{
 					decrementLimit(rslt);
+					m_streams.previous(); /* maintain "current" invariant */
 					return rslt;
 				}
 			}
@@ -148,7 +199,10 @@ public class MarkableSequenceInputStream extends InputStream
 				decrementLimit(skipped);
 				totalSkipped += skipped;
 				if ( 0 >= n )
+				{
+					m_streams.previous(); /* maintain "current" invariant */
 					break;
+				}
 				/*
 				 * A short count from skip doesn't have to mean EOF was reached.
 				 * A read() will settle that question, though.
@@ -174,10 +228,13 @@ public class MarkableSequenceInputStream extends InputStream
 	{
 		synchronized ( this )
 		{
-			if ( -1 == m_activeStream )
+			if ( m_closed )
 				return 0;
 			InputStream s = currentStream();
-			return null == s ? 0 : s.available();
+			if ( null == s )
+				return 0;
+			m_streams.previous(); /* maintain "current" invariant */
+			return s.available();
 		}
 	}
 
@@ -186,14 +243,14 @@ public class MarkableSequenceInputStream extends InputStream
 	{
 		synchronized ( this )
 		{
-			if ( -1 == m_activeStream )
+			if ( m_closed )
 				return;
-			if ( -1 != m_markedStream )
-				m_activeStream = m_markedStream;
-			for ( ; m_streams.length > m_activeStream ; ++ m_activeStream )
-				m_streams[m_activeStream].close();
-			m_activeStream = -1;
+			while ( m_streams.hasPrevious() )
+				m_streams.previous();
+			while ( m_streams.hasNext() )
+				m_streams.next().close();
 			m_streams = null;
+			m_closed = true;
 		}
 	}
 
@@ -208,38 +265,61 @@ public class MarkableSequenceInputStream extends InputStream
 	{
 		synchronized ( this )
 		{
-			if ( -1 == m_activeStream )
+			if ( m_closed )
 				return;
 
-			if ( -1 == m_markedStream )
-				m_markedStream = m_activeStream;
-			else
+			InputStream activeStream = null;
+			if ( m_streams.hasNext() )
 			{
-				for ( ; m_markedStream < m_activeStream ; ++ m_markedStream )
+				m_streams.next();
+				activeStream = m_streams.previous();
+			}
+
+			if ( null != m_markedStream )
+			{
+				for ( InputStream is = activeStream; is != m_markedStream; )
+					is = m_streams.previous();
+				/*
+				 * Whether the above loop executed zero or more times, the last
+				 * event on m_streams was a previous(), and returned the marked
+				 * stream, and the next next() will also.
+				 */
+				m_markedStream = null; // so nextStream() will close things
+				/*
+				 * It is safe to start off this loop with next(), because it
+				 * will return the formerly marked stream, known to exist.
+				 */
+				for ( InputStream is = m_streams.next(); is != activeStream; )
 				{
 					try
 					{
-						m_streams[m_markedStream].close();
+						is = nextStream(); // will close stream and return next
 					}
 					catch ( IOException e )
 					{
+						throw new UndeclaredThrowableException(e);
 					}
-					m_streams[m_markedStream] = null;
 				}
+				/*
+				 * Leave the invariant the same whether this if block was taken
+				 * or not.
+				 */
+				if ( null != activeStream )
+					m_streams.previous();
 			}
 
 			if ( 0 >= readlimit )			/* setting instantly-invalid mark */
 			{
 				m_readlimit_curr = m_readlimit_orig = 0;
-				m_markedStream = -1;
 				return;
 			}
 			m_readlimit_curr = m_readlimit_orig = readlimit;
 
-			if ( m_streams.length == m_markedStream )  /* setting mark at EOF */
+			if ( null == activeStream )  /* setting mark at EOF */
 				return;
 
-			m_streams[m_markedStream].mark(readlimit);
+			m_markedStream = activeStream;
+			activeStream.mark(readlimit);
 		}
 	}
 
@@ -248,19 +328,38 @@ public class MarkableSequenceInputStream extends InputStream
 	{
 		synchronized ( this )
 		{
-			if ( -1 == m_activeStream )
+			if ( m_closed )
 				throw new IOException("reset on closed InputStream");
-			if ( -1 == m_markedStream )
+
+			if ( null == m_markedStream )
+			{
+				if ( 0 < m_readlimit_orig )
+					return; // the mark-at-EOF case; reset allowed, no effect
 				throw new IOException("reset without mark");
+			}
+
+			InputStream is = currentStream();
+			/*
+			 * 'is' right now is the active stream, or null if we are at EOF;
+			 * either way the first call to previous() coming up below will
+			 * return an existing stream, the one we need (in reverse order)
+			 * to reset first.
+			 */
+
 			while ( true )
 			{
-				if ( m_streams.length > m_activeStream )
-					m_streams[m_activeStream].reset();
-				if ( m_activeStream == m_markedStream )
+				is = m_streams.previous();
+				is.reset();
+				if ( is == m_markedStream )
 					break;
-				-- m_activeStream;
+				is.mark(0); // release possible resources
 			}
 			m_readlimit_curr = m_readlimit_orig;
+			/*
+			 * The invariant (that the next next() will return the stream we
+			 * just touched) is already satisfied, as we obtained it with
+			 * previous() above.
+			 */
 		}
 	}
 
@@ -284,19 +383,135 @@ public class MarkableSequenceInputStream extends InputStream
 		{
 			if ( m_markSupported_determined )
 				return m_markSupported;
-			int i = m_markedStream;
-			if ( -1 == i )
-				i = m_activeStream;
-			if ( -1 == i )
+			if ( m_closed )
 				return false;
-			m_markSupported = true;
-			for ( ; m_streams.length > i ; ++ i )
+			
+			InputStream activeStream = null;
+			if ( m_streams.hasNext() )
 			{
-				if ( ! m_streams[i].markSupported() )
-					m_markSupported = false;
+				m_streams.next();
+				activeStream = m_streams.previous();
 			}
+
+			if ( null != m_markedStream )
+			{
+				for ( InputStream is = activeStream; is != m_markedStream; )
+					is = m_streams.previous();
+			}
+
+			/*
+			 * The next next() returns the marked stream (if there is one), or
+			 * the active stream (if there is one).
+			 */
+			m_markSupported = true;
+			while ( m_streams.hasNext() )
+				if ( ! m_streams.next().markSupported() )
+					m_markSupported = false;
+			/*
+			 * We've run to the end of the streams list. Back up to the active
+			 * one.
+			 */
+			for ( InputStream is = null; is != activeStream; )
+				is = m_streams.previous();
+
+			/*
+			 * The "current" invariant is satisfied.
+			 */
 			m_markSupported_determined = true;
 			return m_markSupported;
 		}
+	}
+
+	/**
+	 * A {@code ListIterator} that will fetch an element from a
+	 * {@code BlockingQueue} whenever {@code hasNext} would (otherwise)
+	 * return {@code false}, adding it to the end of the list where the next
+	 * {@code next()} will retrieve it.'
+	 *<p>
+	 * It is possible for the {@code hasNext}, {@code next}, and
+	 * {@code nextIndex} methods to throw {@link CancellationException}, if the
+	 * thread is interrupted while they await something on the queue.
+	 */
+	public static class FetchingListIterator<E> implements ListIterator<E>
+	{
+		private final ListIterator<E> m_li;
+		private BlockingQueue<E> m_q;
+		private final E m_sentinel;
+
+		/**
+		 * Construct a {@code FetchingListIterator} given an existing list,
+		 * a {@code BlockingQueue}, and a particular instance of the list's
+		 * element type to use as an end-of-queue sentinel (it is not possible
+		 * to enqueue a null value on a {@code BlockingQueue}).
+		 * @param list An existing list.
+		 * @param queue A blocking queue whose elements will be taken in order
+		 * following any existing elements in the original list.
+		 * @param sentinel A value that the supplier, feeding the blocking
+		 * queue, will enqueue when no more actual values will be forthcoming.
+		 * When an element is dequeued that matches this sentinel (per reference
+		 * equality), it is not added to the list, and nothing more will be
+		 * fetched from the queue.
+		 * @throws NullPointerException if any parameter is null.
+		 */
+		public FetchingListIterator(
+			List<E> list, BlockingQueue<E> queue, E sentinel)
+		{
+			if ( null == list  ||  null == queue  ||  null == sentinel )
+				throw new NullPointerException(
+					"a null parameter was passed to FetchingListIterator");
+
+			m_li = list.listIterator();
+			m_q = queue;
+			m_sentinel = sentinel;
+		}
+
+		@Override
+		public boolean hasNext()
+		{
+			boolean has = m_li.hasNext();
+			E e;
+			if ( has  ||  null == m_q )
+				return has;
+			try
+			{
+				e = m_q.take();
+			}
+			catch ( InterruptedException ex )
+			{
+				m_q = null;
+				throw (CancellationException)
+					new CancellationException("Interrupted waiting for input")
+						.initCause(ex);
+			}
+			if ( m_sentinel == e )
+			{
+				m_q = null;
+				return has;
+			}
+			m_li.add(e);
+			m_li.previous();
+			return true;
+		}
+
+		@Override
+		public E next()
+		{
+			hasNext();
+			return m_li.next();
+		}
+
+		@Override
+		public int nextIndex()
+		{
+			hasNext();
+			return m_li.nextIndex();
+		}
+
+		@Override public void add(E e) { m_li.add(e); }
+		@Override public boolean hasPrevious() { return m_li.hasPrevious(); }
+		@Override public E previous() { return m_li.previous(); }
+		@Override public int previousIndex() { return m_li.previousIndex(); }
+		@Override public void remove() { m_li.remove(); }
+		@Override public void set(E e) { m_li.set(e); }
 	}
 }

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/MarkableSequenceInputStream.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/MarkableSequenceInputStream.java
@@ -1,0 +1,302 @@
+package org.postgresql.pljava.jdbc;
+
+import java.io.InputStream;
+import java.io.SequenceInputStream;
+import java.io.IOException;
+
+/**
+ * Version of {@link SequenceInputStream} that supports
+ * {@code mark} and {@code reset}, to the extent its constituent input streams
+ * do.
+ *<p>
+ * This class implements {@code mark} and {@code reset} by calling the
+ * corresponding methods on the underlying streams; it does not add buffering
+ * or have any means of providing {@code mark} and {@code reset} support if
+ * the underlying streams do not.
+ *<p>
+ * As with {@code SequenceInputStream}, each underlying stream, when completely
+ * read and no longer needed, is closed to free resources. This instance itself
+ * will remain in "open at EOF" condition until explicitly closed, but does not
+ * prevent reclamation of the underlying streams.
+ *<p>
+ * Unlike {@code SequenceInputStream}, this class can keep underlying streams
+ * open, after fully reading them, if a {@code mark} has been set, so that
+ * {@code reset} will be possible. When a mark is no longer needed, it can be
+ * canceled (by calling {@code mark} with a {@code readlimit} of 0) to again
+ * allow the underlying streams to be reclaimed as soon as possible.
+ */
+public class MarkableSequenceInputStream extends InputStream
+{
+	private InputStream[] m_streams;
+	private int m_activeStream;
+	private int m_markedStream;
+	private int m_readlimit_orig;
+	private int m_readlimit_curr;
+	private boolean m_markSupported;
+	private boolean m_markSupported_determined;
+
+	/**
+	 * Create a {@code MarkableSequenceInputStream} from one or more existing
+	 * input streams.
+	 * @param streams Sequence of {@code InputStream}s that will be read from
+	 * in order.
+	 * @throws NullPointerException if {@code streams} is {@code null}, or
+	 * contains {@code null} for any stream.
+	 */
+	public MarkableSequenceInputStream(InputStream... streams)
+	{
+		if ( null == streams )
+			throw new NullPointerException("MarkableSequenceInputStream(null)");
+		for ( InputStream s : streams )
+			if ( null == s )
+				throw new NullPointerException(
+					"MarkableSequenceInputStream(..., null, ...)");
+
+		m_streams = streams;
+		m_activeStream = 0;		/* -1 will mean closed */
+		m_markedStream = -1;	/* -1 will mean no mark has been set */
+	}
+
+	private InputStream currentStream() throws IOException
+	{
+		if ( -1 == m_activeStream )
+			throw new IOException("I/O on closed InputStream");
+		if ( m_streams.length == m_activeStream )
+			return null;
+		return m_streams[m_activeStream];
+	}
+
+	private InputStream nextStream() throws IOException
+	{
+		assert m_streams.length > m_activeStream;
+		assert -1 == m_streams[m_activeStream].read();
+
+		if ( -1 == m_markedStream )
+		{
+			m_streams[m_activeStream].close();
+			m_streams[m_activeStream++] = null;
+		}
+		else if ( m_streams.length > ++m_activeStream )
+			m_streams[m_activeStream].mark(m_readlimit_curr);
+
+		if ( m_streams.length == m_activeStream )
+			return null;
+		return m_streams[m_activeStream];
+	}
+
+	private void decrementLimit(long bytes)
+	{
+		assert 0 < bytes;
+		if ( -1 == m_markedStream )
+			return;
+		if ( bytes < m_readlimit_curr )
+		{
+			m_readlimit_curr -= bytes;
+			return;
+		}
+		mark(0); /* undo markage of underlying streams */
+	}
+
+	@Override
+	public int read() throws IOException
+	{
+		synchronized ( this )
+		{
+			for ( InputStream s = currentStream(); null != s; s = nextStream() )
+			{
+				int c = s.read();
+				if ( -1 != c )
+				{
+					decrementLimit(1);
+					return c;
+				}
+			}
+			return -1;
+		}
+	}
+
+	@Override
+	public int read(byte[] b, int off, int len) throws IOException
+	{
+		synchronized ( this )
+		{
+			for ( InputStream s = currentStream(); null != s; s = nextStream() )
+			{
+				int rslt = s.read(b, off, len);
+				if ( -1 != rslt )
+				{
+					decrementLimit(rslt);
+					return rslt;
+				}
+			}
+			return -1;
+		}
+	}
+
+	@Override
+	public long skip(long n) throws IOException
+	{
+		synchronized ( this )
+		{
+			long skipped;
+			long totalSkipped = 0;
+			InputStream s = currentStream();
+			while ( null != s )
+			{
+				skipped = s.skip(n);
+				n -= skipped;
+				decrementLimit(skipped);
+				totalSkipped += skipped;
+				if ( 0 >= n )
+					break;
+				/*
+				 * A short count from skip doesn't have to mean EOF was reached.
+				 * A read() will settle that question, though.
+				 */
+				if ( -1 != s.read() )
+				{
+					n -= 1;
+					decrementLimit(1);
+					totalSkipped += 1;
+					continue;
+				}
+				/*
+				 * Ok, it was EOF on that underlying stream.
+				 */
+				s = nextStream();
+			}
+			return totalSkipped;
+		}
+	}
+
+	@Override
+	public int available() throws IOException
+	{
+		synchronized ( this )
+		{
+			if ( -1 == m_activeStream )
+				return 0;
+			InputStream s = currentStream();
+			return null == s ? 0 : s.available();
+		}
+	}
+
+	@Override
+	public void close() throws IOException
+	{
+		synchronized ( this )
+		{
+			if ( -1 == m_activeStream )
+				return;
+			if ( -1 != m_markedStream )
+				m_activeStream = m_markedStream;
+			for ( ; m_streams.length > m_activeStream ; ++ m_activeStream )
+				m_streams[m_activeStream].close();
+			m_activeStream = -1;
+			m_streams = null;
+		}
+	}
+
+	/**
+	 * Marks the current position in this input stream. In this implementation,
+	 * it is possible to 'cancel' a mark, by passing this method a
+	 * {@code readlimit} of zero, returning the stream immediately to the state
+	 * of having no mark.
+	 */
+	@Override
+	public void mark(int readlimit)
+	{
+		synchronized ( this )
+		{
+			if ( -1 == m_activeStream )
+				return;
+
+			if ( -1 == m_markedStream )
+				m_markedStream = m_activeStream;
+			else
+			{
+				for ( ; m_markedStream < m_activeStream ; ++ m_markedStream )
+				{
+					try
+					{
+						m_streams[m_markedStream].close();
+					}
+					catch ( IOException e )
+					{
+					}
+					m_streams[m_markedStream] = null;
+				}
+			}
+
+			if ( 0 >= readlimit )			/* setting instantly-invalid mark */
+			{
+				m_readlimit_curr = m_readlimit_orig = 0;
+				m_markedStream = -1;
+				return;
+			}
+			m_readlimit_curr = m_readlimit_orig = readlimit;
+
+			if ( m_streams.length == m_markedStream )  /* setting mark at EOF */
+				return;
+
+			m_streams[m_markedStream].mark(readlimit);
+		}
+	}
+
+	@Override
+	public void reset() throws IOException
+	{
+		synchronized ( this )
+		{
+			if ( -1 == m_activeStream )
+				throw new IOException("reset on closed InputStream");
+			if ( -1 == m_markedStream )
+				throw new IOException("reset without mark");
+			while ( true )
+			{
+				if ( m_streams.length > m_activeStream )
+					m_streams[m_activeStream].reset();
+				if ( m_activeStream == m_markedStream )
+					break;
+				-- m_activeStream;
+			}
+			m_readlimit_curr = m_readlimit_orig;
+		}
+	}
+
+	/**
+	 * Tests if this input stream supports the mark and reset methods.
+	 *<p>
+	 * By the API spec, this method's return is "an invariant property of a
+	 * particular input stream instance." For any instance of this class, the
+	 * result is determined by the first call to this method, and does not
+	 * change thereafter. At the first call, the result is determined only by
+	 * the underlying input streams remaining to be read (or, if a mark has been
+	 * set, which is possible before checking this method, then by the
+	 * underlying input streams including and following the one that was current
+	 * when the mark was set). The result will be {@code true} unless any of
+	 * those underlying streams reports it as {@code false}.
+	 */
+	@Override
+	public boolean markSupported()
+	{
+		synchronized ( this )
+		{
+			if ( m_markSupported_determined )
+				return m_markSupported;
+			int i = m_markedStream;
+			if ( -1 == i )
+				i = m_activeStream;
+			if ( -1 == i )
+				return false;
+			m_markSupported = true;
+			for ( ; m_streams.length > i ; ++ i )
+			{
+				if ( ! m_streams[i].markSupported() )
+					m_markSupported = false;
+			}
+			m_markSupported_determined = true;
+			return m_markSupported;
+		}
+	}
+}

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/SPIConnection.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/SPIConnection.java
@@ -1119,6 +1119,13 @@ public class SPIConnection implements Connection
 		return _clientInfo;
 	}
 
+	@Override
+	public SQLXML createSQLXML()
+	throws SQLException
+	{
+		return SQLXMLImpl.newWritable();
+	}
+
 	// ************************************************************
 	// Non-implementation of JDBC 4 methods.
 	// ************************************************************
@@ -1137,14 +1144,6 @@ public class SPIConnection implements Connection
 	{
 		throw new SQLFeatureNotSupportedException(
 			"SPIConnection.createArrayOf( String, Object[] ) not implemented yet.", "0A000" );
-	}
-
-	@Override
-	public SQLXML createSQLXML()
-	throws SQLException
-	{
-		throw new SQLFeatureNotSupportedException( "SPIConnection.createSQLXML() not implemented yet.",
-			"0A000" );
 	}
 
 	@Override

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/SPIConnection.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/SPIConnection.java
@@ -742,16 +742,16 @@ public class SPIConnection implements Connection
 
 	/**
 	 * Convert a PostgreSQL type name to a {@link Types} integer, using the
-	 * {@code JDBC3_TYPE_NAMES}/{@code JDBC_TYPE_NUMBERS} arrays; used in
-	 * {@link DatabaseMetaData} and {@link ResultSetMetaData}.
+	 * {@code JDBC_TYPE_NAMES}/{@code JDBC_TYPE_NUMBERS} arrays; used in
+	 * two places in {@link DatabaseMetaData}.
 	 */
     public int getSQLType(String pgTypeName)
     {
         if (pgTypeName == null)
             return Types.OTHER;
 
-        for (int i = 0;i < JDBC3_TYPE_NAMES.length;i++)
-            if (pgTypeName.equals(JDBC3_TYPE_NAMES[i]))
+        for (int i = 0;i < JDBC_TYPE_NAMES.length;i++)
+            if (pgTypeName.equals(JDBC_TYPE_NAMES[i]))
                 return JDBC_TYPE_NUMBERS[i];
 
         return Types.OTHER;
@@ -760,7 +760,14 @@ public class SPIConnection implements Connection
 	/**
 	 * This returns the {@link Types} type for a PG type oid, by mapping it
 	 * to a name using {@link #getPGType} and then to the result via
-	 * {@link #getSQLType(String)}.
+	 * {@link #getSQLType(String)}; used in {@link ResultSetMetaData} and
+	 * five places in {@link DatabaseMetaData}.
+	 *<p>
+	 * This method is a bit goofy, as it first maps from Oid to type name, and
+	 * then from name to JDBC type, all to accomplish the inverse of the JDBC
+	 * type / Oid mapping that already exists in Oid.c, and so the mapping
+	 * arrays in this file have to be updated in sync with that. Look into
+	 * future consolidation....
      *
      * @param oid PostgreSQL type oid
      * @return the java.sql.Types type
@@ -983,10 +990,13 @@ public class SPIConnection implements Connection
      * They default automatically to Types.OTHER
      *
      * Note: This must be in the same order as below.
+	 *
+	 * These arrays are not only used by getSQLType() in this file, but also
+	 * directly accessed by getUDTs() in DatabaseMetaData.
      *
      * Tip: keep these grouped together by the Types. value
      */
-    public static final String JDBC3_TYPE_NAMES[] = {
+    public static final String JDBC_TYPE_NAMES[] = {
                 "int2",
                 "int4", "oid",
                 "int8",
@@ -1002,6 +1012,7 @@ public class SPIConnection implements Connection
                 "date",
                 "time", "timetz",
                 "abstime", "timestamp", "timestamptz",
+				"xml",
                 "_bool", "_char", "_int2", "_int4", "_text",
                 "_oid", "_varchar", "_int8", "_float4", "_float8",
                 "_abstime", "_date", "_time", "_timestamp", "_numeric",
@@ -1032,6 +1043,7 @@ public class SPIConnection implements Connection
                 Types.DATE,
                 Types.TIME, Types.TIME,
                 Types.TIMESTAMP, Types.TIMESTAMP, Types.TIMESTAMP,
+				Types.SQLXML,
                 Types.ARRAY, Types.ARRAY, Types.ARRAY, Types.ARRAY, Types.ARRAY,
                 Types.ARRAY, Types.ARRAY, Types.ARRAY, Types.ARRAY, Types.ARRAY,
                 Types.ARRAY, Types.ARRAY, Types.ARRAY, Types.ARRAY, Types.ARRAY,

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/SPIDatabaseMetaData.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/SPIDatabaseMetaData.java
@@ -2996,7 +2996,7 @@ public class SPIDatabaseMetaData implements DatabaseMetaData
 			+ " end as data_type, pg_catalog.obj_description(t.oid, 'pg_type')  "
 			+ "as remarks, CASE WHEN t.typtype = 'd' then  (select CASE";
 
-		for(int i = 0; i < SPIConnection.JDBC3_TYPE_NAMES.length; i++)
+		for(int i = 0; i < SPIConnection.JDBC_TYPE_NAMES.length; i++)
 		{
 			sql += " when typname = '" + SPIConnection.JDBC_TYPE_NUMBERS[i]
 				+ "' then " + SPIConnection.JDBC_TYPE_NUMBERS[i];

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/SPIPreparedStatement.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/SPIPreparedStatement.java
@@ -435,6 +435,20 @@ public class SPIPreparedStatement extends SPIStatement implements PreparedStatem
 	}
 
 	// ************************************************************
+	// Implementation of JDBC 4 methods. Methods go here if they
+	// don't throw SQLFeatureNotSupportedException; they can be
+	// considered implemented even if they do nothing useful, as
+	// long as that's an allowed behavior by the JDBC spec.
+	// ************************************************************
+
+	public void setSQLXML(int parameterIndex,
+               SQLXML xmlObject)
+		throws SQLException
+	{
+	    setObject(parameterIndex, xmlObject, Types.SQLXML);
+	}
+
+	// ************************************************************
 	// Non-implementation of JDBC 4 methods.
 	// ************************************************************
 
@@ -610,16 +624,6 @@ public class SPIPreparedStatement extends SPIStatement implements PreparedStatem
 			  + "implemented yet.",
 			  "0A000" );
 
-	}
-	
-	public void setSQLXML(int parameterIndex,
-               SQLXML xmlObject)
-		throws SQLException
-	{
-	    throw new SQLFeatureNotSupportedException
-		    ( this.getClass()
-		      + ".setSQLXML( int, SQLXML ) not implemented yet.",
-		      "0A000" );
 	}
 
 	public void setNString(int parameterIndex,

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/SQLInputFromTuple.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/SQLInputFromTuple.java
@@ -199,6 +199,20 @@ public class SQLInputFromTuple extends JavaWrapper implements SQLInput
 	{
 		return SPIConnection.basicCoersion(valueClass, this.readObject());
 	}
+
+	// ************************************************************
+	// Implementation of JDBC 4 methods. Methods go here if they
+	// don't throw SQLFeatureNotSupportedException; they can be
+	// considered implemented even if they do nothing useful, as
+	// long as that's an allowed behavior by the JDBC spec.
+	// ************************************************************
+
+	public SQLXML readSQLXML()
+		throws SQLException
+	{
+		return (SQLXML)this.readValue(SQLXML.class);
+	}
+
 	// ************************************************************
 	// Non-implementation of JDBC 4 methods.
 	// ************************************************************
@@ -210,15 +224,6 @@ public class SQLInputFromTuple extends JavaWrapper implements SQLInput
 		throw new SQLFeatureNotSupportedException
 			( this.getClass()
 			  + ".readRowId() not implemented yet.",
-			  "0A000" );
-	}
-
-	public SQLXML readSQLXML()
-		throws SQLException
-	{
-		throw new SQLFeatureNotSupportedException
-			( this.getClass()
-			  + ".readSQLXML() not implemented yet.",
 			  "0A000" );
 	}
 

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/SQLOutputToTuple.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/SQLOutputToTuple.java
@@ -201,6 +201,19 @@ public class SQLOutputToTuple implements SQLOutput
 	}
 
 	// ************************************************************
+	// Implementation of JDBC 4 methods. Methods go here if they
+	// don't throw SQLFeatureNotSupportedException; they can be
+	// considered implemented even if they do nothing useful, as
+	// long as that's an allowed behavior by the JDBC spec.
+	// ************************************************************
+
+	public void writeSQLXML(SQLXML x)
+		throws SQLException
+	{
+		this.writeValue(x);
+	}
+
+	// ************************************************************
 	// Non-implementation of JDBC 4 methods.
 	// ************************************************************
 
@@ -228,15 +241,6 @@ public class SQLOutputToTuple implements SQLOutput
 		throw new SQLFeatureNotSupportedException
 			( this.getClass()
 			  + ".writeRowId( RowId ) not implemented yet.",
-			  "0A000" );
-	}
-	
-	public void writeSQLXML(SQLXML x)
-		throws SQLException
-	{
-		throw new SQLFeatureNotSupportedException
-			( this.getClass()
-			  + ".writeSQLXML( SQLXML ) not implemented yet.",
 			  "0A000" );
 	}
 

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/SQLXMLImpl.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/SQLXMLImpl.java
@@ -258,7 +258,43 @@ public abstract class SQLXMLImpl<V extends VarlenaWrapper> implements SQLXML
 
 	protected abstract VarlenaWrapper adopt() throws SQLException;
 
+	/**
+	 * Return a description of this object useful for debugging (not the raw
+	 * XML content).
+	 */
+	@Override
+	public String toString()
+	{
+		return toString(this);
+	}
+
+	/**
+	 * Return information about this object useful for debugging, prefixed with
+	 * a possibly shortened form of the class name of the passed object
+	 * {@code o}; the normal Java {@code toString()} will pass {@code this}.
+	 *<p>
+	 * Subclasses are encouraged to override, call the super method and append
+	 * subclass-specific detail.
+	 * @param o Object whose class name should be used to prefix the returned
+	 * string. Passing {@code null} is the same as passing {@code this}.
+	 * @return Description of this object for debugging convenience.
+	 */
+	protected String toString(Object o)
+	{
+		if ( null == o )
+			o = this;
+		V backing = m_backing.get();
+		if ( null != backing )
+			return backing.toString(o);
+		Class<?> c = o.getClass();
+		String cn = c.getCanonicalName();
+		int pnl = c.getPackage().getName().length();
+		return cn.substring(1 + pnl) + " defunct";
+	}
+
 	private static native SQLXML _newWritable();
+
+
 
 	static class Readable extends SQLXMLImpl<VarlenaWrapper.Input>
 	{
@@ -423,6 +459,14 @@ public abstract class SQLXMLImpl<V extends VarlenaWrapper> implements SQLXML
 			if ( null == vw )
 				backingIfNotFreed(); /* shorthand way to throw the exception */
 			return vw;
+		}
+
+		@Override
+		protected String toString(Object o)
+		{
+			return String.format("%s %sreadable %swrapped",
+				super.toString(o), m_readable.get() ? "" : "not ",
+				m_wrapped ? "" : "not ");
 		}
 
 		/**
@@ -684,6 +728,8 @@ public abstract class SQLXMLImpl<V extends VarlenaWrapper> implements SQLXML
 		}
 	}
 
+
+
 	static class Writable extends SQLXMLImpl<VarlenaWrapper.Output>
 	{
 		private AtomicBoolean m_writable = new AtomicBoolean(true);
@@ -877,6 +923,13 @@ public abstract class SQLXMLImpl<V extends VarlenaWrapper> implements SQLXML
 				m_domResult = null;
 			}
 			return vwo;
+		}
+
+		@Override
+		protected String toString(Object o)
+		{
+			return String.format("%s %swritable", super.toString(o),
+				m_writable.get() ? "" : "not ");
 		}
 	}
 

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/SQLXMLImpl.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/SQLXMLImpl.java
@@ -337,7 +337,7 @@ public abstract class SQLXMLImpl<V extends Closeable> implements SQLXML
 				return super.getSource(sourceClass);
 
 			if ( null == sourceClass || Source.class == sourceClass )
-				sourceClass = (Class<T>)StreamSource.class; // trust me on this
+				sourceClass = (Class<T>)SAXSource.class; // trust me on this
 
 			try
 			{
@@ -537,7 +537,7 @@ public abstract class SQLXMLImpl<V extends Closeable> implements SQLXML
 				return super.setResult(resultClass);
 
 			if ( null == resultClass || Result.class == resultClass )
-				resultClass = (Class<T>)StreamResult.class; // trust me on this
+				resultClass = (Class<T>)SAXResult.class; // trust me on this
 
 			try
 			{

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/SQLXMLImpl.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/SQLXMLImpl.java
@@ -31,6 +31,8 @@ import java.io.IOException;
 
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.postgresql.pljava.internal.Backend;
+
 import java.sql.SQLNonTransientException;
 
 /* ... for SQLXMLImpl.Readable */
@@ -211,6 +213,16 @@ public abstract class SQLXMLImpl<V extends Closeable> implements SQLXML
 			"Exception in XML processing, not otherwise provided for",
 			"XX000", e);
 	}
+
+	static SQLXML newWritable()
+	{
+		synchronized ( Backend.THREADLOCK )
+		{
+			return _newWritable();
+		}
+	}
+
+	private static native SQLXML _newWritable();
 
 	static class Readable extends SQLXMLImpl<InputStream>
 	{

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/SQLXMLImpl.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/SQLXMLImpl.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2018 Tada AB and other contributors, as listed below.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Chapman Flack
+ */
+package org.postgresql.pljava.jdbc;
+
+/* Imports for API */
+
+import java.sql.SQLXML;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.Reader;
+import java.io.Writer;
+import javax.xml.transform.Source;
+import javax.xml.transform.Result;
+
+import java.sql.SQLException;
+
+/* Supplemental imports for SQLXMLImpl */
+
+import java.io.Closeable;
+import java.io.IOException;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import java.sql.SQLNonTransientException;
+
+public abstract class SQLXMLImpl<V extends Closeable> implements SQLXML
+{
+	protected AtomicReference<V> m_backing;
+
+	protected SQLXMLImpl(V backing)
+	{
+		m_backing = new AtomicReference<V>(backing);
+	}
+
+	@Override
+	public void free() throws SQLException
+	{
+		V backing = m_backing.getAndSet(null);
+		if ( null == backing )
+			return;
+		try
+		{
+			backing.close();
+		}
+		catch ( IOException e )
+		{
+			throw normalizedException(e);
+		}
+	}
+
+	@Override
+	public InputStream getBinaryStream() throws SQLException
+	{
+		throw new SQLNonTransientException(
+			"Attempted use of getBinaryStream on an unreadable SQLXML object",
+			"55000");
+	}
+
+	@Override
+	public OutputStream setBinaryStream() throws SQLException
+	{
+		throw new SQLNonTransientException(
+			"Attempted use of setBinaryStream on an unwritable SQLXML object",
+			"55000");
+	}
+
+	@Override
+	public Reader getCharacterStream() throws SQLException
+	{
+		throw new SQLNonTransientException(
+			"Attempted use of getCharacterStream on an unreadable " +
+			"SQLXML object", "55000");
+	}
+
+	@Override
+	public Writer setCharacterStream() throws SQLException
+	{
+		throw new SQLNonTransientException(
+			"Attempted use of setCharacterStream on an unwritable " +
+			"SQLXML object", "55000");
+	}
+
+	@Override
+	public String getString() throws SQLException
+	{
+		throw new SQLNonTransientException(
+			"Attempted use of getString on an unreadable SQLXML object",
+			"55000");
+	}
+
+	@Override
+	public void setString(String value) throws SQLException
+	{
+		throw new SQLNonTransientException(
+			"Attempted use of setString on an unwritable SQLXML object",
+			"55000");
+	}
+
+	@Override
+	public <T extends Source> T getSource(Class<T> sourceClass)
+	throws SQLException
+	{
+		throw new SQLNonTransientException(
+			"Attempted use of getSource on an unreadable SQLXML object",
+			"55000");
+	}
+
+	@Override
+	public <T extends Result> T setResult(Class<T> resultClass)
+	throws SQLException
+	{
+		throw new SQLNonTransientException(
+			"Attempted use of setResult on an unwritable SQLXML object",
+			"55000");
+	}
+
+	protected V backingIfNotFreed() throws SQLException
+	{
+		V backing = m_backing.get();
+		if ( null == backing )
+			throw new SQLNonTransientException(
+				"Attempted use of already-freed SQLXML object", "55000");
+		return backing;
+	}
+
+	/**
+	 * Wrap other checked exceptions in SQLException for methods specified to
+	 * throw only that.
+	 */
+	protected SQLException normalizedException(Exception e)
+	{
+		if ( e instanceof SQLException )
+			return (SQLException) e;
+		if ( e instanceof RuntimeException )
+			throw (RuntimeException) e;
+
+		if ( e instanceof IOException )
+		{
+			Throwable cause = e.getCause();
+			if ( cause instanceof SQLException )
+				return (SQLException)cause;
+		}
+
+		return new SQLException(
+			"Exception in XML processing, not otherwise provided for",
+			"XX000", e);
+	}
+}

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/SQLXMLImpl.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/SQLXMLImpl.java
@@ -24,7 +24,7 @@ import javax.xml.transform.Result;
 
 import java.sql.SQLException;
 
-/* Supplemental imports for SQLXMLImpl */
+/* ... for SQLXMLImpl */
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -33,7 +33,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import java.sql.SQLNonTransientException;
 
-/* Supplemental imports for SQLXMLImpl.Readable */
+/* ... for SQLXMLImpl.Readable */
 
 import java.io.InputStreamReader;
 import java.nio.CharBuffer;
@@ -60,6 +60,16 @@ import static org.postgresql.pljava.internal.Session.implServerCharset;
 import org.postgresql.pljava.internal.VarlenaWrapper;
 
 import java.sql.SQLFeatureNotSupportedException;
+
+/* ... for SQLXMLImpl.DeclProbe */
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.SequenceInputStream;
+
+import java.util.Arrays;
+
+import java.sql.SQLDataException;
 
 public abstract class SQLXMLImpl<V extends Closeable> implements SQLXML
 {
@@ -218,7 +228,14 @@ public abstract class SQLXMLImpl<V extends Closeable> implements SQLXML
 			InputStream is = backingAndClearReadable();
 			if ( null == is )
 				return super.getBinaryStream();
-			return is;
+			try
+			{
+				return correctedDeclStream(is);
+			}
+			catch ( IOException e )
+			{
+				throw normalizedException(e);
+			}
 		}
 
 		@Override
@@ -227,7 +244,15 @@ public abstract class SQLXMLImpl<V extends Closeable> implements SQLXML
 			InputStream is = backingAndClearReadable();
 			if ( null == is )
 				return super.getCharacterStream();
-			return new InputStreamReader(is, m_serverCS.newDecoder());
+			try
+			{
+				is = correctedDeclStream(is);
+				return new InputStreamReader(is, m_serverCS.newDecoder());
+			}
+			catch ( IOException e )
+			{
+				throw normalizedException(e);
+			}
 		}
 
 		@Override
@@ -237,10 +262,12 @@ public abstract class SQLXMLImpl<V extends Closeable> implements SQLXML
 			if ( null == is )
 				return super.getString();
 
-			Reader r = new InputStreamReader(is, m_serverCS.newDecoder());
 			CharBuffer cb = CharBuffer.allocate(32768);
 			StringBuilder sb = new StringBuilder();
-			try {
+			try
+			{
+				is = correctedDeclStream(is);
+				Reader r = new InputStreamReader(is, m_serverCS.newDecoder());
 				while ( -1 != r.read(cb) )
 				{
 					sb.append((CharBuffer)cb.flip());
@@ -270,7 +297,7 @@ public abstract class SQLXMLImpl<V extends Closeable> implements SQLXML
 			{
 				if ( sourceClass.isAssignableFrom(StreamSource.class) )
 					return sourceClass.cast(
-						new StreamSource(is));
+						new StreamSource(correctedDeclStream(is)));
 
 				if ( sourceClass.isAssignableFrom(SAXSource.class) )
 				{
@@ -278,7 +305,8 @@ public abstract class SQLXMLImpl<V extends Closeable> implements SQLXML
 					xr.setFeature("http://xml.org/sax/features/namespaces",
 								  true);
 					return sourceClass.cast(
-						new SAXSource(xr, new InputSource(is)));
+						new SAXSource(xr,
+							new InputSource(correctedDeclStream(is))));
 				}
 
 				if ( sourceClass.isAssignableFrom(StAXSource.class) )
@@ -286,7 +314,7 @@ public abstract class SQLXMLImpl<V extends Closeable> implements SQLXML
 					XMLInputFactory xif = XMLInputFactory.newFactory();
 					xif.setProperty(xif.IS_NAMESPACE_AWARE, true);
 					XMLStreamReader xsr =
-						xif.createXMLStreamReader(is);
+						xif.createXMLStreamReader(correctedDeclStream(is));
 					return sourceClass.cast(new StAXSource(xsr));
 				}
 
@@ -296,6 +324,7 @@ public abstract class SQLXMLImpl<V extends Closeable> implements SQLXML
 						DocumentBuilderFactory.newInstance();
 					dbf.setNamespaceAware(true);
 					DocumentBuilder db = dbf.newDocumentBuilder();
+					is = correctedDeclStream(is);
 					return sourceClass.cast(new DOMSource(db.parse(is)));
 				}
 			}
@@ -307,6 +336,518 @@ public abstract class SQLXMLImpl<V extends Closeable> implements SQLXML
 			throw new SQLFeatureNotSupportedException(
 				"No support for SQLXML.getSource(" +
 				sourceClass.getName() + ".class)", "0A000");
+		}
+
+		/**
+		 * Return an InputStream presenting the contents of the underlying
+		 * varlena, but with the leading declaration corrected if need be.
+		 *<p>
+		 * The current stored form in PG for the XML type is a character string
+		 * in server encoding, which may or may not still include a declaration
+		 * left over from an input or cast operation, which declaration may or
+		 * may not be correct (about the encoding, anyway).
+		 * @return An InputStream with its original decl, if any, replaced with
+		 * a new one known to be correct, or none if the defaults are correct.
+		 */
+		private InputStream correctedDeclStream(InputStream is)
+		throws IOException, SQLException
+		{
+			byte[] buf = new byte[40];
+			int got;
+			boolean needMore = false;
+			DeclProbe probe = new DeclProbe();
+
+			while ( -1 != ( got = is.read(buf) ) )
+			{
+				for ( int i = 0 ; i < got ; ++ i )
+					needMore = probe.take(buf[i]);
+				if ( ! needMore )
+					break;
+			}
+
+			/*
+			 * At this point, for better or worse, the loop is done. There may
+			 * or may not be more of m_vwi left to read; the probe may or may
+			 * not have found a decl. If it didn't, prefix() will treat whatever
+			 * had been read as readahead and hand it all back, so it suffices
+			 * here to create a SequenceInputStream of the prefix and whatever
+			 * is or isn't left of m_vwi.
+			 *   A bonus is that the SequenceInputStream closes each underlying
+			 * stream as it reaches EOF. After the last stream is used up, the
+			 * SequenceInputStream remains open-at-EOF until explicitly closed,
+			 * providing the expected input-stream behavior, but the underlying
+			 * resources don't have to stick around for that.
+			 */
+			InputStream pfx =
+				new ByteArrayInputStream(probe.prefix(m_serverCS));
+			return new SequenceInputStream(pfx, is);
+		}
+	}
+
+	/**
+	 * A class to parse and, if necessary, check or correct, the
+	 * possibly-erroneous XMLDecl or TextDecl syntax found in the stored form
+	 * of PG's XML datatype.
+	 *<p>
+	 * This implementation depends heavily on the (currently dependable) fact
+	 * that, in all PG-supported server encodings, the characters that matter
+	 * for decls are encoded as in ASCII.
+	 */
+	static class DeclProbe
+	{
+		/*
+		 * In Python 3, they've achieved a very nice symmetry where they provide
+		 * regular expressions with comparable functionality for both character
+		 * streams and byte streams. Will Java ever follow suit? It's 2018, I
+		 * can ask my phone spoken questions, and I'm writing a DFA by hand.
+		 */
+		private static enum State
+		{
+			START,
+			MAYBEVER,
+			VER, VEQ, VQ, VVAL, VVALTAIL,
+			MAYBEENC,
+			ENC, EEQ, EQ, EVAL, EVALTAIL,
+			MAYBESA,
+			SA , SEQ, SQ, SVAL, SVALTAIL,
+			TRAILING, END, MATCHED, UNMATCHED, ABANDONED
+		};
+		private State m_state = State.START;
+		private int m_idx = 0;
+		private byte m_q = 0;
+		private ByteArrayOutputStream m_save = new ByteArrayOutputStream();
+		private static final byte[] s_tpl = {
+			'<', '?', 'x', 'm', 'l',     0,                           // 0 - 5
+			'v', 'e', 'r', 's', 'i', 'o', 'n',     0,                 // 6 - 13
+			'1', '.',     0,                                          // 14 - 16
+			'e', 'n', 'c', 'o', 'd', 'i', 'n', 'g',     0,            // 17 - 25
+			's', 't', 'a', 'n', 'd', 'a', 'l', 'o', 'n', 'e',     0,  // 26 - 36
+			'y', 'e', 's',     0,                                     // 37 - 40
+			'n', 'o',     0                                           // 41 - 43
+		};
+
+		private boolean m_saving = true;
+		private int m_pos = 0;
+		private boolean m_mustBeDecl = false;
+		private boolean m_mustBeXmlDecl = false;
+		private boolean m_mustBeTextDecl = false;
+		private boolean m_xml1_0 = false;
+		private Boolean m_standalone = null;
+
+		private int m_versionStart, m_versionEnd;
+		private int m_encodingStart, m_encodingEnd;
+		private int m_readaheadStart;
+
+		/**
+		 * Parse for an initial declaration (XMLDecl or TextDecl) in a stream
+		 * made available a byte at a time.
+		 *<p>
+		 * Pass bytes in as long as this method keeps returning {@code true};
+		 * once it returns {@code false}, it has either parsed a declaration
+		 * successfully or determined none to be present. The results of parsing
+		 * are remembered in the instance and available to the
+		 * {@link #prefix prefix()} method to generate a suitable decl with the
+		 * encoding corrected as needed.
+		 *<p>
+		 * It is not an error to pass some more bytes after the method has
+		 * returned {@code false}; they will simply be buffered as readahead
+		 * and included in the result of {@code prefix()}. If no decl
+		 * was found, the readahead will include all bytes passed in. If a
+		 * partial or malformed decl was found, an exception is thrown.
+		 * @param b The next byte of the stream.
+		 * @return True if more input is needed to fully parse a decl or be sure
+		 * that none is present; false when enough input has been seen.
+		 * @throws SQLDataException If a partial or malformed decl is found.
+		 */
+		boolean take(byte b) throws SQLException
+		{
+			if ( m_saving )
+			{
+				m_save.write(b);
+				++ m_pos;
+			}
+			byte tpl = s_tpl[m_idx];
+			switch ( m_state )
+			{
+			case START:
+				if ( 0 == tpl  &&  isSpace(b) )
+				{
+					m_mustBeDecl = true;
+					m_saving = false;
+					m_state = State.MAYBEVER;
+					return true;
+				}
+				if ( tpl != b )
+				{
+					m_state = State.UNMATCHED;
+					return false;
+				}
+				++ m_idx;
+				return true;
+			case MAYBEVER:
+				if ( isSpace(b) )
+					return true;
+				switch ( b )
+				{
+				case 'v':
+					m_state = State.VER;
+					m_idx = 7;
+					return true;
+				case 'e':
+					m_mustBeTextDecl = true;
+					m_state = State.ENC;
+					m_idx = 18;
+					return true;
+				default:
+				}
+				break;
+			case VER:
+				if ( 0 == tpl )
+				{
+					if ( isSpace(b) )
+					{
+						m_state = State.VEQ;
+						return true;
+					}
+					if ( '=' == b )
+					{
+						m_state = State.VQ;
+						return true;
+					}
+				}
+				if ( tpl != b )
+					break;
+				++ m_idx;
+				return true;
+			case VEQ:
+				if ( isSpace(b) )
+					return true;
+				if ( '=' != b )
+					break;
+				m_state = State.VQ;
+				return true;
+			case VQ:
+				if ( isSpace(b) )
+					return true;
+				if ( '\'' != b   &&  '"' != b)
+					break;
+				m_q = b;
+				m_state = State.VVAL;
+				m_idx = 14;
+				m_saving = true;
+				m_versionStart = m_pos;
+				return true;
+			case VVAL:
+				if ( 0 == tpl )
+				{
+					if ( '0' > b  ||  b > '9' )
+						break;
+					if ( '0' == b )
+						m_xml1_0 = true;
+					m_state = State.VVALTAIL;
+					return true;
+				}
+				if ( tpl != b )
+					break;
+				++ m_idx;
+				return true;
+			case VVALTAIL:
+				if ( '0' <= b  &&  b <= '9' )
+				{
+					m_xml1_0 = false;
+					return true;
+				}
+				if ( m_q != b )
+					break;
+				m_state = State.MAYBEENC;
+				m_saving = false;
+				m_versionEnd = m_pos - 1;
+				return true;
+			case MAYBEENC:
+				if ( isSpace(b) )
+					return true;
+				if ( 'e' == b )
+				{
+					m_state = State.ENC;
+					m_idx = 18;
+					return true;
+				}
+				if ( m_mustBeTextDecl )
+					break;
+				m_mustBeXmlDecl = true;
+				if ( 's' == b )
+				{
+					m_state = State.SA;
+					m_idx = 27;
+					return true;
+				}
+				if ( '?' != b )
+					break;
+				m_state = State.END;
+				return true;
+			case ENC:
+				if ( 0 == tpl )
+				{
+					if ( isSpace(b) )
+					{
+						m_state = State.EEQ;
+						return true;
+					}
+					if ( '=' == b )
+					{
+						m_state = State.EQ;
+						return true;
+					}
+				}
+				if ( tpl != b )
+					break;
+				++ m_idx;
+				return true;
+			case EEQ:
+				if ( isSpace(b) )
+					return true;
+				if ( '=' != b )
+					break;
+				m_state = State.EQ;
+				return true;
+			case EQ:
+				if ( isSpace(b) )
+					return true;
+				if ( '\'' != b   &&  '"' != b)
+					break;
+				m_q = b;
+				m_state = State.EVAL;
+				m_saving = true;
+				m_encodingStart = m_pos;
+				return true;
+			case EVAL:
+				if ( ( 'A' > b || b > 'Z' ) && ( 'a' > b || b > 'z' ) )
+					break;
+				m_state = State.EVALTAIL;
+				return true;
+			case EVALTAIL:
+				if ( ( 'A' <= b && b <= 'Z' ) || ( 'a' <= b && b <= 'z' ) ||
+					 ( '0' <= b && b <= '9' ) || ( '.' == b ) || ( '_' == b ) ||
+					 ( '-' == b ) )
+					return true;
+				if ( m_q != b )
+					break;
+				m_state = m_mustBeTextDecl ? State.TRAILING : State.MAYBESA;
+				m_saving = false;
+				m_encodingEnd = m_pos - 1;
+				return true;
+			case MAYBESA:
+				if ( isSpace(b) )
+					return true;
+				switch ( b )
+				{
+				case 's':
+					m_mustBeXmlDecl = true;
+					m_state = State.SA;
+					m_idx = 27;
+					return true;
+				case '?':
+					m_state = State.END;
+					return true;
+				default:
+				}
+				break;
+			case SA:
+				if ( 0 == tpl )
+				{
+					if ( isSpace(b) )
+					{
+						m_state = State.SEQ;
+						return true;
+					}
+					if ( '=' == b )
+					{
+						m_state = State.SQ;
+						return true;
+					}
+				}
+				if ( tpl != b )
+					break;
+				++ m_idx;
+				return true;
+			case SEQ:
+				if ( isSpace(b) )
+					return true;
+				if ( '=' != b )
+					break;
+				m_state = State.SQ;
+				return true;
+			case SQ:
+				if ( isSpace(b) )
+					return true;
+				if ( '\'' != b   &&  '"' != b)
+					break;
+				m_q = b;
+				m_state = State.SVAL;
+				return true;
+			case SVAL:
+				if ( 'y' == b )
+				{
+					m_idx = 38;
+					m_standalone = Boolean.TRUE;
+				}
+				else if ( 'n' == b )
+				{
+					m_idx = 42;
+					m_standalone = Boolean.FALSE;
+				}
+				else
+					break;
+				m_state = State.SVALTAIL;
+				return true;
+			case SVALTAIL:
+				if ( 0 == tpl )
+				{
+					if ( m_q != b )
+						break;
+					m_state = State.TRAILING;
+					return true;
+				}
+				if ( tpl != b )
+					break;
+				++ m_idx;
+				return true;
+			case TRAILING:
+				if ( isSpace(b) )
+					return true;
+				if ( '?' != b )
+					break;
+				m_state = State.END;
+				return true;
+			case END:
+				if ( '>' != b )
+					break;
+				m_state = State.MATCHED;
+				m_readaheadStart = m_pos;
+				m_saving = true;
+				return false;
+			case MATCHED:     // no more input needed for a determination;
+			case UNMATCHED:   // whatever more is provided, just buffer it
+				return false; // as readahead
+			case ABANDONED:
+			}
+			m_state = State.ABANDONED;
+			String m = "Invalid XML/Text declaration";
+			if ( m_mustBeXmlDecl )
+				m = "Invalid XML declaration";
+			else if ( m_mustBeTextDecl )
+				m = "Invalid text declaration";
+			throw new SQLDataException(m, "2200N");
+		}
+
+		private boolean isSpace(byte b)
+		{
+			return (0x20 == b) || (0x09 == b) || (0x0D == b) || (0x0A == b);
+		}
+
+		/**
+		 * Generate a declaration, if necessary, with the XML version and
+		 * standalone status determined in declaration parsing and the name of
+		 * the server encoding, followed always by any readahead buffered during
+		 * a nonmatching parse or following a matching one.
+		 * @param serverCharset The encoding to be named in the declaration if
+		 * one is generated (which is forced if the encoding isn't UTF-8).
+		 * @return A byte array representing the declaration if any, followed
+		 * by any readahead.
+		 */
+		byte[] prefix(Charset serverCharset) throws IOException
+		{
+			/*
+			 * Will this be DOCUMENT or CONTENT ?
+			 * Without some out-of-band indication, we just don't know yet.
+			 * For now, get DOCUMENT working.
+			 */
+			// boolean mightBeDocument = true;
+			// boolean mightBeContent  = true;
+
+			/*
+			 * Defaults for when no declaration was matched:
+			 */
+			boolean canOmitVersion = true; // no declaration => 1.0
+			byte[] version = new byte[] { '1', '.', '0' };
+			boolean canOmitEncoding = "UTF-8".equals(serverCharset.name());
+			boolean canOmitStandalone = true;
+
+			byte[] parseResult = m_save.toByteArray();
+
+			if ( State.MATCHED == m_state )
+			{
+				/*
+				 * Parsing the decl could have turned up a non-1.0 XML version,
+				 * which would mean we can't neglect to declare it, As for any
+				 * encoding found in the varlena, the value doesn't matter (PG
+				 * always uses the server encoding, whatever the stored decl
+				 * might say). Its presence or absence in the decl can influence
+				 * m_mustBeXmlDecl: the grammar productions XMLDecl and TextDecl
+				 * are slightly different, which in a better world could help
+				 * distinguish DOCUMENT from CONTENT, but PG doesn't preserve
+				 * the distinction, instead always omitting the encoding in
+				 * xml_out, which only XMLDecl can match. This code isn't
+				 * reading from xml_out ... but if the value has ever been put
+				 * through PG expressions that involved casting, xml_out may
+				 * have eaten the encoding at that time.
+				 *   So, for now, all that can be done here is refinement of
+				 * canOmitVersion and canOmitStandalone. Also, PG's hand-laid
+				 * parse_xml_decl always insists on the version being present,
+				 * so if we produce a decl at all, it had better not have either
+				 * the version or the encoding omitted.
+				 */
+				canOmitVersion = m_xml1_0; //  &&  ! m_mustBeXmlDecl;
+				// canOmitEncoding &&= ! m_mustBeTextDecl;
+				canOmitStandalone = null == m_standalone;
+				if ( ! m_xml1_0  &&  m_versionEnd > m_versionStart )
+					version = Arrays.copyOfRange(parseResult,
+						m_versionStart, m_versionEnd);
+			}
+
+			ByteArrayOutputStream baos = new ByteArrayOutputStream();
+
+			if ( ! ( canOmitVersion && canOmitEncoding && canOmitStandalone ) )
+			{
+				baos.write(s_tpl, 0, 5); // <?xml
+				baos.write(' ');
+				baos.write(s_tpl, 6, 7); // version
+				baos.write('=');
+				baos.write('"');
+				baos.write(version);
+				baos.write('"');
+				baos.write(' ');
+				baos.write(s_tpl, 17, 8); // encoding
+				baos.write('=');
+				baos.write('"');
+				/*
+				 * This is no different from all the rest of this class in
+				 * relying on the current fact that all supported PG server
+				 * encodings match ASCII as far as the characters for decls go.
+				 * It's just a bit more explicit here.
+				 */
+				baos.write(serverCharset.name().getBytes(serverCharset));
+				baos.write('"');
+				if ( ! canOmitStandalone )
+				{
+					baos.write(' ');
+					baos.write(s_tpl, 26, 10); // standalone
+					baos.write('=');
+					baos.write('"');
+					if ( m_standalone )
+						baos.write(s_tpl, 37, 3); // yes
+					else
+						baos.write(s_tpl, 41, 2); // no
+					baos.write('"');
+				}
+				baos.write('?');
+				baos.write('>');
+			}
+
+			baos.write(parseResult,
+				m_readaheadStart, parseResult.length - m_readaheadStart);
+
+			return baos.toByteArray();
 		}
 	}
 }

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/SQLXMLImpl.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/SQLXMLImpl.java
@@ -800,14 +800,29 @@ public abstract class SQLXMLImpl<V extends Closeable> implements SQLXML
 		public void startEntity(String name)
 		throws SAXException
 		{
-			m_th.startEntity(name);
+			/*
+			 * For the time being, do NOT pass through startEntity/endEntity.
+			 * When we are the result of a transform using the JRE-bundled
+			 * Transformer implementation, we may get called by a class
+			 * com.sun.org.apache.xml.internal.serializer.ToXMLSAXHandler
+			 * that overrides startEntity and gives us those, but neglects to
+			 * override endEntity and never gives us those, leaving our
+			 * serializer thinking it's stuck in an entity forever. (Insert
+			 * Java bug number here if assigned.) Can revisit later if a fixed
+			 * Java version is known, or could use a simple test to check for
+			 * presence of the bug.
+			 */
+			//m_th.startEntity(name);
 		}
 
 		@Override
 		public void endEntity(String name)
 		throws SAXException
 		{
-			m_th.endEntity(name);
+			/*
+			 * See startEntity.
+			 */
+			// m_th.endEntity(name);
 		}
 
 		@Override

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/SQLXMLImpl.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/SQLXMLImpl.java
@@ -31,6 +31,7 @@ import java.io.IOException;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.postgresql.pljava.internal.Backend;
+import org.postgresql.pljava.internal.MarkableSequenceInputStream;
 
 import java.sql.SQLNonTransientException;
 

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/SQLXMLImpl.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/SQLXMLImpl.java
@@ -552,6 +552,17 @@ public abstract class SQLXMLImpl<V extends Closeable> implements SQLXML
 				"No support for SQLXML.setResult(" +
 				resultClass.getName() + ".class)", "0A000");
 		}
+
+		private VarlenaWrapper.Output adopt() throws SQLException
+		{
+			VarlenaWrapper.Output vwo = m_backing.getAndSet(null);
+			if ( m_writable.get() )
+				throw new SQLNonTransientException(
+					"Writable SQLXML object has not been written yet", "55000");
+			if ( null == vwo )
+				backingIfNotFreed(); /* shorthand way to throw the exception */
+			return vwo;
+		}
 	}
 
 	static class DeclCheckedOutputStream extends FilterOutputStream

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/SQLXMLImpl.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/SQLXMLImpl.java
@@ -47,6 +47,8 @@ import javax.xml.transform.stax.StAXSource;
 import javax.xml.transform.dom.DOMSource;
 
 import org.xml.sax.InputSource;
+import org.xml.sax.XMLReader;
+import org.xml.sax.helpers.XMLReaderFactory;
 
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamReader;
@@ -271,12 +273,18 @@ public abstract class SQLXMLImpl<V extends Closeable> implements SQLXML
 						new StreamSource(is));
 
 				if ( sourceClass.isAssignableFrom(SAXSource.class) )
+				{
+					XMLReader xr = XMLReaderFactory.createXMLReader();
+					xr.setFeature("http://xml.org/sax/features/namespaces",
+								  true);
 					return sourceClass.cast(
-						new SAXSource(new InputSource(is)));
+						new SAXSource(xr, new InputSource(is)));
+				}
 
 				if ( sourceClass.isAssignableFrom(StAXSource.class) )
 				{
 					XMLInputFactory xif = XMLInputFactory.newFactory();
+					xif.setProperty(xif.IS_NAMESPACE_AWARE, true);
 					XMLStreamReader xsr =
 						xif.createXMLStreamReader(is);
 					return sourceClass.cast(new StAXSource(xsr));
@@ -286,6 +294,7 @@ public abstract class SQLXMLImpl<V extends Closeable> implements SQLXML
 				{
 					DocumentBuilderFactory dbf =
 						DocumentBuilderFactory.newInstance();
+					dbf.setNamespaceAware(true);
 					DocumentBuilder db = dbf.newDocumentBuilder();
 					return sourceClass.cast(new DOMSource(db.parse(is)));
 				}

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/SQLXMLImpl.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/SQLXMLImpl.java
@@ -37,6 +37,7 @@ import java.sql.SQLNonTransientException;
 
 /* ... for SQLXMLImpl.Readable */
 
+import java.io.FilterInputStream;
 import java.io.InputStreamReader;
 import java.nio.CharBuffer;
 import java.nio.charset.Charset;
@@ -524,10 +525,21 @@ public abstract class SQLXMLImpl<V extends Closeable> implements SQLXML
 			boolean mustBeDocument = false;
 			boolean cantBeDocument = false;
 
+			/*
+			 * The XMLStreamReader may actually close the input stream if it
+			 * reaches the end skipping only whitespace. That is probably a bug;
+			 * in any case, protect the original input stream from being closed.
+			 */
+			InputStream tmpis = new FilterInputStream(is)
+			{
+				@Override
+				public void close() throws IOException { }
+			};
+
 			XMLStreamReader xsr = null;
 			try
 			{
-				xsr = xif.createXMLStreamReader(is);
+				xsr = xif.createXMLStreamReader(tmpis);
 				while ( xsr.hasNext() )
 				{
 					int evt = xsr.next();

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/SQLXMLImpl.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/SQLXMLImpl.java
@@ -33,6 +33,32 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import java.sql.SQLNonTransientException;
 
+/* Supplemental imports for SQLXMLImpl.Readable */
+
+import java.io.InputStreamReader;
+import java.nio.CharBuffer;
+import java.nio.charset.Charset;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import javax.xml.transform.stream.StreamSource;
+import javax.xml.transform.sax.SAXSource;
+import javax.xml.transform.stax.StAXSource;
+import javax.xml.transform.dom.DOMSource;
+
+import org.xml.sax.InputSource;
+
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamReader;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import static org.postgresql.pljava.internal.Session.implServerCharset;
+import org.postgresql.pljava.internal.VarlenaWrapper;
+
+import java.sql.SQLFeatureNotSupportedException;
+
 public abstract class SQLXMLImpl<V extends Closeable> implements SQLXML
 {
 	protected AtomicReference<V> m_backing;
@@ -154,5 +180,124 @@ public abstract class SQLXMLImpl<V extends Closeable> implements SQLXML
 		return new SQLException(
 			"Exception in XML processing, not otherwise provided for",
 			"XX000", e);
+	}
+
+	static class Readable extends SQLXMLImpl<InputStream>
+	{
+		private AtomicBoolean m_readable = new AtomicBoolean(true);
+		private Charset m_serverCS = implServerCharset();
+
+		private Readable(VarlenaWrapper.Input vwi) throws SQLException
+		{
+			super(vwi);
+			if ( null == m_serverCS )
+			{
+				try
+				{
+					vwi.close();
+				}
+				catch ( IOException ioe ) { }
+				throw new SQLFeatureNotSupportedException("SQLXML: no Java " +
+					"Charset found to match server encoding; perhaps set " +
+					"org.postgresql.server.encoding system property to a " +
+					"valid Java charset name for the same encoding?", "0A000");
+			}
+		}
+
+		private InputStream backingAndClearReadable() throws SQLException
+		{
+			InputStream backing = backingIfNotFreed();
+			return m_readable.getAndSet(false) ? backing : null;
+		}
+
+		@Override
+		public InputStream getBinaryStream() throws SQLException
+		{
+			InputStream is = backingAndClearReadable();
+			if ( null == is )
+				return super.getBinaryStream();
+			return is;
+		}
+
+		@Override
+		public Reader getCharacterStream() throws SQLException
+		{
+			InputStream is = backingAndClearReadable();
+			if ( null == is )
+				return super.getCharacterStream();
+			return new InputStreamReader(is, m_serverCS.newDecoder());
+		}
+
+		@Override
+		public String getString() throws SQLException
+		{
+			InputStream is = backingAndClearReadable();
+			if ( null == is )
+				return super.getString();
+
+			Reader r = new InputStreamReader(is, m_serverCS.newDecoder());
+			CharBuffer cb = CharBuffer.allocate(32768);
+			StringBuilder sb = new StringBuilder();
+			try {
+				while ( -1 != r.read(cb) )
+				{
+					sb.append((CharBuffer)cb.flip());
+					cb.clear();
+				}
+				r.close();
+				return sb.toString();
+			}
+			catch ( Exception e )
+			{
+				throw normalizedException(e);
+			}
+		}
+
+		@Override
+		public <T extends Source> T getSource(Class<T> sourceClass)
+		throws SQLException
+		{
+			InputStream is = backingAndClearReadable();
+			if ( null == is )
+				return super.getSource(sourceClass);
+
+			if ( null == sourceClass || Source.class == sourceClass )
+				sourceClass = (Class<T>)StreamSource.class; // trust me on this
+
+			try
+			{
+				if ( sourceClass.isAssignableFrom(StreamSource.class) )
+					return sourceClass.cast(
+						new StreamSource(is));
+
+				if ( sourceClass.isAssignableFrom(SAXSource.class) )
+					return sourceClass.cast(
+						new SAXSource(new InputSource(is)));
+
+				if ( sourceClass.isAssignableFrom(StAXSource.class) )
+				{
+					XMLInputFactory xif = XMLInputFactory.newFactory();
+					XMLStreamReader xsr =
+						xif.createXMLStreamReader(is);
+					return sourceClass.cast(new StAXSource(xsr));
+				}
+
+				if ( sourceClass.isAssignableFrom(DOMSource.class) )
+				{
+					DocumentBuilderFactory dbf =
+						DocumentBuilderFactory.newInstance();
+					DocumentBuilder db = dbf.newDocumentBuilder();
+					return sourceClass.cast(new DOMSource(db.parse(is)));
+				}
+			}
+			catch ( Exception e )
+			{
+				throw normalizedException(e);
+			}
+
+			throw new SQLFeatureNotSupportedException(
+				"No support for SQLXML.getSource(" +
+				sourceClass.getName() + ".class)", "0A000");
+		}
 	}
 }


### PR DESCRIPTION
This type has been unsupported in PL/Java until now, despite being specified in JDBC since version 4 and Java 6 and despite PostgreSQL having an XML type since PG 8.3.

It has not been impossible for PL/Java functions to work with XML data; the default mappings have allowed accessing a value of XML type as a `String` object. But that's an extra porting burden on code developed with the standard API in mind, can risk either unexpected errors or silent corruption for some combinations of character encoding settings, and also has memory implications.

While a database design using XML may be such that each XML datum is individually small, it is also easy to store—or generate in queries—large XML values. When mapped to a Java `String`, every XML value ends up with its full, uncompressed, character-serialized size having to be allocated on the Java heap and copied there from native memory, before the Java code even begins to make use of it. Even in cases where the Java processing to be done can be organized as a scan through parse events in constant-bounded memory, the `String` representation forces the entire XML value to occupy Java memory at once, and a worst-case estimate of that size may need to be used when tuning heap size options for the Java VM, to avoid failures at run time.

An `SQLXML` instance can have the "conceptual states" _readable_ or _not readable_, _writable_ or _not writable_. In PL/Java, an instance passed in as a parameter to a function, or retrieved from a `ResultSet`, is _readable_ and _not writable_, and can be used as input to processing with any of several Java XML APIs. It can be used that way exactly once, which changes its state to _not readable_. As it is read, it streams data as needed from PG native memory directly, without ever (unless requested in `String` or `DOM` form) accumulating it all on the Java heap. Java heap sizing can thus be based on just what the application Java code will be doing with the data.

To obtain a _readable_ instance, declare `java.sql.SQLXML` as the type of a function parameter where PostgreSQL will pass an XML argument, or use the `getSQLXML` or `getObject(..., SQLXML.class)` methods on a `ResultSet`, or the `readSQLXML` or `readObject(SQLXML.class)` methods on `SQLInput`. A fully JDBC-4.0 compliant driver would also return `SQLXML` instances from the non-specific `getObject` and `readObject` methods, but in PL/Java, those have historically returned `String`. Because 1.5.1 is not a major release, their behavior has not changed, and the more-specific methods must be used to obtain `SQLXML` instances.

PL/Java will supply an empty `SQLXML` instance that is _writable_ and _not readable_ via the `Connection` method `createSQLXML()`. It can be used as an output destination for any of several Java XML APIs, again exactly once, which changes its state to _not writable_. Once fully written and closed, it can be returned from a Java function, passed as a `PreparedStatement` parameter to a nested query, or stored into writable `ResultSet`s used for composite function or trigger results. Data written to it accumulates in PostgreSQL native memory, not the Java heap.

A written `SQLXML` instance can be used exactly once in any of those ways, which transfer its ownership back to PostgreSQL, leaving it inaccessible from Java.

The general rule that only a _writable_ instance (that has been written and closed) can be used as a function result, or passed into a nested query, admits one exception, allowing a _readable_ instance that Java code has obtained but not read. That makes it simple for Java code to obtain an `SQLXML` instance passed in as a parameter, or from a query, and use it directly as a result or a nested-query parameter. Each instance, again, can be used this way exactly once.

An XML value in SQL can have the type `XML(DOCUMENT)` or `XML(CONTENT)` (as those are defined in the ISO SQL standard, 2006 and later), which PostgreSQL does not currently treat as distinct types. The `DOCUMENT` form must have exactly one root element, may have a DTD, and has strict limits on where other productions (other than comments and processing instructions) can occur. A value in `CONTENT` form may have no root element, or more than one element at top level, and other productions such as character data outside of a root element where `DOCUMENT` form would not.

Java code using a _readable_ `SQLXML` instance as input should be prepared to encounter either form (unless it has out-of-band knowledge of which form will be supplied). If it requests a `DOMSource`, it can simply check the type of node it retrieves from the `DOMSource`'s `getNode` method, which will be a `Document` node, if the value met all the requirements for `DOCUMENT`, or a `DocumentFragment` node, if it was parsable as `CONTENT`. Java code requesting a `SAXSource` or `StAXSource` should be prepared to handle a sequence of parse events that might not be encountered when parsing a strictly conforming `DOCUMENT`. Java code that requests an `InputStream`, `Reader`, `String`, or `StreamSource` will be on its own to parse the data in whichever form appears.

Java code using a _writable_ SQLXML instance to produce a result may write either `DOCUMENT` or `CONTENT` form. If using `DOMResult`, it must supply a `DocumentFragment` node to produce a `CONTENT` result, as a `Document` node will enforce the `DOCUMENT` requirements.

The JDBC spec provides that an `SQLXML` instance is "valid for the duration of the transaction in which it was created." One PL/Java function can hold an `SQLXML` instance (in a static or session variable or data structure), and other PL/Java functions called later in the same transaction can continue reading from or writing to it. If the transaction has committed or rolled back, those operations will generate an exception.

PostgreSQL may store large XML values in "TOASTed" form, which can be in memory but compressed (XML typically compresses to a small fraction of its serialized size), or may be a small pointer to a location in storage. A _readable_ `SQLXML` instance over a TOASTed value will not be detoasted until Java code actually begins to read it, so the memory footprint of an instance being held but not yet read is kept low. This is transparent to the application code.

Some of the methods by which a _writable_ instance can be written are not XML-specific APIs, but allow arbitrary content to be written (as a `String`, `Writer`, or `OutputStream`). When written by those methods, it upholds type safety by verifying that the written content can be successfully reparsed, accepting either `DOCUMENT` or `CONTENT` form.

It remains possible to declare the Java type `String` for function parameters and returns of XML type, and to retrieve and supply `String` for `ResultSet` columns and `PreparedStatement` parameters of XML type. This historic mapping from `String` to XML uses PostgreSQL's `xml_in` function to verify the contents of a `String` from Java. As always, that function may reject some valid values if the server configuration variable `xmloption` is not first set to `DOCUMENT` or `CONTENT` to match the type of the value.

In symmetry to using Java `String` for SQL's XML types, PL/Java allows the Java `SQLXML` type to be used with PostgreSQL data of type `text`. This allows full use of the Java XML APIs even in PostgreSQL instances built without XML support. All of the `SQLXML` behaviors described above also apply in this usage.

If a _readable_ `SQLXML` instance obtained from a `text` value is directly used to set or return a value of PostgreSQL's XML type, the XML-ness of the content is verified.