### PR TITLE
Use an updated snapshot for queries made by PL/Java's class loader.

### DIFF
--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/ComplexScalar.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/ComplexScalar.java
@@ -32,10 +32,8 @@ import static
 /**
  * Complex (re and im parts are doubles) implemented in Java as a scalar UDT.
  */
-@SQLAction(requires={
-	"scalar complex type", "complex assertHasValues", "complexscalar boot fn"
-	}, install={
-		"SELECT javatest.complexscalar()",
+@SQLAction(requires = { "scalar complex type", "complex assertHasValues" },
+	install = {
 		"SELECT javatest.assertHasValues(" +
 		" CAST('(1,2)' AS javatest.complex), 1, 2)"
 	}
@@ -148,24 +146,5 @@ public class ComplexScalar implements SQLData {
 		s_logger.info(m_typeName + " to SQLOutput");
 		stream.writeDouble(m_x);
 		stream.writeDouble(m_y);
-	}
-
-	/**
-	 * A no-op function that forces the ComplexScalar class to be loaded.
-	 * This is only necessary because the deployment-descriptor install
-	 * actions contain a query making use of this type, and PostgreSQL does
-	 * not expect type in/out/send/recv functions to need an updated
-	 * snapshot, so it will try to find this class in the snapshot from
-	 * before the jar was installed, and fail. By providing this function,
-	 * which defaults to volatile so it gets an updated snapshot, and
-	 * calling it first, the class will be found and loaded; once it is
-	 * loaded, the user-defined type operations are able to find it.
-	 * <p>
-	 * Again, this is only an issue when trying to make use of the newly
-	 * loaded UDT from right within the deployment descriptor for the jar.
-	 */
-	@Function(schema="javatest", provides="complexscalar boot fn")
-	public static void ComplexScalar()
-	{
 	}
 }

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/UDTScalarIOTest.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/UDTScalarIOTest.java
@@ -54,9 +54,8 @@ import static
  * supported JDBC data types, which it writes on output, and reads/verifies on
  * input.
  */
-@SQLAction(requires={"udtscalariotest type", "udtscalariotest boot fn"},
-	install={
-		"SELECT javatest.udtscalariotest()", // force class to resolve
+@SQLAction(requires= { "udtscalariotest type" },
+	install = {
 		"SELECT CAST('' AS javatest.udtscalariotest)" // test send/recv
 	})
 @BaseUDT(schema="javatest", provides="udtscalariotest type")
@@ -216,24 +215,5 @@ public class UDTScalarIOTest implements SQLData
 			throw new SQLException("timestamp mismatch");
 		if ( ! s_url.equals(stream.readURL()) )
 			throw new SQLException("url mismatch");
-	}
-
-	/**
-	 * A no-op function that forces the UDTScalarIOTest class to be loaded.
-	 * This is only necessary because the deployment-descriptor install
-	 * actions contain a query making use of this type, and PostgreSQL does
-	 * not expect type in/out/send/recv functions to need an updated
-	 * snapshot, so it will try to find this class in the snapshot from
-	 * before the jar was installed, and fail. By providing this function,
-	 * which defaults to volatile so it gets an updated snapshot, and
-	 * calling it first, the class will be found and loaded; once it is
-	 * loaded, the user-defined type operations are able to find it.
-	 * <p>
-	 * Again, this is only an issue when trying to make use of the newly
-	 * loaded UDT from right within the deployment descriptor for the jar.
-	 */
-	@Function(schema="javatest", provides="udtscalariotest boot fn")
-	public static void udtscalariotest()
-	{
 	}
 }

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/VarlenaUDTTest.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/VarlenaUDTTest.java
@@ -18,6 +18,8 @@ import java.sql.SQLOutput;
 
 import org.postgresql.pljava.annotation.SQLAction;
 import org.postgresql.pljava.annotation.BaseUDT;
+import org.postgresql.pljava.annotation.Function;
+import static org.postgresql.pljava.annotation.Function.Effects.IMMUTABLE;
 
 /**
  * A User Defined Type with varlena storage, testing github issue 52.
@@ -46,6 +48,7 @@ public class VarlenaUDTTest implements SQLData {
 
 	public VarlenaUDTTest() { }
 
+	@Function(effects=IMMUTABLE)
 	public static VarlenaUDTTest parse( String s, String typname) {
 		int i = Integer.parseInt( s);
 		VarlenaUDTTest u = new VarlenaUDTTest();
@@ -54,6 +57,7 @@ public class VarlenaUDTTest implements SQLData {
 		return u;
 	}
 
+	@Function(effects=IMMUTABLE)
 	public String toString() {
 		return String.valueOf( apop);
 	}
@@ -62,11 +66,13 @@ public class VarlenaUDTTest implements SQLData {
 		return typname;
 	}
 
+	@Function(effects=IMMUTABLE)
 	public void writeSQL( SQLOutput stream) throws SQLException {
 		for ( int i = 0 ; i < apop ; ++ i )
 			stream.writeByte( (byte)'a');
 	}
 
+	@Function(effects=IMMUTABLE)
 	public void readSQL( SQLInput stream, String typname) throws SQLException {
 		this.typname = typname;
 		int i = 0;

--- a/pljava-so/src/main/c/ExecutionPlan.c
+++ b/pljava-so/src/main/c/ExecutionPlan.c
@@ -1,8 +1,14 @@
 /*
- * Copyright (c) 2004, 2005, 2006 TADA AB - Taby Sweden
- * Distributed under the terms shown in the file COPYRIGHT
- * found in the root folder of this project or at
- * http://eng.tada.se/osprojects/COPYRIGHT.html
+ * Copyright (c) 2004-2018 Tada AB and other contributors, as listed below.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Tada AB
+ *   Chapman Flack
  *
  * @author Thomas Hallgren
  */
@@ -26,6 +32,11 @@
 /* Class 07 - Dynamic SQL Error */
 #define ERRCODE_PARAMETER_COUNT_MISMATCH	MAKE_SQLSTATE('0','7', '0','0','1')
 
+/* These three values must match those in ExecutionPlan.java */
+#define SPI_READONLY_DEFAULT 0
+#define SPI_READONLY_FORCED  1
+#define SPI_READONLY_CLEARED 2
+
 /* Make this datatype available to the postgres system.
  */
 extern void ExecutionPlan_initialize(void);
@@ -35,7 +46,7 @@ void ExecutionPlan_initialize(void)
 	{
 		{
 		"_cursorOpen",
-		"(JJLjava/lang/String;[Ljava/lang/Object;)Lorg/postgresql/pljava/internal/Portal;",
+		"(JJLjava/lang/String;[Ljava/lang/Object;S)Lorg/postgresql/pljava/internal/Portal;",
 		Java_org_postgresql_pljava_internal_ExecutionPlan__1cursorOpen
 		},
 		{
@@ -45,7 +56,7 @@ void ExecutionPlan_initialize(void)
 		},
 		{
 		"_execute",
-		"(JJ[Ljava/lang/Object;I)I",
+		"(JJ[Ljava/lang/Object;SI)I",
 		Java_org_postgresql_pljava_internal_ExecutionPlan__1execute
 		},
 		{
@@ -117,10 +128,10 @@ static bool coerceObjects(void* ePlan, jobjectArray jvalues, Datum** valuesPtr, 
 /*
  * Class:     org_postgresql_pljava_internal_ExecutionPlan
  * Method:    _cursorOpen
- * Signature: (JJLjava/lang/String;[Ljava/lang/Object;)Lorg/postgresql/pljava/internal/Portal;
+ * Signature: (JJLjava/lang/String;[Ljava/lang/Object;S)Lorg/postgresql/pljava/internal/Portal;
  */
 JNIEXPORT jobject JNICALL
-Java_org_postgresql_pljava_internal_ExecutionPlan__1cursorOpen(JNIEnv* env, jclass clazz, jlong _this, jlong threadId, jstring cursorName, jobjectArray jvalues)
+Java_org_postgresql_pljava_internal_ExecutionPlan__1cursorOpen(JNIEnv* env, jclass clazz, jlong _this, jlong threadId, jstring cursorName, jobjectArray jvalues, jshort readonly_spec)
 {
 	jobject jportal = 0;
 	if(_this != 0)
@@ -138,12 +149,17 @@ Java_org_postgresql_pljava_internal_ExecutionPlan__1cursorOpen(JNIEnv* env, jcla
 			{
 				Portal portal;
 				char* name = 0;
+				bool read_only;
 				if(cursorName != 0)
 					name = String_createNTS(cursorName);
 
 				Invocation_assertConnect();
+				if ( SPI_READONLY_DEFAULT == readonly_spec )
+					read_only = Function_isCurrentReadOnly();
+				else
+					read_only = (SPI_READONLY_FORCED == readonly_spec);
 				portal = SPI_cursor_open(
-					name, p2l.ptrVal, values, nulls, Function_isCurrentReadOnly());
+					name, p2l.ptrVal, values, nulls, read_only);
 				if(name != 0)
 					pfree(name);
 				if(values != 0)
@@ -198,10 +214,10 @@ Java_org_postgresql_pljava_internal_ExecutionPlan__1isCursorPlan(JNIEnv* env, jc
 /*
  * Class:     org_postgresql_pljava_internal_ExecutionPlan
  * Method:    _execute
- * Signature: (JJ[Ljava/lang/Object;I)V
+ * Signature: (JJ[Ljava/lang/Object;SI)V
  */
 JNIEXPORT jint JNICALL
-Java_org_postgresql_pljava_internal_ExecutionPlan__1execute(JNIEnv* env, jclass clazz, jlong _this, jlong threadId, jobjectArray jvalues, jint count)
+Java_org_postgresql_pljava_internal_ExecutionPlan__1execute(JNIEnv* env, jclass clazz, jlong _this, jlong threadId, jobjectArray jvalues, jshort readonly_spec, jint count)
 {
 	jint result = 0;
 	if(_this != 0)
@@ -217,9 +233,14 @@ Java_org_postgresql_pljava_internal_ExecutionPlan__1execute(JNIEnv* env, jclass 
 			p2l.longVal = _this;
 			if(coerceObjects(p2l.ptrVal, jvalues, &values, &nulls))
 			{
+				bool read_only;
 				Invocation_assertConnect();
+				if ( SPI_READONLY_DEFAULT == readonly_spec )
+					read_only = Function_isCurrentReadOnly();
+				else
+					read_only = (SPI_READONLY_FORCED == readonly_spec);
 				result = (jint)SPI_execute_plan(
-					p2l.ptrVal, values, nulls, Function_isCurrentReadOnly(), (int)count);
+					p2l.ptrVal, values, nulls, read_only, (int)count);
 				if(result < 0)
 					Exception_throwSPI("execute_plan", result);
 

--- a/pljava/src/main/java/org/postgresql/pljava/internal/SPI.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/SPI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2016 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2018 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -50,8 +50,10 @@ public class SPI
 	 * of <code>rowCount</code> of zero is interpreted as no limit, i.e.,
 	 * run to completion.
 	 * @return One of the declared status codes.
+	 * @deprecated This seems never to have been used in git history of project.
 	 */
-	public static int exec(String command, int rowCount)
+	@Deprecated
+	private static int exec(String command, int rowCount)
 	{
 		synchronized(Backend.THREADLOCK)
 		{
@@ -105,7 +107,10 @@ public class SPI
 	}
 
 	/**
-	 * Returns a textual representatio of a result code
+	 * Returns a textual representation of a result code.
+	 */
+	/*
+	 * XXX PG 11 introduces a real SPI_result_code_string function.
 	 */
 	public static String getResultText(int resultCode)
 	{
@@ -181,7 +186,9 @@ public class SPI
 	return s;
 	}
 
+	@Deprecated
 	private native static int _exec(long threadId, String command, int rowCount);
+
 	private native static long _getProcessed();
 	private native static int _getResult();
 	private native static void _freeTupTable();

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/SPIReadOnlyControl.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/SPIReadOnlyControl.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2018 Tada AB and other contributors, as listed below.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Chapman Flack
+ */
+package org.postgresql.pljava.jdbc;
+
+/**
+ * An extended interface on {@code Statement} (accessible with {@code unwrap()})
+ * allowing control of the {@code read_only} flag that PostgreSQL SPI will see
+ * when the statement is next executed.
+ *<p>
+ * Currently an internal interface, not in {@code pljava-api}, as the known need
+ * so far is just for the internal class loader.
+ */
+public interface SPIReadOnlyControl
+{
+	/**
+	 * Specify that the statement, when next executed, will have the
+	 * behavior recommended in the PostgreSQL SPI documentation:
+	 * {@code read_only} will be set to {@code true} if the currently-executing
+	 * PL/Java function is declared {@code IMMUTABLE}, {@code false} otherwise.
+	 */
+	void defaultReadOnly();
+
+	/**
+	 * Specify that the statement, when next executed, will have have
+	 * {@code read_only} set to {@code true} unconditionally.
+	 */
+	void forceReadOnly();
+
+	/**
+	 * Specify that the statement, when next executed, will have have
+	 * {@code read_only} set to {@code false} unconditionally.
+	 */
+	void clearReadOnly();
+}
+


### PR DESCRIPTION
Awkward workarounds have been necessary for classes that may be referred to by deployment-descriptor commands in the same jar that contains them, if the references happen via functions that are declared `immutable`. Following the conventions recommended in the PostgreSQL SPI docs, the queries made by the class loader get executed with the `read_only` flag in that case, which has caused SPI to use a snapshot from before the needed class images were loaded (issue #178).

This PR implements the solution favored in [(1)][n1], making all queries originating from `Loader` execute with `read_only => false` unconditionally.

A less blunt solution proposed in [(2)][n2] would rely on PostgreSQL API not available before 9.1, so is not practical for this PL/Java branch, which supports earlier versions.

[n1]: https://www.postgresql.org/message-id/14247.1537418670%40sss.pgh.pa.us
[n2]: https://www.postgresql.org/message-id/5BA6BA96.5030309%40anastigmatix.net