### PR TITLE
Exclude Saxon 9.9 for now.

### DIFF
--- a/pljava-examples/pom.xml
+++ b/pljava-examples/pom.xml
@@ -17,7 +17,7 @@
 				<dependency>
 					<groupId>net.sf.saxon</groupId>
 					<artifactId>Saxon-HE</artifactId>
-					<version>[9.8.0-14,)</version>
+					<version>[9.8.0-14,9.9)</version>
 				</dependency>
 			</dependencies>
 			<build>


### PR DESCRIPTION
Saxon 9.9 is out, but some API has changed, so it is not drop-in. For now, simply exclude the new version; the API can be adapted later.

Addresses issue #185.