### PR TITLE
Avoid self-install jar failure on certain Rhino-based JavaScript engines.

### DIFF
--- a/pljava-packaging/build.xml
+++ b/pljava-packaging/build.xml
@@ -354,7 +354,7 @@ if (found) {
     var fsep = properties.getProperty('file.separator');
     var plen = fsep.length() - 1; /* original separator had length 1 */
     plen += prefix.length;
-    computedPath = replacement + computedPath.slice(plen);
+    computedPath = String(replacement + computedPath.slice(plen));
 }
 ]]>
 		</jarxbuild>


### PR DESCRIPTION
Addresses issue #179.

What apparently happened in some OpenJDK 6 and 7 packages was that it was left to the packager to obtain (or not) the [Rhino JavaScript engine][rhino] and, separately, the wrapper layer that presents it through the `javax.script` API. It's not clear whether there is a single, authoritative, open source for that wrapper layer (see, for example, [here][w1] and [here][w2], of which the second is more up to date, but both have problems). Among the things incomplete in these wrappers are conversions to Java `String` from some implementation factors of JavaScript `String`. The obvious cases are handled, but Rhino in some cases will have a JavaScript String represented by a `ConsString` instance, which is not treated by the wrapper as a String.

Using the ConsString to construct a new, ordinary JavaScript string seems to solve the problem; the adapter knows what to do with one of those.

[rhino]: https://developer.mozilla.org/en-US/docs/Mozilla/Projects/Rhino
[w1]: https://github.com/scijava/javax-scripting/tree/master/engines/javascript/src/com/sun/phobos/script
[w2]: https://bitbucket.org/bunkenburg/rhino-js-engine
