### PR TITLE
Use schema class loader in OId.getJavaClass

### DIFF
--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/jdk7/TypeRoundTripper.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/jdk7/TypeRoundTripper.java
@@ -86,14 +86,14 @@ import org.postgresql.pljava.example.annotation.ConditionalDDR; // for javadoc
  *  orig = roundtripped AS good, *
  *FROM
  *  (VALUES (timestamptz '2017-08-21 18:25:29.900005Z')) AS p(orig),
- *  roundtrip(p) AS r(roundtripped timestamptz);
+ *  roundtrip(p) AS (roundtripped timestamptz);
  *</pre>
  *<p>
  * This example relies on {@code implementor} tags reflecting the PostgreSQL
  * version, set up in the {@link ConditionalDDR} example.
  */
 @SQLAction(implementor = "postgresql_ge_90300", // funcs see earlier FROM items
-	requires = "TypeRoundTripper.roundTrip",
+	requires = {"TypeRoundTripper.roundTrip", "point mirror type"},
 	install = {
 	" SELECT" +
 	"  CASE WHEN every(orig = roundtripped)" +
@@ -106,7 +106,7 @@ import org.postgresql.pljava.example.annotation.ConditionalDDR; // for javadoc
 	"   (timestamp '1970-03-07 17:37:49.300009')," +
 	"   (timestamp '1919-05-29 13:08:33.600001')" +
 	"  ) AS p(orig)," +
-	"  roundtrip(p) AS r(roundtripped timestamp)",
+	"  roundtrip(p) AS (roundtripped timestamp)",
 
 	" SELECT" +
 	"  CASE WHEN every(orig = roundtripped)" +
@@ -119,7 +119,16 @@ import org.postgresql.pljava.example.annotation.ConditionalDDR; // for javadoc
 	"   (timestamptz '1970-03-07 17:37:49.300009Z')," +
 	"   (timestamptz '1919-05-29 13:08:33.600001Z')" +
 	"  ) AS p(orig)," +
-	"  roundtrip(p) AS r(roundtripped timestamptz)",
+	"  roundtrip(p) AS (roundtripped timestamptz)",
+
+	" SELECT" +
+	"  CASE WHEN classjdbc = 'org.postgresql.pljava.example.annotation.Point'" +
+	"  THEN javatest.logmessage('INFO', 'issue192 test passes')" +
+	"  ELSE javatest.logmessage('WARNING', 'issue192 test fails')" +
+	"  END" +
+	" FROM" +
+	"  (VALUES (point '0,0')) AS p," +
+	"  roundtrip(p) AS (classjdbc text)",
 	}
 )
 public class TypeRoundTripper

--- a/pljava-so/src/main/c/type/Oid.c
+++ b/pljava-so/src/main/c/type/Oid.c
@@ -18,6 +18,7 @@
 #include "pljava/type/Oid.h"
 #include "pljava/type/String.h"
 #include "pljava/Exception.h"
+#include "pljava/Function.h"
 #include "pljava/Invocation.h"
 
 static jclass    s_Oid_class;
@@ -193,6 +194,11 @@ void Oid_initialize(void)
 		"(I)Ljava/lang/String;",
 	  	Java_org_postgresql_pljava_internal_Oid__1getJavaClassName
 		},
+		{
+		"_getCurrentLoader",
+		"()Ljava/lang/ClassLoader;",
+		Java_org_postgresql_pljava_internal_Oid__1getCurrentLoader
+		},
 		{ 0, 0, 0 }};
 
 	jobject tmp;
@@ -301,6 +307,21 @@ Java_org_postgresql_pljava_internal_Oid__1getJavaClassName(JNIEnv* env, jclass c
 		Type type = Type_objectTypeFromOid((Oid)oid, Invocation_getTypeMap());
 		result = String_createJavaStringFromNTS(Type_getJavaTypeName(type));
 	}
+	END_NATIVE
+	return result;
+}
+
+/*
+ * Class:     org_postgresql_pljava_internal_Oid
+ * Method:    _getCurrentLoader
+ * Signature: ()Ljava/lang/ClassLoader;
+ */
+JNIEXPORT jobject JNICALL
+Java_org_postgresql_pljava_internal_Oid__1getCurrentLoader(JNIEnv *env, jclass cls)
+{
+	jobject result;
+	BEGIN_NATIVE
+	result = Function_currentLoader();
 	END_NATIVE
 	return result;
 }

--- a/pljava-so/src/main/include/pljava/Function.h
+++ b/pljava-so/src/main/include/pljava/Function.h
@@ -75,6 +75,13 @@ extern jobject Function_getTypeMap(Function self);
 extern bool Function_isCurrentReadOnly(void);
 
 /*
+ * Return a local reference to the initiating (schema) class loader used to load
+ * the currently-executing function, or NULL if there is no currently-executing
+ * function or the schema loaders have been cleared and that loader is gone.
+ */
+extern jobject Function_currentLoader(void);
+
+/*
  * A nameless Function singleton with the property ! isCurrentReadOnly()
  */
 extern Function Function_INIT_WRITER;

--- a/pljava/src/main/java/org/postgresql/pljava/internal/Oid.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/Oid.java
@@ -149,13 +149,18 @@ public class Oid extends Number
 		if(c == null)
 		{
 			String className;
+			ClassLoader loader;
 			synchronized(Backend.THREADLOCK)
 			{
 				className = _getJavaClassName(m_native);
+				loader = _getCurrentLoader();
 			}
 			try
 			{
-				c = Class.forName(getCanonicalClassName(className, 0));
+				String canonName = getCanonicalClassName(className, 0);
+				if ( null == loader )
+					loader = getClass().getClassLoader();
+				c = Class.forName(canonName, true, loader);
 			}
 			catch(ClassNotFoundException e)
 			{
@@ -246,5 +251,13 @@ public class Oid extends Number
 	private native static Oid _getTypeId();
 
 	private native static String _getJavaClassName(int nativeOid)
+	throws SQLException;
+
+	/**
+	 * Return the (initiating, "schema") ClassLoader of the innermost
+	 * currently-executing PL/Java function, or null if there is none or the
+	 * schema loaders have since been cleared and the loader is gone.
+	 */
+	private native static ClassLoader _getCurrentLoader()
 	throws SQLException;
 }


### PR DESCRIPTION
Addresses issue #192.

`Oid.getJavaClass` had been using the class loader that loaded `Oid` itself, which is on `pljava.classpath`; its loader cannot see classes in user-loaded jars on the schema classpath.

Add a `Function_getCurrentLoader()` to retrieve a saved reference to the initiating loader used to find the function's containing class. That should be the "schema loader" for the schema in which the function is declared. Tempting to cheat and just use `getClassLoader` on the function's class, but that would return the defining loader, in cases where it and the initiating loader are different.

The choice to use the schema loader for the innermost executing PL/Java function is for consistency with the documented convention (in the developer notes) of using the innermost executing function's schema to determine the type map to use.

Taking a step back, the whole `Oid` class seems like something between a misnomer and a solution-in-search-of-a-problem. It is something of a stash for information on the correspondences between PG and Java types, but hardly a complete one, and a lot of that information is in other places; meanwhile, plenty of things in PG, besides types, have Oids. In some future version, I envision this `Oid` class gone, with its type mapping information merged into something more like a much-evolved `TypeBridge` that would centralize a lot of type-correspondence knowledge that is held now in many places. There might be an entirely different class to represent oids, if that is useful, with subclasses corresponding to the different `reg*` oid types in PG.

But for now, the existing `Oid` class gets nursed along.