### PR TITLE
Add a ddr.reproducible option to SQL generator.

### DIFF
--- a/pljava-api/src/main/java/org/postgresql/pljava/annotation/package-info.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/annotation/package-info.java
@@ -66,17 +66,35 @@
  * generated from elements that do not specify their own. If this is set to a
  * single hyphen (-), elements that specify no implementor will produce plain
  * {@code <SQL statement>}s not wrapped in {@code <implementor block>}s.
+ * <dt><code>ddr.reproducible</code>
+ * <dd>When {@code true} (the default), SQL statements are written to the
+ * deployment descriptor in an order meant to be consistent across successive
+ * compilations of the same sources. This option is further discussed below.
  * </dl>
  * <li>The deployment descriptor may contain statements that cannot succeed if
  * placed in the wrong order, and to keep a manually-edited script in a workable
  * order while adding and modifying code can be difficult. Most of the
- * annotations in this package accept arbitrary <code>requires</code> and
- * <code>provides</code> strings, which can be used to control the order of
+ * annotations in this package accept arbitrary {@code requires} and
+ * {@code provides} strings, which can be used to control the order of
  * statements in the generated descriptor. The strings given for
- * <code>requires</code> and <code>provides</code> have no meaning to the
+ * {@code requires} and {@code provides} have no meaning to the
  * compiler, except that it will make sure not to write anything that
- * <code>requires</code> some string <em>X</em> into the generated script
- * before whatever <code>provides</code> it.
+ * {@code requires} some string <em>X</em> into the generated script
+ * before whatever {@code provides} it.
+ * <li>There can be multiple ways to order the statements in the deployment
+ * descriptor to satisfy the given {@code provides} and {@code requires}
+ * relationships. While the compiler will always write the descriptor in an
+ * order that satisfies those relationships, when the {@code ddr.reproducible}
+ * option is {@code false}, the precise order may differ between successive
+ * compilations of the same sources, which <em>should</em> not affect successful
+ * loading and unloading of the jar with {@code install_jar} and
+ * {@code remove_jar}. In testing, this can help to confirm that all of the
+ * needed {@code provides} and {@code requires} relationships have been
+ * declared. When the {@code ddr.reproducible} option is {@code true}, the order
+ * of statements in the deployment descriptor will be one of the possible
+ * orders, chosen arbitrarily but consistently between multiple compilations as
+ * long as the sources are unchanged. This can be helpful in software
+ * distribution when reproducible output is wanted.
  * </ul>
  */
 package org.postgresql.pljava.annotation;


### PR DESCRIPTION
When true, it constrains the order of the generated DDR to be
consistent over successive compilations of the same sources,
useful in distribution builds where reproducibility is valued.
When false, it selects the previous behavior, where descriptors
can have different order from one compilation to the next of the
same sources; during testing, this can help to detect whether
there are necessary provides/requires relationships that haven't
been declared.

Addresses issue #181.

The 'reproducible' option also makes deterministic the order of Java-to-SQL
type mappings known to the generator, though this is an internal
detail; the ordered mappings are not emitted explicitly into the
DDR, and if a change in their order would affect what is written
there, that would probably indicate a more serious issue.