### PR TITLE
Schema-qualify objects in queries/DDL PL/Java generates internally.

### DIFF
--- a/pljava-api/src/main/java/org/postgresql/pljava/sqlgen/DDRProcessor.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/sqlgen/DDRProcessor.java
@@ -2505,7 +2505,7 @@ hunt:	for ( ExecutableElement ee : ees )
 					e, rslt, array, row, defaults, withDefault);
 
 			if ( tm.getKind().equals( TypeKind.VOID) )
-				return "void"; // can't be a parameter type so no defaults apply
+				return "pg_catalog.void"; // return type only; no defaults apply
 
 			if ( tm.getKind().equals( TypeKind.ERROR) )
 			{

--- a/pljava-api/src/main/java/org/postgresql/pljava/sqlgen/DDRProcessor.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/sqlgen/DDRProcessor.java
@@ -1632,7 +1632,7 @@ hunt:	for ( ExecutableElement ee : ees )
 			appendNameAndParams( sb, true);
 			sb.append( "\n\tRETURNS ");
 			if ( trigger )
-				sb.append( "trigger");
+				sb.append( "pg_catalog.trigger");
 			else
 			{
 				if ( setof )
@@ -1642,7 +1642,7 @@ hunt:	for ( ExecutableElement ee : ees )
 				else if ( null != setofComponent )
 					sb.append( tmpr.getSQLType( setofComponent, func));
 				else if ( setof )
-					sb.append( "RECORD");
+					sb.append( "pg_catalog.RECORD");
 				else
 					sb.append( tmpr.getSQLType( func.getReturnType(), func));
 			}
@@ -1707,10 +1707,10 @@ hunt:	for ( ExecutableElement ee : ees )
 
 	static enum BaseUDTFunctionID
 	{
-		INPUT( "in", "cstring, oid, integer", null),
-		OUTPUT( "out", null, "cstring"),
-		RECEIVE( "recv", "internal, oid, integer", null),
-		SEND( "send", null, "bytea");
+		INPUT( "in", "pg_catalog.cstring, pg_catalog.oid, integer", null),
+		OUTPUT( "out", null, "pg_catalog.cstring"),
+		RECEIVE( "recv", "pg_catalog.internal, pg_catalog.oid, integer", null),
+		SEND( "send", null, "pg_catalog.bytea");
 		BaseUDTFunctionID( String suffix, String param, String ret)
 		{
 			this.suffix = suffix;
@@ -2228,7 +2228,7 @@ hunt:	for ( ExecutableElement ee : ees )
 		{
 			protoMappings = new ArrayList<Map.Entry<TypeMirror, String>>();
 
-			// Primitives
+			// Primitives (these need not, indeed cannot, be schema-qualified)
 			//
 			this.addMap(boolean.class, "boolean");
 			this.addMap(Boolean.class, "boolean");
@@ -2249,27 +2249,29 @@ hunt:	for ( ExecutableElement ee : ees )
 
 			// Known common mappings
 			//
-			this.addMap(Number.class, "numeric");
-			this.addMap(String.class, "varchar");
-			this.addMap(java.util.Date.class, "timestamp");
-			this.addMap(Timestamp.class, "timestamp");
-			this.addMap(Time.class, "time");
-			this.addMap(java.sql.Date.class, "date");
-			this.addMap(java.sql.SQLXML.class, "xml");
-			this.addMap(BigInteger.class, "numeric");
-			this.addMap(BigDecimal.class, "numeric");
-			this.addMap(ResultSet.class, "record");
-			this.addMap(Object.class, "\"any\"");
+			this.addMap(Number.class, "pg_catalog.numeric");
+			this.addMap(String.class, "pg_catalog.varchar");
+			this.addMap(java.util.Date.class, "pg_catalog.timestamp");
+			this.addMap(Timestamp.class, "pg_catalog.timestamp");
+			this.addMap(Time.class, "pg_catalog.time");
+			this.addMap(java.sql.Date.class, "pg_catalog.date");
+			this.addMap(java.sql.SQLXML.class, "pg_catalog.xml");
+			this.addMap(BigInteger.class, "pg_catalog.numeric");
+			this.addMap(BigDecimal.class, "pg_catalog.numeric");
+			this.addMap(ResultSet.class, "pg_catalog.record");
+			this.addMap(Object.class, "pg_catalog.\"any\"");
 
-			this.addMap(byte[].class, "bytea");
+			this.addMap(byte[].class, "pg_catalog.bytea");
 
 			// (Once Java back horizon advances to 8, do these the easy way.)
 			//
-			this.addMapIfExists("java.time.LocalDate", "date");
-			this.addMapIfExists("java.time.LocalTime", "time");
-			this.addMapIfExists("java.time.OffsetTime", "timetz");
-			this.addMapIfExists("java.time.LocalDateTime", "timestamp");
-			this.addMapIfExists("java.time.OffsetDateTime", "timestamptz");
+			this.addMapIfExists("java.time.LocalDate", "pg_catalog.date");
+			this.addMapIfExists("java.time.LocalTime", "pg_catalog.time");
+			this.addMapIfExists("java.time.OffsetTime", "pg_catalog.timetz");
+			this.addMapIfExists("java.time.LocalDateTime",
+				"pg_catalog.timestamp");
+			this.addMapIfExists("java.time.OffsetDateTime",
+				"pg_catalog.timestamptz");
 		}
 
 		private boolean mappingsFrozen()

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/SPIConnection.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/SPIConnection.java
@@ -702,7 +702,7 @@ public class SPIConnection implements Connection
         	return VERSION_NUMBER;
 
         ResultSet rs = createStatement().executeQuery(
-            "SELECT version()");
+            "SELECT pg_catalog.version()");
 
         try
         {

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/SPIDatabaseMetaData.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/SPIDatabaseMetaData.java
@@ -26,6 +26,7 @@ import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 import java.sql.Statement;
 import java.util.ArrayList;
+import static java.util.Arrays.sort;
 import java.util.HashMap;
 
 import org.postgresql.pljava.internal.AclId;
@@ -1695,12 +1696,9 @@ public class SPIDatabaseMetaData implements DatabaseMetaData
 		sql += " AND (false ";
 		for(int i = 0; i < types.length; i++)
 		{
-			HashMap clauses = (HashMap)s_tableTypeClauses.get(types[i]);
-			if(clauses != null)
-			{
-				String clause = (String)clauses.get(useSchemas);
+			String clause = s_tableTypeClauses.get(types[i]);
+			if(clause != null)
 				sql += " OR ( " + clause + " ) ";
-			}
 		}
 		sql += ") ";
 		sql += orderby;
@@ -1708,104 +1706,48 @@ public class SPIDatabaseMetaData implements DatabaseMetaData
 		return createMetaDataStatement().executeQuery(sql);
 	}
 
-	private static final HashMap s_tableTypeClauses;
+	private static final HashMap<String,String> s_tableTypeClauses;
 	static
 	{
-		s_tableTypeClauses = new HashMap();
-		HashMap ht = new HashMap();
-		s_tableTypeClauses.put("TABLE", ht);
-		ht.put("SCHEMAS",
+		s_tableTypeClauses = new HashMap<String,String>();
+		s_tableTypeClauses.put("TABLE",
 			"c.relkind OPERATOR(pg_catalog.=) 'r' " +
 			"AND n.nspname NOT LIKE 'pg!_%' ESCAPE '!' " +
 			"AND n.nspname OPERATOR(pg_catalog.<>) 'information_schema'");
-		ht.put("NOSCHEMAS",
-			"c.relkind OPERATOR(pg_catalog.=) 'r' " +
-			"AND c.relname NOT LIKE 'pg!_%' ESCAPE '!'");
-		ht = new HashMap();
-		s_tableTypeClauses.put("VIEW", ht);
-		ht.put("SCHEMAS",
+		s_tableTypeClauses.put("VIEW",
 			"c.relkind OPERATOR(pg_catalog.=) 'v' " +
 			"AND n.nspname OPERATOR(pg_catalog.<>) 'pg_catalog' " +
 			"AND n.nspname OPERATOR(pg_catalog.<>) 'information_schema'");
-		ht.put("NOSCHEMAS",
-			"c.relkind OPERATOR(pg_catalog.=) 'v' " +
-			"AND c.relname NOT LIKE 'pg!_%' ESCAPE '!'");
-		ht = new HashMap();
-		s_tableTypeClauses.put("INDEX", ht);
-		ht.put("SCHEMAS",
+		s_tableTypeClauses.put("INDEX",
 			"c.relkind OPERATOR(pg_catalog.=) 'i' " +
 			"AND n.nspname NOT LIKE 'pg!_%' ESCAPE '!' " +
 			"AND n.nspname OPERATOR(pg_catalog.<>) 'information_schema'");
-		ht.put("NOSCHEMAS",
-			"c.relkind OPERATOR(pg_catalog.=) 'i' " +
-			"AND c.relname NOT LIKE 'pg!_%' ESCAPE '!'");
-		ht = new HashMap();
-		s_tableTypeClauses.put("SEQUENCE", ht);
-		ht.put("SCHEMAS", "c.relkind OPERATOR(pg_catalog.=) 'S'");
-		ht.put("NOSCHEMAS", "c.relkind OPERATOR(pg_catalog.=) 'S'");
-		ht = new HashMap();
-		s_tableTypeClauses.put("SYSTEM TABLE", ht);
-		ht.put("SCHEMAS",
+		s_tableTypeClauses.put("SEQUENCE",
+			"c.relkind OPERATOR(pg_catalog.=) 'S'");
+		s_tableTypeClauses.put("SYSTEM TABLE",
 			"c.relkind OPERATOR(pg_catalog.=) 'r' AND (" +
 			" n.nspname OPERATOR(pg_catalog.=) 'pg_catalog'" +
 			" OR n.nspname OPERATOR(pg_catalog.=) 'information_schema')");
-		ht.put("NOSCHEMAS",
-			"c.relkind OPERATOR(pg_catalog.=) 'r' " +
-			"AND c.relname LIKE 'pg!_%' ESCAPE '!' " +
-			"AND c.relname NOT LIKE 'pg!_toast!_%' ESCAPE '!' " +
-			"AND c.relname NOT LIKE 'pg!_temp!_%' ESCAPE '!'");
-		ht = new HashMap();
-		s_tableTypeClauses.put("SYSTEM TOAST TABLE", ht);
-		ht.put("SCHEMAS",
+		s_tableTypeClauses.put("SYSTEM TOAST TABLE",
 			"c.relkind OPERATOR(pg_catalog.=) 'r' " +
 			"AND n.nspname OPERATOR(pg_catalog.=) 'pg_toast'");
-		ht.put("NOSCHEMAS",
-			"c.relkind OPERATOR(pg_catalog.=) 'r' " +
-			"AND c.relname LIKE 'pg!_toast!_%' ESCAPE '!'");
-		ht = new HashMap();
-		s_tableTypeClauses.put("SYSTEM TOAST INDEX", ht);
-		ht.put("SCHEMAS",
+		s_tableTypeClauses.put("SYSTEM TOAST INDEX",
 			"c.relkind OPERATOR(pg_catalog.=) 'i' " +
 			"AND n.nspname OPERATOR(pg_catalog.=) 'pg_toast'");
-		ht.put("NOSCHEMAS",
-			"c.relkind OPERATOR(pg_catalog.=) 'i' " +
-			"AND c.relname LIKE 'pg!_toast!_%' ESCAPE '!'");
-		ht = new HashMap();
-		s_tableTypeClauses.put("SYSTEM VIEW", ht);
-		ht.put("SCHEMAS",
+		s_tableTypeClauses.put("SYSTEM VIEW",
 			"c.relkind OPERATOR(pg_catalog.=) 'v' AND (" +
 			" n.nspname OPERATOR(pg_catalog.=) 'pg_catalog'" +
 			" OR n.nspname OPERATOR(pg_catalog.=) 'information_schema') ");
-		ht.put("NOSCHEMAS",
-			"c.relkind OPERATOR(pg_catalog.=) 'v' " +
-			"AND c.relname LIKE 'pg!_%' ESCAPE '!'");
-		ht = new HashMap();
-		s_tableTypeClauses.put("SYSTEM INDEX", ht);
-		ht.put("SCHEMAS",
+		s_tableTypeClauses.put("SYSTEM INDEX",
 			"c.relkind OPERATOR(pg_catalog.=) 'i' AND (" +
 			" n.nspname OPERATOR(pg_catalog.=) 'pg_catalog'" +
 			" OR n.nspname OPERATOR(pg_catalog.=) 'information_schema') ");
-		ht.put("NOSCHEMAS",
-			"c.relkind OPERATOR(pg_catalog.=) 'i' " +
-			"AND c.relname LIKE 'pg!_%' ESCAPE '!' " +
-			"AND c.relname NOT LIKE 'pg!_toast!_%' ESCAPE '!' " +
-			"AND c.relname NOT LIKE 'pg!_temp!_%' ESCAPE '!'");
-		ht = new HashMap();
-		s_tableTypeClauses.put("TEMPORARY TABLE", ht);
-		ht.put("SCHEMAS",
+		s_tableTypeClauses.put("TEMPORARY TABLE",
 			"c.relkind OPERATOR(pg_catalog.=) 'r' " +
 			"AND n.nspname LIKE 'pg!_temp!_%' ESCAPE '!' ");
-		ht.put("NOSCHEMAS",
-			"c.relkind OPERATOR(pg_catalog.=) 'r' " +
-			"AND c.relname LIKE 'pg!_temp!_%' ESCAPE '!' ");
-		ht = new HashMap();
-		s_tableTypeClauses.put("TEMPORARY INDEX", ht);
-		ht.put("SCHEMAS",
+		s_tableTypeClauses.put("TEMPORARY INDEX",
 			"c.relkind OPERATOR(pg_catalog.=) 'i' " +
 			"AND n.nspname LIKE 'pg!_temp!_%' ESCAPE '!' ");
-		ht.put("NOSCHEMAS",
-			"c.relkind OPERATOR(pg_catalog.=) 'i' " +
-			"AND c.relname LIKE 'pg!_temp!_%' ESCAPE '!' ");
 	}
 
 	// These are the default tables, used when NULL is passed to getTables
@@ -1851,7 +1793,7 @@ public class SPIDatabaseMetaData implements DatabaseMetaData
 	public java.sql.ResultSet getTableTypes() throws SQLException
 	{
 		String types[] = (String[])s_tableTypeClauses.keySet().toArray(new String[s_tableTypeClauses.size()]);
-		sortStringArray(types);
+		sort(types);
 
 		ResultSetField f[] = new ResultSetField[1];
 		ArrayList v = new ArrayList();
@@ -2141,7 +2083,7 @@ public class SPIDatabaseMetaData implements DatabaseMetaData
 			acls = (String[])rs.getObject("relacl");
 			permissions = parseACL(acls, owner);
 			permNames = (String[])permissions.keySet().toArray(new String[permissions.size()]);
-			sortStringArray(permNames);
+			sort(permNames);
 			for(int i = 0; i < permNames.length; i++)
 			{
 				ArrayList grantees = (ArrayList)permissions.get(permNames[i]);
@@ -2238,7 +2180,7 @@ public class SPIDatabaseMetaData implements DatabaseMetaData
 			acls = (String[])rs.getObject("relacl");
 			permissions = parseACL(acls, owner);
 			permNames = (String[])permissions.keySet().toArray(new String[permissions.size()]);
-			sortStringArray(permNames);
+			sort(permNames);
 			for(int i = 0; i < permNames.length; i++)
 			{
 				ArrayList grantees = (ArrayList)permissions.get(permNames[i]);
@@ -2261,22 +2203,6 @@ public class SPIDatabaseMetaData implements DatabaseMetaData
 		rs.close();
 
 		return createSyntheticResultSet(f, v);
-	}
-
-	private static void sortStringArray(String s[])
-	{
-		for(int i = 0; i < s.length - 1; i++)
-		{
-			for(int j = i + 1; j < s.length; j++)
-			{
-				if(s[i].compareTo(s[j]) > 0)
-				{
-					String tmp = s[i];
-					s[i] = s[j];
-					s[j] = tmp;
-				}
-			}
-		}
 	}
 
 	/**

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/SPIDatabaseMetaData.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/SPIDatabaseMetaData.java
@@ -67,10 +67,12 @@ public class SPIDatabaseMetaData implements DatabaseMetaData
 	{
 		if(NAMEDATALEN == 0)
 		{
-			String sql = "SELECT t.typlen FROM pg_catalog.pg_type t, pg_catalog.pg_namespace n" +
-						 " WHERE t.typnamespace=n.oid" +
-						 "   AND t.typname='name'" +
-						 "   AND n.nspname='pg_catalog'";
+			String sql =
+				"SELECT t.typlen" +
+				" FROM pg_catalog.pg_type t, pg_catalog.pg_namespace n" +
+				" WHERE t.typnamespace OPERATOR(pg_catalog.=) n.oid" +
+				"	AND t.typname OPERATOR(pg_catalog.=) 'name'" +
+				"	AND n.nspname OPERATOR(pg_catalog.=) 'pg_catalog'";
 
 			ResultSet rs = m_connection.createStatement().executeQuery(sql);
 			if(!rs.next()){ throw new SQLException(
@@ -102,7 +104,7 @@ public class SPIDatabaseMetaData implements DatabaseMetaData
 	}
 
 	/*
-	 * What is the URL for this database? @return the url or null if it cannott
+	 * What is the URL for this database? @return the url or null if it cannot
 	 * be generated @exception SQLException if a database access error occurs
 	 */
 	public String getURL() throws SQLException
@@ -1339,7 +1341,7 @@ public class SPIDatabaseMetaData implements DatabaseMetaData
 			//This means that only "visible" schemas are searched.
 			//It was approved to change to *all* schemas.
             //return expr + " " + operator + " ANY (current_schemas(true))";
-			return "1=1";
+			return "1 OPERATOR(pg_catalog.=) 1";
         }
         //schema is specified => search in this schema
 		else if(!"".equals(schema))
@@ -1363,7 +1365,8 @@ public class SPIDatabaseMetaData implements DatabaseMetaData
 	 */
 	private static String resolveSchemaCondition(String expr, String schema)
 	{
-        return resolveSchemaConditionWithOperator(expr, schema, "=");
+        return resolveSchemaConditionWithOperator(
+			expr, schema, "OPERATOR(pg_catalog.=)");
     }
 
 	/**
@@ -1407,10 +1410,15 @@ public class SPIDatabaseMetaData implements DatabaseMetaData
 				+ java.sql.DatabaseMetaData.procedureReturnsResult
 				+ " AS PROCEDURE_TYPE "
 				+ " FROM pg_catalog.pg_namespace n, pg_catalog.pg_proc p "
-				+ " LEFT JOIN pg_catalog.pg_description d ON (p.oid=d.objoid) "
-				+ " LEFT JOIN pg_catalog.pg_class c ON (d.classoid=c.oid AND c.relname='pg_proc') "
-				+ " LEFT JOIN pg_catalog.pg_namespace pn ON (c.relnamespace=pn.oid AND pn.nspname='pg_catalog') "
-				+ " WHERE p.pronamespace=n.oid "
+				+ " LEFT JOIN pg_catalog.pg_description d"
+				+ "  ON (p.oid OPERATOR(pg_catalog.=) d.objoid) "
+				+ " LEFT JOIN pg_catalog.pg_class c ON ("
+				+ "  d.classoid OPERATOR(pg_catalog.=) c.oid"
+				+ "  AND c.relname OPERATOR(pg_catalog.=) 'pg_proc') "
+				+ " LEFT JOIN pg_catalog.pg_namespace pn ON ("
+				+ "  c.relnamespace OPERATOR(pg_catalog.=) pn.oid"
+				+ "  AND pn.nspname OPERATOR(pg_catalog.=) 'pg_catalog') "
+				+ " WHERE p.pronamespace OPERATOR(pg_catalog.=) n.oid "
                 + " AND " + resolveSchemaPatternCondition(
                                 "n.nspname", schemaPattern);
 		if(procedureNamePattern != null)
@@ -1482,11 +1490,17 @@ public class SPIDatabaseMetaData implements DatabaseMetaData
 		f[12] = new ResultSetField("REMARKS", TypeOid.VARCHAR,
 			getMaxNameLength());
 
-		String sql = "SELECT n.nspname,p.proname,p.prorettype,p.proargtypes, t.typtype::varchar,t.typrelid "
-				+ " FROM pg_catalog.pg_proc p,pg_catalog.pg_namespace n, pg_catalog.pg_type t "
-				+ " WHERE p.pronamespace=n.oid AND p.prorettype=t.oid "
-                + " AND " + resolveSchemaPatternCondition(
-                                "n.nspname", schemaPattern);
+		String sql =
+			"SELECT"
+			+ "  n.nspname, p.proname, p.prorettype, p.proargtypes,"
+			+ "  t.typtype::pg_catalog.varchar, t.typrelid "
+			+ " FROM"
+			+ "  pg_catalog.pg_proc p, pg_catalog.pg_namespace n,"
+			+ "  pg_catalog.pg_type t"
+			+ " WHERE p.pronamespace OPERATOR(pg_catalog.=) n.oid"
+			+ " AND p.prorettype OPERATOR(pg_catalog.=) t.oid "
+            + " AND " + resolveSchemaPatternCondition(
+                            "n.nspname", schemaPattern);
 		if(procedureNamePattern != null)
 		{
 			sql += " AND p.proname LIKE '"
@@ -1607,46 +1621,63 @@ public class SPIDatabaseMetaData implements DatabaseMetaData
 	 * should be "%" @param types a list of table types to include; null returns
 	 * all types @return each row is a table description @exception SQLException
 	 * if a database-access error occurs.
+	 *
+	 * September 2018: instead of rewriting all these CASE foo WHEN WHEN WHEN
+	 * structures to avoid the implicit = operator, just cast the WHEN operands
+	 * to the known type ("char") of the proband, as there is sure to be an
+	 * =("char","char") in pg_catalog.
 	 */
 	public java.sql.ResultSet getTables(String catalog, String schemaPattern,
 		String tableNamePattern, String types[]) throws SQLException
 	{
 		String useSchemas = "SCHEMAS";
 		String select = "SELECT NULL AS TABLE_CAT, n.nspname AS TABLE_SCHEM, c.relname AS TABLE_NAME, "
-				+ " CASE n.nspname LIKE 'pg!_%' ESCAPE '!' OR n.nspname = 'information_schema' "
+				+ " CASE"
+				+ "  n.nspname LIKE 'pg!_%' ESCAPE '!'"
+				+ "  OR n.nspname OPERATOR(pg_catalog.=) 'information_schema' "
 				+ " WHEN true THEN CASE "
-				+ " WHEN n.nspname = 'pg_catalog' OR n.nspname = 'information_schema' THEN CASE c.relkind "
-				+ "  WHEN 'r' THEN 'SYSTEM TABLE' "
-				+ "  WHEN 'v' THEN 'SYSTEM VIEW' "
-				+ "  WHEN 'i' THEN 'SYSTEM INDEX' "
-				+ "  ELSE NULL "
+				+ "  WHEN"
+				+ "   n.nspname OPERATOR(pg_catalog.=) 'pg_catalog'"
+				+ "   OR n.nspname OPERATOR(pg_catalog.=) 'information_schema'"
+				+ "  THEN CASE c.relkind "
+				+ "   WHEN 'r'::pg_catalog.\"char\" THEN 'SYSTEM TABLE' "
+				+ "   WHEN 'v'::pg_catalog.\"char\" THEN 'SYSTEM VIEW' "
+				+ "   WHEN 'i'::pg_catalog.\"char\" THEN 'SYSTEM INDEX' "
+				+ "   ELSE NULL "
+				+ "   END "
+				+ "  WHEN n.nspname OPERATOR(pg_catalog.=) 'pg_toast'"
+				+ "  THEN CASE c.relkind "
+				+ "   WHEN 'r'::pg_catalog.\"char\" THEN 'SYSTEM TOAST TABLE' "
+				+ "   WHEN 'i'::pg_catalog.\"char\" THEN 'SYSTEM TOAST INDEX' "
+				+ "   ELSE NULL "
+				+ "   END "
+				+ "  ELSE CASE c.relkind "
+				+ "   WHEN 'r'::pg_catalog.\"char\" THEN 'TEMPORARY TABLE' "
+				+ "   WHEN 'i'::pg_catalog.\"char\" THEN 'TEMPORARY INDEX' "
+				+ "   ELSE NULL "
+				+ "   END "
 				+ "  END "
-				+ " WHEN n.nspname = 'pg_toast' THEN CASE c.relkind "
-				+ "  WHEN 'r' THEN 'SYSTEM TOAST TABLE' "
-				+ "  WHEN 'i' THEN 'SYSTEM TOAST INDEX' "
-				+ "  ELSE NULL "
-				+ "  END "
-				+ " ELSE CASE c.relkind "
-				+ "  WHEN 'r' THEN 'TEMPORARY TABLE' "
-				+ "  WHEN 'i' THEN 'TEMPORARY INDEX' "
-				+ "  ELSE NULL "
-				+ "  END "
-				+ " END "
 				+ " WHEN false THEN CASE c.relkind "
-				+ " WHEN 'r' THEN 'TABLE' "
-				+ " WHEN 'i' THEN 'INDEX' "
-				+ " WHEN 'S' THEN 'SEQUENCE' "
-				+ " WHEN 'v' THEN 'VIEW' "
-				+ " ELSE NULL "
-				+ " END "
+				+ "  WHEN 'r'::pg_catalog.\"char\" THEN 'TABLE' "
+				+ "  WHEN 'i'::pg_catalog.\"char\" THEN 'INDEX' "
+				+ "  WHEN 'S'::pg_catalog.\"char\" THEN 'SEQUENCE' "
+				+ "  WHEN 'v'::pg_catalog.\"char\" THEN 'VIEW' "
+				+ "  ELSE NULL "
+				+ "  END "
 				+ " ELSE NULL "
 				+ " END "
 				+ " AS TABLE_TYPE, d.description AS REMARKS "
 				+ " FROM pg_catalog.pg_namespace n, pg_catalog.pg_class c "
-				+ " LEFT JOIN pg_catalog.pg_description d ON (c.oid = d.objoid AND d.objsubid = 0) "
-				+ " LEFT JOIN pg_catalog.pg_class dc ON (d.classoid=dc.oid AND dc.relname='pg_class') "
-				+ " LEFT JOIN pg_catalog.pg_namespace dn ON (dn.oid=dc.relnamespace AND dn.nspname='pg_catalog') "
-				+ " WHERE c.relnamespace = n.oid "
+				+ " LEFT JOIN pg_catalog.pg_description d ON ("
+				+ "  c.oid OPERATOR(pg_catalog.=) d.objoid"
+				+ "  AND d.objsubid OPERATOR(pg_catalog.=) 0) "
+				+ " LEFT JOIN pg_catalog.pg_class dc ON ("
+				+ "  d.classoid OPERATOR(pg_catalog.=) dc.oid"
+				+ "  AND dc.relname OPERATOR(pg_catalog.=) 'pg_class') "
+				+ " LEFT JOIN pg_catalog.pg_namespace dn ON ("
+				+ "  dn.oid OPERATOR(pg_catalog.=) dc.relnamespace"
+				+ "  AND dn.nspname OPERATOR(pg_catalog.=) 'pg_catalog') "
+				+ " WHERE c.relnamespace OPERATOR(pg_catalog.=) n.oid "
                 + " AND " + resolveSchemaPatternCondition(
                                 "n.nspname", schemaPattern);
 		String orderby = " ORDER BY TABLE_TYPE,TABLE_SCHEM,TABLE_NAME ";
@@ -1684,64 +1715,97 @@ public class SPIDatabaseMetaData implements DatabaseMetaData
 		HashMap ht = new HashMap();
 		s_tableTypeClauses.put("TABLE", ht);
 		ht.put("SCHEMAS",
-			"c.relkind = 'r' AND n.nspname NOT LIKE 'pg!_%' ESCAPE '!' AND n.nspname <> 'information_schema'");
+			"c.relkind OPERATOR(pg_catalog.=) 'r' " +
+			"AND n.nspname NOT LIKE 'pg!_%' ESCAPE '!' " +
+			"AND n.nspname OPERATOR(pg_catalog.<>) 'information_schema'");
 		ht.put("NOSCHEMAS",
-			"c.relkind = 'r' AND c.relname NOT LIKE 'pg!_%' ESCAPE '!'");
+			"c.relkind OPERATOR(pg_catalog.=) 'r' " +
+			"AND c.relname NOT LIKE 'pg!_%' ESCAPE '!'");
 		ht = new HashMap();
 		s_tableTypeClauses.put("VIEW", ht);
 		ht.put("SCHEMAS",
-			"c.relkind = 'v' AND n.nspname <> 'pg_catalog' AND n.nspname <> 'information_schema'");
+			"c.relkind OPERATOR(pg_catalog.=) 'v' " +
+			"AND n.nspname OPERATOR(pg_catalog.<>) 'pg_catalog' " +
+			"AND n.nspname OPERATOR(pg_catalog.<>) 'information_schema'");
 		ht.put("NOSCHEMAS",
-			"c.relkind = 'v' AND c.relname NOT LIKE 'pg!_%' ESCAPE '!'");
+			"c.relkind OPERATOR(pg_catalog.=) 'v' " +
+			"AND c.relname NOT LIKE 'pg!_%' ESCAPE '!'");
 		ht = new HashMap();
 		s_tableTypeClauses.put("INDEX", ht);
 		ht.put("SCHEMAS",
-			"c.relkind = 'i' AND n.nspname NOT LIKE 'pg!_%' ESCAPE '!' AND n.nspname <> 'information_schema'");
+			"c.relkind OPERATOR(pg_catalog.=) 'i' " +
+			"AND n.nspname NOT LIKE 'pg!_%' ESCAPE '!' " +
+			"AND n.nspname OPERATOR(pg_catalog.<>) 'information_schema'");
 		ht.put("NOSCHEMAS",
-			"c.relkind = 'i' AND c.relname NOT LIKE 'pg!_%' ESCAPE '!'");
+			"c.relkind OPERATOR(pg_catalog.=) 'i' " +
+			"AND c.relname NOT LIKE 'pg!_%' ESCAPE '!'");
 		ht = new HashMap();
 		s_tableTypeClauses.put("SEQUENCE", ht);
-		ht.put("SCHEMAS", "c.relkind = 'S'");
-		ht.put("NOSCHEMAS", "c.relkind = 'S'");
+		ht.put("SCHEMAS", "c.relkind OPERATOR(pg_catalog.=) 'S'");
+		ht.put("NOSCHEMAS", "c.relkind OPERATOR(pg_catalog.=) 'S'");
 		ht = new HashMap();
 		s_tableTypeClauses.put("SYSTEM TABLE", ht);
 		ht.put("SCHEMAS",
-			"c.relkind = 'r' AND (n.nspname = 'pg_catalog' OR n.nspname = 'information_schema')");
+			"c.relkind OPERATOR(pg_catalog.=) 'r' AND (" +
+			" n.nspname OPERATOR(pg_catalog.=) 'pg_catalog'" +
+			" OR n.nspname OPERATOR(pg_catalog.=) 'information_schema')");
 		ht.put("NOSCHEMAS",
-			"c.relkind = 'r' AND c.relname LIKE 'pg!_%' ESCAPE '!' AND c.relname NOT LIKE 'pgLIKE 'pg!_toast!_%' ESCAPE '!'toast!_%' ESCAPE '!' AND c.relname NOT LIKE 'pg!_temp!_%' ESCAPE '!'");
+			"c.relkind OPERATOR(pg_catalog.=) 'r' " +
+			"AND c.relname LIKE 'pg!_%' ESCAPE '!' " +
+			"AND c.relname NOT LIKE 'pg!_toast!_%' ESCAPE '!' " +
+			"AND c.relname NOT LIKE 'pg!_temp!_%' ESCAPE '!'");
 		ht = new HashMap();
 		s_tableTypeClauses.put("SYSTEM TOAST TABLE", ht);
-		ht.put("SCHEMAS", "c.relkind = 'r' AND n.nspname = 'pg_toast'");
+		ht.put("SCHEMAS",
+			"c.relkind OPERATOR(pg_catalog.=) 'r' " +
+			"AND n.nspname OPERATOR(pg_catalog.=) 'pg_toast'");
 		ht.put("NOSCHEMAS",
-			"c.relkind = 'r' AND c.relname LIKE 'pg!_toast!_%' ESCAPE '!'");
+			"c.relkind OPERATOR(pg_catalog.=) 'r' " +
+			"AND c.relname LIKE 'pg!_toast!_%' ESCAPE '!'");
 		ht = new HashMap();
 		s_tableTypeClauses.put("SYSTEM TOAST INDEX", ht);
-		ht.put("SCHEMAS", "c.relkind = 'i' AND n.nspname = 'pg_toast'");
+		ht.put("SCHEMAS",
+			"c.relkind OPERATOR(pg_catalog.=) 'i' " +
+			"AND n.nspname OPERATOR(pg_catalog.=) 'pg_toast'");
 		ht.put("NOSCHEMAS",
-			"c.relkind = 'i' AND c.relname LIKE 'pg!_toast!_%' ESCAPE '!'");
+			"c.relkind OPERATOR(pg_catalog.=) 'i' " +
+			"AND c.relname LIKE 'pg!_toast!_%' ESCAPE '!'");
 		ht = new HashMap();
 		s_tableTypeClauses.put("SYSTEM VIEW", ht);
 		ht.put("SCHEMAS",
-			"c.relkind = 'v' AND (n.nspname = 'pg_catalog' OR n.nspname = 'information_schema') ");
-		ht.put("NOSCHEMAS", "c.relkind = 'v' AND c.relname LIKE 'pg!_%' ESCAPE '!'");
+			"c.relkind OPERATOR(pg_catalog.=) 'v' AND (" +
+			" n.nspname OPERATOR(pg_catalog.=) 'pg_catalog'" +
+			" OR n.nspname OPERATOR(pg_catalog.=) 'information_schema') ");
+		ht.put("NOSCHEMAS",
+			"c.relkind OPERATOR(pg_catalog.=) 'v' " +
+			"AND c.relname LIKE 'pg!_%' ESCAPE '!'");
 		ht = new HashMap();
 		s_tableTypeClauses.put("SYSTEM INDEX", ht);
 		ht.put("SCHEMAS",
-			"c.relkind = 'i' AND (n.nspname = 'pg_catalog' OR n.nspname = 'information_schema') ");
+			"c.relkind OPERATOR(pg_catalog.=) 'i' AND (" +
+			" n.nspname OPERATOR(pg_catalog.=) 'pg_catalog'" +
+			" OR n.nspname OPERATOR(pg_catalog.=) 'information_schema') ");
 		ht.put("NOSCHEMAS",
-			"c.relkind = 'v' AND c.relname LIKE 'pg!_%' ESCAPE '!' AND c.relname NOT LIKE 'pg!_toast!_%' ESCAPE '!' AND c.relname NOT LIKE 'pg!_temp!_%' ESCAPE '!'");
+			"c.relkind OPERATOR(pg_catalog.=) 'i' " +
+			"AND c.relname LIKE 'pg!_%' ESCAPE '!' " +
+			"AND c.relname NOT LIKE 'pg!_toast!_%' ESCAPE '!' " +
+			"AND c.relname NOT LIKE 'pg!_temp!_%' ESCAPE '!'");
 		ht = new HashMap();
 		s_tableTypeClauses.put("TEMPORARY TABLE", ht);
 		ht.put("SCHEMAS",
-			"c.relkind = 'r' AND n.nspname LIKE 'pg!_temp!_%' ESCAPE '!' ");
+			"c.relkind OPERATOR(pg_catalog.=) 'r' " +
+			"AND n.nspname LIKE 'pg!_temp!_%' ESCAPE '!' ");
 		ht.put("NOSCHEMAS",
-			"c.relkind = 'r' AND c.relname LIKE 'pg!_temp!_%' ESCAPE '!' ");
+			"c.relkind OPERATOR(pg_catalog.=) 'r' " +
+			"AND c.relname LIKE 'pg!_temp!_%' ESCAPE '!' ");
 		ht = new HashMap();
 		s_tableTypeClauses.put("TEMPORARY INDEX", ht);
 		ht.put("SCHEMAS",
-			"c.relkind = 'i' AND n.nspname LIKE 'pg!_temp!_%' ESCAPE '!' ");
+			"c.relkind OPERATOR(pg_catalog.=) 'i' " +
+			"AND n.nspname LIKE 'pg!_temp!_%' ESCAPE '!' ");
 		ht.put("NOSCHEMAS",
-			"c.relkind = 'i' AND c.relname LIKE 'pg!_temp!_%' ESCAPE '!' ");
+			"c.relkind OPERATOR(pg_catalog.=) 'i' " +
+			"AND c.relname LIKE 'pg!_temp!_%' ESCAPE '!' ");
 	}
 
 	// These are the default tables, used when NULL is passed to getTables
@@ -1757,7 +1821,11 @@ public class SPIDatabaseMetaData implements DatabaseMetaData
 	 */
 	public java.sql.ResultSet getSchemas() throws SQLException
 	{
-		String sql = "SELECT nspname AS TABLE_SCHEM FROM pg_catalog.pg_namespace WHERE nspname <> 'pg_toast' AND nspname NOT LIKE 'pg!_temp!_%' ESCAPE '!' ORDER BY TABLE_SCHEM";
+		String sql =
+			"SELECT nspname AS TABLE_SCHEM FROM pg_catalog.pg_namespace " +
+			"WHERE nspname  OPERATOR(pg_catalog.<>) 'pg_toast' " +
+			"AND nspname NOT LIKE 'pg!_temp!_%' ESCAPE '!' " +
+			"ORDER BY TABLE_SCHEM";
 		return createMetaDataStatement().executeQuery(sql);
 	}
 
@@ -1866,17 +1934,29 @@ public class SPIDatabaseMetaData implements DatabaseMetaData
 		f[17] = new ResultSetField("IS_NULLABLE", TypeOid.VARCHAR,
 			getMaxNameLength());
 
-		String sql = "SELECT n.nspname,c.relname,a.attname,"
-				+ " a.atttypid as atttypid,a.attnotnull,a.atttypmod,"
-				+ " a.attlen::int4 as attlen,a.attnum,def.adsrc,dsc.description "
+		String sql = "SELECT n.nspname, c.relname, a.attname,"
+				+ " a.atttypid as atttypid, a.attnotnull, a.atttypmod,"
+				+ " a.attlen::pg_catalog.int4 as attlen, a.attnum, def.adsrc,"
+				+ " dsc.description"
 				+ " FROM pg_catalog.pg_namespace n "
-				+ " JOIN pg_catalog.pg_class c ON (c.relnamespace = n.oid) "
-				+ " JOIN pg_catalog.pg_attribute a ON (a.attrelid=c.oid) "
-				+ " LEFT JOIN pg_catalog.pg_attrdef def ON (a.attrelid=def.adrelid AND a.attnum = def.adnum) "
-				+ " LEFT JOIN pg_catalog.pg_description dsc ON (c.oid=dsc.objoid AND a.attnum = dsc.objsubid) "
-				+ " LEFT JOIN pg_catalog.pg_class dc ON (dc.oid=dsc.classoid AND dc.relname='pg_class') "
-				+ " LEFT JOIN pg_catalog.pg_namespace dn ON (dc.relnamespace=dn.oid AND dn.nspname='pg_catalog') "
-				+ " WHERE a.attnum > 0 AND NOT a.attisdropped "
+				+ " JOIN pg_catalog.pg_class c"
+				+ "  ON (c.relnamespace OPERATOR(pg_catalog.=) n.oid) "
+				+ " JOIN pg_catalog.pg_attribute a "
+				+ "  ON (a.attrelid OPERATOR(pg_catalog.=) c.oid) "
+				+ " LEFT JOIN pg_catalog.pg_attrdef def ON ("
+				+ "  a.attrelid OPERATOR(pg_catalog.=) def.adrelid"
+				+ "  AND a.attnum OPERATOR(pg_catalog.=) def.adnum) "
+				+ " LEFT JOIN pg_catalog.pg_description dsc ON ("
+				+ "  c.oid OPERATOR(pg_catalog.=) dsc.objoid"
+				+ "  AND a.attnum OPERATOR(pg_catalog.=) dsc.objsubid) "
+				+ " LEFT JOIN pg_catalog.pg_class dc ON ("
+				+ "  dc.oid OPERATOR(pg_catalog.=) dsc.classoid"
+				+ "  AND dc.relname OPERATOR(pg_catalog.=) 'pg_class') "
+				+ " LEFT JOIN pg_catalog.pg_namespace dn ON ("
+				+ "  dc.relnamespace OPERATOR(pg_catalog.=) dn.oid"
+				+ "  AND dn.nspname OPERATOR(pg_catalog.=) 'pg_catalog') "
+				+ " WHERE a.attnum OPERATOR(pg_catalog.>) 0"
+				+ " AND NOT a.attisdropped "
                 + " AND " + resolveSchemaPatternCondition(
                                 "n.nspname", schemaPattern);
 
@@ -2025,14 +2105,17 @@ public class SPIDatabaseMetaData implements DatabaseMetaData
 
 		String sql = "SELECT n.nspname,c.relname,u.usename,c.relacl,a.attname "
 				+ " FROM pg_catalog.pg_namespace n, pg_catalog.pg_class c, pg_catalog.pg_user u, pg_catalog.pg_attribute a "
-				+ " WHERE c.relnamespace = n.oid "
-				+ " AND u.usesysid = c.relowner " + " AND c.oid = a.attrelid "
-				+ " AND c.relkind = 'r' "
-				+ " AND a.attnum > 0 AND NOT a.attisdropped "
+				+ " WHERE c.relnamespace OPERATOR(pg_catalog.=) n.oid "
+				+ " AND u.usesysid OPERATOR(pg_catalog.=) c.relowner "
+				+ " AND c.oid OPERATOR(pg_catalog.=) a.attrelid "
+				+ " AND c.relkind OPERATOR(pg_catalog.=) 'r' "
+				+ " AND a.attnum OPERATOR(pg_catalog.>) 0"
+				+ " AND NOT a.attisdropped "
                 + " AND " + resolveSchemaCondition(
                                 "n.nspname", schema);
 
-		sql += " AND c.relname = '" + escapeQuotes(table) + "' ";
+		sql += " AND c.relname OPERATOR(pg_catalog.=) '"
+			+ escapeQuotes(table) + "' ";
 		if(columnNamePattern != null && !"".equals(columnNamePattern))
 		{
 			sql += " AND a.attname LIKE '" + escapeQuotes(columnNamePattern)
@@ -2127,7 +2210,8 @@ public class SPIDatabaseMetaData implements DatabaseMetaData
 		String sql = "SELECT n.nspname,c.relname,u.usename,c.relacl "
 				+ " FROM pg_catalog.pg_namespace n, pg_catalog.pg_class c, pg_catalog.pg_user u "
 				+ " WHERE c.relnamespace = n.oid "
-				+ " AND u.usesysid = c.relowner " + " AND c.relkind = 'r' "
+				+ " AND u.usesysid OPERATOR(pg_catalog.=) c.relowner "
+				+ " AND c.relkind OPERATOR(pg_catalog.=) 'r' "
                 + " AND " + resolveSchemaPatternCondition(
                                 "n.nspname", schemaPattern);
 
@@ -2330,13 +2414,17 @@ public class SPIDatabaseMetaData implements DatabaseMetaData
 
 		String where = "";
 		String from = " FROM pg_catalog.pg_namespace n, pg_catalog.pg_class ct, pg_catalog.pg_class ci, pg_catalog.pg_attribute a, pg_catalog.pg_index i ";
-			where = " AND ct.relnamespace = n.oid "
+			where = " AND ct.relnamespace OPERATOR(pg_catalog.=) n.oid "
                   + " AND " + resolveSchemaCondition(
                                   "n.nspname", schema);
 		String sql = "SELECT a.attname, a.atttypid as atttypid " + from
-			+ " WHERE ct.oid=i.indrelid AND ci.oid=i.indexrelid "
-			+ " AND a.attrelid=ci.oid AND i.indisprimary "
-			+ " AND ct.relname = '" + escapeQuotes(table) + "' " + where
+			+ " WHERE ct.oid OPERATOR(pg_catalog.=) i.indrelid "
+			+ " AND ci.oid OPERATOR(pg_catalog.=) i.indexrelid "
+			+ " AND a.attrelid OPERATOR(pg_catalog.=) ci.oid"
+			+ " AND i.indisprimary "
+			+ " AND ct.relname OPERATOR(pg_catalog.=) '"
+				+ escapeQuotes(table) + "' "
+			+ where
 			+ " ORDER BY a.attnum ";
 
 		ResultSet rs = m_connection.createStatement().executeQuery(sql);
@@ -2439,17 +2527,21 @@ public class SPIDatabaseMetaData implements DatabaseMetaData
 		String where = "";
 		String select = "SELECT NULL AS TABLE_CAT, n.nspname AS TABLE_SCHEM, ";
 			from = " FROM pg_catalog.pg_namespace n, pg_catalog.pg_class ct, pg_catalog.pg_class ci, pg_catalog.pg_attribute a, pg_catalog.pg_index i ";
-			where = " AND ct.relnamespace = n.oid AND " +
+			where = " AND ct.relnamespace OPERATOR(pg_catalog.=) n.oid AND " +
                 resolveSchemaCondition("n.nspname", schema);
 
 		String sql = select + " ct.relname AS TABLE_NAME, "
-			+ " a.attname AS COLUMN_NAME, " + " a.attnum::int2 AS KEY_SEQ, "
+			+ " a.attname AS COLUMN_NAME,"
+			+ " a.attnum::pg_catalog.int2 AS KEY_SEQ, "
 			+ " ci.relname AS PK_NAME " + from
-			+ " WHERE ct.oid=i.indrelid AND ci.oid=i.indexrelid "
-			+ " AND a.attrelid=ci.oid AND i.indisprimary ";
+			+ " WHERE ct.oid OPERATOR(pg_catalog.=) i.indrelid"
+			+ " AND ci.oid OPERATOR(pg_catalog.=) i.indexrelid "
+			+ " AND a.attrelid OPERATOR(pg_catalog.=) ci.oid"
+			+ " AND i.indisprimary ";
 		if(table != null && !"".equals(table))
 		{
-			sql += " AND ct.relname = '" + escapeQuotes(table) + "' ";
+			sql += " AND ct.relname OPERATOR(pg_catalog.=) '"
+				+ escapeQuotes(table) + "' ";
 		}
 		sql += where + " ORDER BY table_name, pk_name, key_seq";
 
@@ -2505,33 +2597,38 @@ public class SPIDatabaseMetaData implements DatabaseMetaData
 		 * multiple unique indexes covering the same keys can be created which
 		 * make it difficult to determine the PK_NAME field.
 		 */
-		String sql = "SELECT NULL::text AS PKTABLE_CAT, pkn.nspname AS PKTABLE_SCHEM, pkc.relname AS PKTABLE_NAME, pka.attname AS PKCOLUMN_NAME, "
-			+ "NULL::text AS FKTABLE_CAT, fkn.nspname AS FKTABLE_SCHEM, fkc.relname AS FKTABLE_NAME, fka.attname AS FKCOLUMN_NAME, "
-			+ "pos.n::int2 AS KEY_SEQ, "
+		String sql = "SELECT "
+			+ "NULL::pg_catalog.text AS PKTABLE_CAT, "
+			+ "pkn.nspname AS PKTABLE_SCHEM, pkc.relname AS PKTABLE_NAME, "
+			+ "pka.attname AS PKCOLUMN_NAME, "
+			+ "NULL::pg_catalog.text AS FKTABLE_CAT, "
+			+ "fkn.nspname AS FKTABLE_SCHEM, fkc.relname AS FKTABLE_NAME, "
+			+ "fka.attname AS FKCOLUMN_NAME, "
+			+ "pos.n::pg_catalog.int2 AS KEY_SEQ, "
 			+ "CASE con.confupdtype "
-			+ " WHEN 'c' THEN "
+			+ " WHEN 'c'::pg_catalog.\"char\" THEN "
 			+ DatabaseMetaData.importedKeyCascade
-			+ " WHEN 'n' THEN "
+			+ " WHEN 'n'::pg_catalog.\"char\" THEN "
 			+ DatabaseMetaData.importedKeySetNull
-			+ " WHEN 'd' THEN "
+			+ " WHEN 'd'::pg_catalog.\"char\" THEN "
 			+ DatabaseMetaData.importedKeySetDefault
-			+ " WHEN 'r' THEN "
+			+ " WHEN 'r'::pg_catalog.\"char\" THEN "
 			+ DatabaseMetaData.importedKeyRestrict
-			+ " WHEN 'a' THEN "
+			+ " WHEN 'a'::pg_catalog.\"char\" THEN "
 			+ DatabaseMetaData.importedKeyNoAction
-			+ " ELSE NULL END::int2 AS UPDATE_RULE, "
+			+ " ELSE NULL END::pg_catalog.int2 AS UPDATE_RULE, "
 			+ "CASE con.confdeltype "
-			+ " WHEN 'c' THEN "
+			+ " WHEN 'c'::pg_catalog.\"char\" THEN "
 			+ DatabaseMetaData.importedKeyCascade
-			+ " WHEN 'n' THEN "
+			+ " WHEN 'n'::pg_catalog.\"char\" THEN "
 			+ DatabaseMetaData.importedKeySetNull
-			+ " WHEN 'd' THEN "
+			+ " WHEN 'd'::pg_catalog.\"char\" THEN "
 			+ DatabaseMetaData.importedKeySetDefault
-			+ " WHEN 'r' THEN "
+			+ " WHEN 'r'::pg_catalog.\"char\" THEN "
 			+ DatabaseMetaData.importedKeyRestrict
-			+ " WHEN 'a' THEN "
+			+ " WHEN 'a'::pg_catalog.\"char\" THEN "
 			+ DatabaseMetaData.importedKeyNoAction
-			+ " ELSE NULL END::int2 AS DELETE_RULE, "
+			+ " ELSE NULL END::pg_catalog.int2 AS DELETE_RULE, "
 			+ "con.conname AS FK_NAME, pkic.relname AS PK_NAME, "
 			+ "CASE "
 			+ " WHEN con.condeferrable AND con.condeferred THEN "
@@ -2540,27 +2637,42 @@ public class SPIDatabaseMetaData implements DatabaseMetaData
 			+ DatabaseMetaData.importedKeyInitiallyImmediate
 			+ " ELSE "
 			+ DatabaseMetaData.importedKeyNotDeferrable
-			+ " END::int2 AS DEFERRABILITY "
+			+ " END::pg_catalog.int2 AS DEFERRABILITY "
 			+ " FROM "
 			+ " pg_catalog.pg_namespace pkn, pg_catalog.pg_class pkc, pg_catalog.pg_attribute pka, "
 			+ " pg_catalog.pg_namespace fkn, pg_catalog.pg_class fkc, pg_catalog.pg_attribute fka, "
 			+ " pg_catalog.pg_constraint con, "
 			+ " pg_catalog.generate_series(1, " + getMaxIndexKeys() + ") pos(n), "
 			+ " pg_catalog.pg_depend dep, pg_catalog.pg_class pkic "
-			+ " WHERE pkn.oid = pkc.relnamespace AND pkc.oid = pka.attrelid AND pka.attnum = con.confkey[pos.n] AND con.confrelid = pkc.oid "
-			+ " AND fkn.oid = fkc.relnamespace AND fkc.oid = fka.attrelid AND fka.attnum = con.conkey[pos.n] AND con.conrelid = fkc.oid "
-			+ " AND con.contype = 'f' AND con.oid = dep.objid AND pkic.oid = dep.refobjid AND pkic.relkind = 'i' AND dep.classid = 'pg_constraint'::regclass::oid AND dep.refclassid = 'pg_class'::regclass::oid " +
-             " AND " + resolveSchemaCondition("pkn.nspname", primarySchema) +
-             " AND " + resolveSchemaCondition("fkn.nspname", foreignSchema);
+			+ " WHERE pkn.oid OPERATOR(pg_catalog.=) pkc.relnamespace"
+			+ " AND pkc.oid OPERATOR(pg_catalog.=) pka.attrelid"
+			+ " AND pka.attnum OPERATOR(pg_catalog.=) con.confkey[pos.n]"
+			+ " AND con.confrelid OPERATOR(pg_catalog.=) pkc.oid "
+			+ " AND fkn.oid OPERATOR(pg_catalog.=) fkc.relnamespace"
+			+ " AND fkc.oid OPERATOR(pg_catalog.=) fka.attrelid"
+			+ " AND fka.attnum OPERATOR(pg_catalog.=) con.conkey[pos.n]"
+			+ " AND con.conrelid OPERATOR(pg_catalog.=) fkc.oid "
+			+ " AND con.contype OPERATOR(pg_catalog.=) 'f'"
+			+ " AND con.oid OPERATOR(pg_catalog.=) dep.objid"
+			+ " AND pkic.oid OPERATOR(pg_catalog.=) dep.refobjid"
+			+ " AND pkic.relkind OPERATOR(pg_catalog.=) 'i'"
+			+ " AND dep.classid OPERATOR(pg_catalog.=)"
+				+ " 'pg_constraint'::pg_catalog.regclass::pg_catalog.oid"
+			+ " AND dep.refclassid OPERATOR(pg_catalog.=)"
+				+ " 'pg_class'::pg_catalog.regclass::pg_catalog.oid"
+			+ " AND " + resolveSchemaCondition("pkn.nspname", primarySchema)
+			+ " AND " + resolveSchemaCondition("fkn.nspname", foreignSchema);
 
         if(primaryTable != null && !"".equals(primaryTable))
 		{
-			sql += " AND pkc.relname = '" + escapeQuotes(primaryTable)
+			sql += " AND pkc.relname OPERATOR(pg_catalog.=) '"
+				+ escapeQuotes(primaryTable)
 				+ "' ";
 		}
 		if(foreignTable != null && !"".equals(foreignTable))
 		{
-			sql += " AND fkc.relname = '" + escapeQuotes(foreignTable)
+			sql += " AND fkc.relname OPERATOR(pg_catalog.=) '"
+				+ escapeQuotes(foreignTable)
 				+ "' ";
 		}
 
@@ -2755,7 +2867,9 @@ public class SPIDatabaseMetaData implements DatabaseMetaData
 		f[16] = new ResultSetField("SQL_DATETIME_SUB", TypeOid.INT4, 4);
 		f[17] = new ResultSetField("NUM_PREC_RADIX", TypeOid.INT4, 4);
 
-		String sql = "SELECT typname FROM pg_catalog.pg_type where typrelid = 0";
+		String sql =
+			"SELECT typname FROM pg_catalog.pg_type " +
+			"WHERE typrelid OPERATOR(pg_catalog.=) 0";
 
 		ResultSet rs = m_connection.createStatement().executeQuery(sql);
 		// cache some results, this will keep memory useage down, and speed
@@ -2853,7 +2967,7 @@ public class SPIDatabaseMetaData implements DatabaseMetaData
 		String select = "SELECT NULL AS TABLE_CAT, n.nspname AS TABLE_SCHEM, ";
 		String from = " FROM pg_catalog.pg_namespace n, pg_catalog.pg_class ct, pg_catalog.pg_class ci, pg_catalog.pg_index i, pg_catalog.pg_attribute a, pg_catalog.pg_am am ";
 		String where =
-            " AND n.oid = ct.relnamespace " +
+            " AND n.oid OPERATOR(pg_catalog.=) ct.relnamespace " +
             " AND " + resolveSchemaCondition("n.nspname", schema);
 
 		String sql = select
@@ -2861,22 +2975,27 @@ public class SPIDatabaseMetaData implements DatabaseMetaData
 			+ " CASE i.indisclustered "
 			+ " WHEN true THEN "
 			+ java.sql.DatabaseMetaData.tableIndexClustered
-			+ " ELSE CASE am.amname "
-			+ " WHEN 'hash' THEN "
+			+ " ELSE CASE"
+			+ " WHEN am.amname OPERATOR(pg_catalog.=) 'hash' THEN "
 			+ java.sql.DatabaseMetaData.tableIndexHashed
 			+ " ELSE "
 			+ java.sql.DatabaseMetaData.tableIndexOther
 			+ " END "
-			+ " END::int2 AS TYPE, "
-			+ " a.attnum::int2 AS ORDINAL_POSITION, "
+			+ " END::pg_catalog.int2 AS TYPE, "
+			+ " a.attnum::pg_catalog.int2 AS ORDINAL_POSITION, "
 			+ " a.attname AS COLUMN_NAME, "
 			+ " NULL AS ASC_OR_DESC, "
 			+ " ci.reltuples AS CARDINALITY, "
 			+ " ci.relpages AS PAGES, "
 			+ " NULL AS FILTER_CONDITION "
 			+ from
-			+ " WHERE ct.oid=i.indrelid AND ci.oid=i.indexrelid AND a.attrelid=ci.oid AND ci.relam=am.oid "
-			+ where + " AND ct.relname = '" + escapeQuotes(tableName) + "' ";
+			+ " WHERE ct.oid OPERATOR(pg_catalog.=) i.indrelid"
+			+ " AND ci.oid OPERATOR(pg_catalog.=) i.indexrelid"
+			+ " AND a.attrelid OPERATOR(pg_catalog.=) ci.oid"
+			+ " AND ci.relam OPERATOR(pg_catalog.=) am.oid "
+			+ where
+			+ " AND ct.relname OPERATOR(pg_catalog.=) '"
+				+ escapeQuotes(tableName) + "' ";
 
 		if(unique)
 		{
@@ -2987,26 +3106,35 @@ public class SPIDatabaseMetaData implements DatabaseMetaData
 	public java.sql.ResultSet getUDTs(String catalog, String schemaPattern,
 		String typeNamePattern, int[] types) throws SQLException
 	{
-		String sql = "select "
-			+ "null as type_cat, n.nspname as type_schem, t.typname as type_name,  null as class_name, "
-			+ "CASE WHEN t.typtype='c' then "
-			+ java.sql.Types.STRUCT
-			+ " else "
-			+ java.sql.Types.DISTINCT
-			+ " end as data_type, pg_catalog.obj_description(t.oid, 'pg_type')  "
-			+ "as remarks, CASE WHEN t.typtype = 'd' then  (select CASE";
+		String sql =
+			"SELECT" +
+			" null AS type_cat, n.nspname AS type_schem," +
+			" t.typname AS type_name, null AS class_name," +
+			" CASE WHEN t.typtype OPERATOR(pg_catalog.=) 'c' THEN " +
+				java.sql.Types.STRUCT +
+			" ELSE " +
+				java.sql.Types.DISTINCT +
+			" END AS data_type," +
+			" pg_catalog.obj_description(t.oid, 'pg_type') AS remarks," +
+			" CASE WHEN t.typtype OPERATOR(pg_catalog.=) 'd' THEN (" +
+			"  select CASE";
 
 		for(int i = 0; i < SPIConnection.JDBC_TYPE_NAMES.length; i++)
 		{
-			sql += " when typname = '" + SPIConnection.JDBC_TYPE_NUMBERS[i]
-				+ "' then " + SPIConnection.JDBC_TYPE_NUMBERS[i];
+			sql += " WHEN typname OPERATOR(pg_catalog.=) '"
+					+ SPIConnection.JDBC_TYPE_NUMBERS[i]
+				+ "' THEN " + SPIConnection.JDBC_TYPE_NUMBERS[i];
 		}
 
-		sql += " else "
+		sql += " ELSE "
 			+ java.sql.Types.OTHER
-			+ " end from pg_type where oid=t.typbasetype) "
-			+ "else null end as base_type "
-			+ "from pg_catalog.pg_type t, pg_catalog.pg_namespace n where t.typnamespace = n.oid and n.nspname != 'pg_catalog' and n.nspname != 'pg_toast'";
+			+ " END"
+			+ " FROM pg_type WHERE oid OPERATOR(pg_catalog.=) t.typbasetype) "
+			+ "ELSE null END AS base_type "
+			+ "FROM pg_catalog.pg_type t, pg_catalog.pg_namespace n "
+			+ "WHERE t.typnamespace OPERATOR(pg_catalog.=) n.oid "
+			+ "AND n.nspname OPERATOR(pg_catalog.<>) 'pg_catalog' "
+			+ "AND n.nspname OPERATOR(pg_catalog.<>) 'pg_toast'";
 
 		String toAdd = "";
 		if(types != null)
@@ -3017,10 +3145,10 @@ public class SPIDatabaseMetaData implements DatabaseMetaData
 				switch(types[i])
 				{
 					case java.sql.Types.STRUCT:
-						toAdd += " or t.typtype = 'c'";
+						toAdd += " or t.typtype OPERATOR(pg_catalog.=) 'c'";
 						break;
 					case java.sql.Types.DISTINCT:
-						toAdd += " or t.typtype = 'd'";
+						toAdd += " or t.typtype OPERATOR(pg_catalog.=) 'd'";
 						break;
 				}
 			}
@@ -3028,7 +3156,9 @@ public class SPIDatabaseMetaData implements DatabaseMetaData
 		}
 		else
 		{
-			toAdd += " and t.typtype IN ('c','d') ";
+			toAdd +=
+				" AND t.typtype IN " +
+				"('c'::pg_catalog.\"char\", 'd'::pg_catalog.\"char\") ";
 		}
 		// spec says that if typeNamePattern is a fully qualified name
 		// then the schema and catalog are ignored
@@ -3112,7 +3242,7 @@ public class SPIDatabaseMetaData implements DatabaseMetaData
 	 */
 	public boolean supportsSavepoints() throws SQLException
 	{
-		return this.getDatabaseMajorVersion() >= 8;
+		return true; // PG < 8 no longer supported
 	}
 
 	/**

--- a/pljava/src/main/java/org/postgresql/pljava/management/Commands.java
+++ b/pljava/src/main/java/org/postgresql/pljava/management/Commands.java
@@ -247,14 +247,18 @@ import static org.postgresql.pljava.annotation.Function.Security.DEFINER;
 /*
  * Attention: any evolution of the schema here needs to be reflected in
  * o.p.p.internal.InstallHelper.SchemaVariant and .recognizeSchema().
+ *
+ * Schema-qualification of a type with a typmod, e.g. pg_catalog.varchar(100),
+ * is possible from PostgreSQL 8.3 onward, but not in 8.2. As a compromise, use
+ * the two-word CHARACTER VARYING syntax, to evade capture by a user type.
  */
 @SQLAction(install={
 "	CREATE TABLE sqlj.jar_repository(" +
 "		jarId       SERIAL PRIMARY KEY," +
-"		jarName     VARCHAR(100) UNIQUE NOT NULL," +
-"		jarOrigin   VARCHAR(500) NOT NULL," +
-"		jarOwner    NAME NOT NULL," +
-"		jarManifest TEXT" +
+"		jarName     CHARACTER VARYING(100) UNIQUE NOT NULL," +
+"		jarOrigin   CHARACTER VARYING(500) NOT NULL," +
+"		jarOwner    pg_catalog.NAME NOT NULL," +
+"		jarManifest pg_catalog.TEXT" +
 "	)",
 "	COMMENT ON TABLE sqlj.jar_repository IS" +
 "	'Information on jars loaded by PL/Java, one row per jar.'",
@@ -262,10 +266,10 @@ import static org.postgresql.pljava.annotation.Function.Security.DEFINER;
 
 "	CREATE TABLE sqlj.jar_entry(" +
 "		entryId     SERIAL PRIMARY KEY," +
-"		entryName   VARCHAR(200) NOT NULL," +
+"		entryName   CHARACTER VARYING(200) NOT NULL," +
 "		jarId       INT NOT NULL" +
 "					REFERENCES sqlj.jar_repository ON DELETE CASCADE," +
-"		entryImage  BYTEA NOT NULL," +
+"		entryImage  pg_catalog.BYTEA NOT NULL," +
 "		UNIQUE(jarId, entryName)" +
 "	)",
 "	COMMENT ON TABLE sqlj.jar_entry IS" +
@@ -274,7 +278,7 @@ import static org.postgresql.pljava.annotation.Function.Security.DEFINER;
 
 "	CREATE TABLE sqlj.jar_descriptor(" +
 "		jarId       INT REFERENCES sqlj.jar_repository ON DELETE CASCADE," +
-"		ordinal     INT2," +
+"		ordinal     pg_catalog.INT2," +
 "		PRIMARY KEY (jarId, ordinal)," +
 "		entryId     INT NOT NULL REFERENCES sqlj.jar_entry ON DELETE CASCADE" +
 "	)",
@@ -285,8 +289,8 @@ import static org.postgresql.pljava.annotation.Function.Security.DEFINER;
 "	GRANT SELECT ON sqlj.jar_descriptor TO public",
 
 "	CREATE TABLE sqlj.classpath_entry(" +
-"		schemaName  VARCHAR(30) NOT NULL," +
-"		ordinal     INT2 NOT NULL," +
+"		schemaName  CHARACTER VARYING(30) NOT NULL," +
+"		ordinal     pg_catalog.INT2 NOT NULL," +
 "		jarId       INT NOT NULL" +
 "					REFERENCES sqlj.jar_repository ON DELETE CASCADE," +
 "		PRIMARY KEY(schemaName, ordinal)" +
@@ -299,8 +303,8 @@ import static org.postgresql.pljava.annotation.Function.Security.DEFINER;
 
 "	CREATE TABLE sqlj.typemap_entry(" +
 "		mapId       SERIAL PRIMARY KEY," +
-"		javaName    VARCHAR(200) NOT NULL," +
-"		sqlName     NAME NOT NULL" +
+"		javaName    CHARACTER VARYING(200) NOT NULL," +
+"		sqlName     pg_catalog.NAME NOT NULL" +
 "	)",
 "	COMMENT ON TABLE sqlj.typemap_entry IS" +
 "	'A row for each SQL type <-> Java type custom mapping.'",
@@ -350,7 +354,8 @@ public class Commands
 				PreparedStatement us = SQLUtils
 					.getDefaultConnection()
 					.prepareStatement(
-						"UPDATE sqlj.jar_repository SET jarManifest = ? WHERE jarId = ?");
+						"UPDATE sqlj.jar_repository SET jarManifest = ? " +
+						"WHERE jarId OPERATOR(pg_catalog.=) ?");
 				try
 				{
 					us.setString(1, manifest);
@@ -398,8 +403,9 @@ public class Commands
 				if ( descIdFetchStmt == null )
 					descIdFetchStmt = SQLUtils.getDefaultConnection()
 						.prepareStatement(
-							"SELECT entryId FROM sqlj.jar_entry"
-								+ " WHERE jarId = ? AND entryName = ?");
+							"SELECT entryId FROM sqlj.jar_entry " +
+							"WHERE jarId OPERATOR(pg_catalog.=) ?" +
+							"  AND entryName OPERATOR(pg_catalog.=) ?");
 				descIdFetchStmt.setInt(1, jarId);
 				descIdFetchStmt.setString(2, entryName);
 				rs = descIdFetchStmt.executeQuery();
@@ -561,7 +567,8 @@ public class Commands
 		{
 			sqlTypeName = getFullSqlNameOwned(sqlTypeName);
 			stmt = SQLUtils.getDefaultConnection().prepareStatement(
-				"DELETE FROM sqlj.typemap_entry WHERE sqlName = ?");
+				"DELETE FROM sqlj.typemap_entry " +
+				"WHERE sqlName OPERATOR(pg_catalog.=) ?");
 			stmt.setString(1, sqlTypeName);
 			stmt.executeUpdate();
 		}
@@ -597,9 +604,13 @@ public class Commands
 			stmt = SQLUtils
 				.getDefaultConnection()
 				.prepareStatement(
-					"SELECT r.jarName"
-						+ " FROM sqlj.jar_repository r INNER JOIN sqlj.classpath_entry c ON r.jarId = c.jarId"
-						+ " WHERE c.schemaName = ? ORDER BY c.ordinal");
+					"SELECT r.jarName" +
+					" FROM" +
+					"  sqlj.jar_repository r" +
+					"  INNER JOIN sqlj.classpath_entry c" +
+					"  ON r.jarId OPERATOR(pg_catalog.=) c.jarId" +
+					" WHERE c.schemaName OPERATOR(pg_catalog.=) ?" +
+					" ORDER BY c.ordinal");
 
 			stmt.setString(1, schemaName);
 			rs = stmt.executeQuery();
@@ -705,7 +716,9 @@ public class Commands
 
 		PreparedStatement stmt = SQLUtils
 			.getDefaultConnection()
-			.prepareStatement("DELETE FROM sqlj.jar_repository WHERE jarId = ?");
+			.prepareStatement(
+				"DELETE FROM sqlj.jar_repository " +
+				"WHERE jarId OPERATOR(pg_catalog.=) ?");
 		try
 		{
 			stmt.setInt(1, jarId);
@@ -807,7 +820,8 @@ public class Commands
 			//
 			entries = new ArrayList();
 			stmt = SQLUtils.getDefaultConnection().prepareStatement(
-				"SELECT jarId FROM sqlj.jar_repository WHERE jarName = ?");
+				"SELECT jarId FROM sqlj.jar_repository " +
+				"WHERE jarName OPERATOR(pg_catalog.=) ?");
 			try
 			{
 				for(;;)
@@ -841,7 +855,8 @@ public class Commands
 		// Delete the old classpath
 		//
 		stmt = SQLUtils.getDefaultConnection().prepareStatement(
-			"DELETE FROM sqlj.classpath_entry WHERE schemaName = ?");
+			"DELETE FROM sqlj.classpath_entry " +
+			"WHERE schemaName OPERATOR(pg_catalog.=) ?");
 		try
 		{
 			stmt.setString(1, schemaName);
@@ -979,8 +994,8 @@ public class Commands
 			.prepareStatement(
 				"SELECT e.entryImage"
 					+ " FROM sqlj.jar_descriptor d INNER JOIN sqlj.jar_entry e"
-					+ "   ON d.entryId = e.entryId"
-					+ " WHERE d.jarId = ?"
+					+ "   ON d.entryId OPERATOR(pg_catalog.=) e.entryId"
+					+ " WHERE d.jarId OPERATOR(pg_catalog.=) ?"
 					+ " ORDER BY d.ordinal");
 		try
 		{
@@ -1035,7 +1050,8 @@ public class Commands
 				"SELECT n.nspname, t.typname,"
 					+ " pg_catalog.pg_has_role(?, t.typowner, 'USAGE')"
 					+ " FROM pg_catalog.pg_type t, pg_catalog.pg_namespace n"
-					+ " WHERE t.oid = ? AND n.oid = t.typnamespace");
+					+ " WHERE t.oid OPERATOR(pg_catalog.=) ?"
+					+ " AND n.oid OPERATOR(pg_catalog.=) t.typnamespace");
 
 		try
 		{
@@ -1099,7 +1115,8 @@ public class Commands
 		PreparedStatement stmt = SQLUtils
 			.getDefaultConnection()
 			.prepareStatement(
-				"SELECT jarId, jarOwner FROM sqlj.jar_repository WHERE jarName = ?");
+				"SELECT jarId, jarOwner FROM sqlj.jar_repository " +
+				"WHERE jarName OPERATOR(pg_catalog.=) ?");
 		try
 		{
 			return getJarId(stmt, jarName, ownerRet);
@@ -1123,7 +1140,8 @@ public class Commands
 		ResultSet rs = null;
 		PreparedStatement stmt = SQLUtils.getDefaultConnection()
 			.prepareStatement(
-				"SELECT oid FROM pg_catalog.pg_namespace WHERE nspname = ?");
+				"SELECT oid FROM pg_catalog.pg_namespace " +
+				"WHERE nspname OPERATOR(pg_catalog.=) ?");
 		try
 		{
 			stmt.setString(1, schemaName);
@@ -1212,7 +1230,7 @@ public class Commands
 			.prepareStatement(
 				"UPDATE sqlj.jar_repository "
 				+ "SET jarOrigin = ?, jarOwner = ?, jarManifest = NULL "
-				+ "WHERE jarId = ?");
+				+ "WHERE jarId OPERATOR(pg_catalog.=) ?");
 		try
 		{
 			stmt.setString(1, urlString);
@@ -1228,7 +1246,7 @@ public class Commands
 		}
 
 		stmt = SQLUtils.getDefaultConnection().prepareStatement(
-			"DELETE FROM sqlj.jar_entry WHERE jarId = ?");
+			"DELETE FROM sqlj.jar_entry WHERE jarId OPERATOR(pg_catalog.=) ?");
 		try
 		{
 			stmt.setInt(1, jarId);

--- a/pljava/src/main/java/org/postgresql/pljava/sqlj/EntryStreamHandler.java
+++ b/pljava/src/main/java/org/postgresql/pljava/sqlj/EntryStreamHandler.java
@@ -73,7 +73,8 @@ class EntryStreamHandler extends URLStreamHandler
 			{
 
 				stmt = SQLUtils.getDefaultConnection().prepareStatement(
-					"SELECT entryName, entryImage FROM sqlj.jar_entry WHERE entryId = ?");
+					"SELECT entryName, entryImage FROM sqlj.jar_entry " +
+					"WHERE entryId OPERATOR(pg_catalog.=) ?");
 				stmt.setInt(1, m_entryId);
 	    		rs = stmt.executeQuery();
 				if(rs.next())

--- a/pljava/src/main/java/org/postgresql/pljava/sqlj/Loader.java
+++ b/pljava/src/main/java/org/postgresql/pljava/sqlj/Loader.java
@@ -90,7 +90,7 @@ public class Loader extends ClassLoader
 		ResultSet rs = null;
 		try
 		{
-			rs = stmt.executeQuery("SELECT current_schema()");
+			rs = stmt.executeQuery("SELECT pg_catalog.current_schema()");
 			if(!rs.next())
 				throw new SQLException("Unable to determine current schema");
 			schema = rs.getString(1);
@@ -132,11 +132,16 @@ public class Loader extends ClassLoader
 			//
 			outer = conn.prepareStatement(
 				"SELECT r.jarId" +
-				" FROM sqlj.jar_repository r INNER JOIN sqlj.classpath_entry c ON r.jarId = c.jarId" +
-				" WHERE c.schemaName = ? ORDER BY c.ordinal DESC");
+				" FROM" +
+				"  sqlj.jar_repository r" +
+				"  INNER JOIN sqlj.classpath_entry c" +
+				"  ON r.jarId OPERATOR(pg_catalog.=) c.jarId" +
+				" WHERE c.schemaName OPERATOR(pg_catalog.=) ?" +
+				" ORDER BY c.ordinal DESC");
 
 			inner = conn.prepareStatement(
-				"SELECT entryId, entryName FROM sqlj.jar_entry WHERE jarId = ?");
+				"SELECT entryId, entryName FROM sqlj.jar_entry " +
+				"WHERE jarId OPERATOR(pg_catalog.=) ?");
 
 			outer.setString(1, schemaName);
 			ResultSet rs = outer.executeQuery();
@@ -304,7 +309,8 @@ public class Loader extends ClassLoader
 				// for the duration of the loader.
 				//
 				stmt = SQLUtils.getDefaultConnection().prepareStatement(
-					"SELECT entryImage FROM sqlj.jar_entry WHERE entryId = ?");
+					"SELECT entryImage FROM sqlj.jar_entry " +
+					"WHERE entryId OPERATOR(pg_catalog.=) ?");
 
 				stmt.setInt(1, entryId[0]);
 				rs = stmt.executeQuery();

--- a/src/site/markdown/releasenotes.md.vm
+++ b/src/site/markdown/releasenotes.md.vm
@@ -41,6 +41,18 @@ transition tables are available to triggers.
 
 $h3 Security
 
+$h4 Schema-qualification
+
+PL/Java now more consistently schema-qualifies objects in queries and DDL
+it generates internally, as a measure of defense-in-depth in case the database
+it is installed in has not been [protected][prot1058] from [CVE-2018-1058][].
+
+_No schema-qualification work has been done on the example code._ If the
+examples jar will be installed, it should be in a database that
+[the recommended steps have been taken to secure][prot1058].
+
+$h4 Some large-object code removed
+
 1.5.1 removes the code at issue in [CVE-2016-0768][], which pertained to
 PostgreSQL large objects, but had never been documented or exposed as API.
 
@@ -53,6 +65,9 @@ to keep that code around, it is more satisfying to remove it entirely.
 Developers wishing to manipulate large objects in PL/Java are able to do so
 using the SPI JDBC interface and the large-object SQL functions already
 available in every PostgreSQL version PL/Java currently supports.
+
+[CVE-2018-1058]: http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-1058
+[prot1058]: https://wiki.postgresql.org/wiki/A_Guide_to_CVE-2018-1058:_Protect_Your_Search_Path#Next_Steps:_How_Can_I_Protect_My_Databases.3F
 
 $h3 Version compatibility
 


### PR DESCRIPTION
Rather tedious to do, and perhaps obsessive in any database where the [recommended steps][prot] have been taken to protect from CVE-2018-1058, but adds a measure of defense-in-depth in case they have not.

No changes in `pljava-examples`; if the examples jar will be installed, it should be in a database where the recommended steps have been followed.

[prot]: https://wiki.postgresql.org/wiki/A_Guide_to_CVE-2018-1058:_Protect_Your_Search_Path#Next_Steps:_How_Can_I_Protect_My_Databases.3F