### PR TITLE
No really, avoid #if among macro arguments.

### DIFF
--- a/pljava-so/src/main/c/InstallHelper.c
+++ b/pljava-so/src/main/c/InstallHelper.c
@@ -517,11 +517,14 @@ char *InstallHelper_hello()
 	nativeVer = String_createJavaStringFromNTS(SO_VERSION_STRING);
 	serverBuiltVer = String_createJavaStringFromNTS(PG_VERSION_STR);
 
-	InitFunctionCallInfoData(fcinfo, NULL, 0,
 #if PG_VERSION_NUM >= 90100
+	InitFunctionCallInfoData(fcinfo, NULL, 0,
 	InvalidOid, /* collation */
-#endif
 	NULL, NULL);
+#else
+	InitFunctionCallInfoData(fcinfo, NULL, 0,
+	NULL, NULL);
+#endif
 	runningVer = DatumGetTextP(pgsql_version(&fcinfo));
 	serverRunningVer = String_createJavaString(runningVer);
 	pfree(runningVer);


### PR DESCRIPTION
Thanks to Ken Olson for the reminder that the Windows MSVC compiler
won't accept conditional-compilation syntax within an invocation
of a preprocessor macro. 5e01f8f was already about that, but a few
uses have crept back in through my inattention.

Honestly, MSVC is doing a service here, as a quick check of the
standard shows that preprocessing directives within macro invocations
really do have undefined behavior. Addresses issue #182.