### PR TITLE
Avoid segfault in VarlenaWrapper.Input on 32-bit.

### DIFF
--- a/pljava-so/src/main/c/VarlenaWrapper.c
+++ b/pljava-so/src/main/c/VarlenaWrapper.c
@@ -249,7 +249,7 @@ constructResult:
 	vr = JNI_newObjectLocked(s_VarlenaWrapper_Input_class,
 		s_VarlenaWrapper_Input_init, pljava_DualState_key(),
 		p2lro.longVal, p2lcxt.longVal, p2lpin.longVal, p2ldatum.longVal,
-		parked, actual, dbb);
+		(jlong)parked, (jlong)actual, dbb);
 
 	if ( NULL != dbb )
 		JNI_deleteLocalRef(dbb);


### PR DESCRIPTION
Addresses issue #177.

The size of `Size` can be architecture-specific and differ from that of `jlong`. When writing JNI calls to Java methods, one is essentially performing without a net; the JNI method invocation functions take C variable arg lists, and the C compiler has no information for checking the types of the passed parameters against the signature of the method.

It would not be a bad thing to come up with a way to statically check those calls.