### PR TITLE
Avoid timestamp in SetOfRecordTest.

### DIFF
--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/SetOfRecordTest.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/SetOfRecordTest.java
@@ -36,16 +36,16 @@ install=
 " SELECT " +
 "  CASE WHEN r IS DISTINCT FROM ROW('Foo'::varchar, 1::integer, 1.5::float, " +
 "       23.67::decimal(8,2), '2005-06-01'::date, '20:56'::time, " +
-"       '2006-02-04 23:55:10'::timestamp) " +
+"       '192.168'::cidr) " +
 "  THEN javatest.logmessage('WARNING', 'SetOfRecordTest not ok') " +
 "  ELSE javatest.logmessage('INFO', 'SetOfRecordTest ok') " +
 "  END " +
 " FROM " +
 "  javatest.executeselecttorecords( " +
 "   'select ''Foo'',  1,  1.5,  23.67,  ''2005-06-01'',  ''20:56''::time, " +
-"           ''2006-02-04 23:55:10''') " +
+"           ''192.168.0''') " +
 "  AS r(t_varchar varchar, t_integer integer, t_float float, " +
-"      t_decimal decimal(8,2), t_date date, t_time time, t_timestamp timestamp)"
+"      t_decimal decimal(8,2), t_date date, t_time time, t_cidr cidr)"
 )
 public class SetOfRecordTest implements ResultSetHandle {
 


### PR DESCRIPTION
The SetOfRecordTest is only there to demonstrate that sets of RECORD
can be returned, and that casts are done from a ResultSetHandle as
needed. Using a timestamp as one of the test values can make it also
(in some circumstances) a demonstration of java.sql.Timestamp's
unintuitive dependence on local time zone settings ... which is why
the JDBC 4.2 mapping to java.time.LocalDateTime is preferable, which
the documentation and release notes already explain. The purpose of
SetOfRecordTest can be achieved just as well using types that don't
have that sort of environment dependency.

Addresses issue #195.