### PR TITLE
Adopt generics in more places where applicable.

### DIFF
--- a/pljava-api/src/main/java/org/postgresql/pljava/ObjectPool.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/ObjectPool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2015 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2019 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -21,7 +21,7 @@ import java.sql.SQLException;
  * for the class to be pooled, which must implement {@link PooledObject}.
  * @author Thomas Hallgren
  */
-public interface ObjectPool
+public interface ObjectPool<T extends PooledObject>
 {
 	/**
 	 * Obtain a pooled object, calling its {@link PooledObject#activate()}
@@ -30,7 +30,7 @@ public interface ObjectPool
 	 * 
 	 * @return A new object or an object found in the pool.
 	 */
-	PooledObject activateInstance()
+	T activateInstance()
 	throws SQLException;
 
 	/**
@@ -38,13 +38,13 @@ public interface ObjectPool
 	 * to the pool.
 	 * @param instance The instance to passivate.
 	 */
-	void passivateInstance(PooledObject instance)
+	void passivateInstance(T instance)
 	throws SQLException;
 
 	/**
 	 * Call the {@link PooledObject#remove()} method and evict the object
 	 * from the pool.
 	 */
-	void removeInstance(PooledObject instance)
+	void removeInstance(T instance)
 	throws SQLException;
 }

--- a/pljava-api/src/main/java/org/postgresql/pljava/Session.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/Session.java
@@ -70,7 +70,7 @@ public interface Session
 	 * constructor for one argument of type <code>ObjectPool</code>.
 	 * @return An object pool that pools object of the given class.
 	 */
-	ObjectPool getObjectPool(Class cls);
+	<T extends PooledObject> ObjectPool<T> getObjectPool(Class<T> cls);
 
 	/**
 	 * Return the current <em>effective</em> database user name.

--- a/pljava/src/main/java/org/postgresql/pljava/internal/Oid.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/Oid.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2018 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2019 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -25,9 +25,12 @@ import java.util.HashMap;
  */
 public class Oid extends Number
 {
-	private static final HashMap s_class2typeId = new HashMap();
+	private static final HashMap<Class<?>,Oid> s_class2typeId =
+		new HashMap<Class<?>,Oid>();
 
-	private static final HashMap s_typeId2class = new HashMap();
+	private static final HashMap<Oid,Class<?>> s_typeId2class =
+		new HashMap<Oid,Class<?>>();
+
 	static
 	{
 		try
@@ -52,7 +55,7 @@ public class Oid extends Number
 	{
 		if ( obj instanceof SQLData )
 			return forTypeName(((SQLData)obj).getSQLTypeName());
-		return (Oid)s_class2typeId.get(obj.getClass());
+		return s_class2typeId.get(obj.getClass());
 	}
 
 	/**
@@ -145,7 +148,7 @@ public class Oid extends Number
 	public Class getJavaClass()
 	throws SQLException
 	{
-		Class c = (Class)s_typeId2class.get(this);
+		Class c = s_typeId2class.get(this);
 		if(c == null)
 		{
 			String className;

--- a/pljava/src/main/java/org/postgresql/pljava/internal/Session.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/Session.java
@@ -21,6 +21,7 @@ import java.sql.Statement;
 import java.util.HashMap;
 
 import org.postgresql.pljava.ObjectPool;
+import org.postgresql.pljava.PooledObject;
 import org.postgresql.pljava.SavepointListener;
 import org.postgresql.pljava.TransactionListener;
 import org.postgresql.pljava.jdbc.SQLUtils;
@@ -98,7 +99,7 @@ public class Session implements org.postgresql.pljava.Session
 		return m_attributes.get(attributeName);
 	}
 
-	public ObjectPool getObjectPool(Class cls)
+	public <T extends PooledObject> ObjectPool<T> getObjectPool(Class<T> cls)
 	{
 		return ObjectPoolImpl.getObjectPool(cls);
 	}

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/ObjectResultSet.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/ObjectResultSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2018 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2019 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -98,7 +98,7 @@ public abstract class ObjectResultSet extends AbstractResultSet
 	public Array getArray(int columnIndex)
 	throws SQLException
 	{
-		return (Array)this.getValue(columnIndex, Array.class);
+		return getValue(columnIndex, Array.class);
 	}
 
 	/**
@@ -108,7 +108,7 @@ public abstract class ObjectResultSet extends AbstractResultSet
 	public InputStream getAsciiStream(int columnIndex)
 	throws SQLException
 	{
-		Clob c = this.getClob(columnIndex);
+		Clob c = getClob(columnIndex);
 		return (c == null) ? null : c.getAsciiStream();
 	}
 
@@ -119,7 +119,7 @@ public abstract class ObjectResultSet extends AbstractResultSet
 	public BigDecimal getBigDecimal(int columnIndex)
 	throws SQLException
 	{
-		return (BigDecimal)this.getValue(columnIndex, BigDecimal.class);
+		return getValue(columnIndex, BigDecimal.class);
 	}
 
 	/**
@@ -140,7 +140,7 @@ public abstract class ObjectResultSet extends AbstractResultSet
 	public InputStream getBinaryStream(int columnIndex)
 	throws SQLException
 	{
-		Blob b = this.getBlob(columnIndex);
+		Blob b = getBlob(columnIndex);
 		return (b == null) ? null : b.getBinaryStream();
 	}
 
@@ -151,7 +151,7 @@ public abstract class ObjectResultSet extends AbstractResultSet
 	public Blob getBlob(int columnIndex)
 	throws SQLException
 	{
-		byte[] bytes = this.getBytes(columnIndex);
+		byte[] bytes = getBytes(columnIndex);
 		return (bytes == null) ? null :  new BlobValue(bytes);
 	}
 
@@ -162,7 +162,7 @@ public abstract class ObjectResultSet extends AbstractResultSet
 	public boolean getBoolean(int columnIndex)
 	throws SQLException
 	{
-		Boolean b = (Boolean)this.getValue(columnIndex, Boolean.class);
+		Boolean b = getValue(columnIndex, Boolean.class);
 		return (b == null) ? false : b.booleanValue();
 	}
 
@@ -173,7 +173,7 @@ public abstract class ObjectResultSet extends AbstractResultSet
 	public byte getByte(int columnIndex)
 	throws SQLException
 	{
-		Number b = this.getNumber(columnIndex, byte.class);
+		Number b = getNumber(columnIndex, byte.class);
 		return (b == null) ? 0 : b.byteValue();
 	}
 
@@ -184,7 +184,7 @@ public abstract class ObjectResultSet extends AbstractResultSet
 	public byte[] getBytes(int columnIndex)
 	throws SQLException
 	{
-		return (byte[])this.getValue(columnIndex, byte[].class);
+		return getValue(columnIndex, byte[].class);
 	}
 
 	/**
@@ -194,7 +194,7 @@ public abstract class ObjectResultSet extends AbstractResultSet
 	public Reader getCharacterStream(int columnIndex)
 	throws SQLException
 	{
-		Clob c = this.getClob(columnIndex);
+		Clob c = getClob(columnIndex);
 		return (c == null) ? null : c.getCharacterStream();
 	}
 
@@ -205,7 +205,7 @@ public abstract class ObjectResultSet extends AbstractResultSet
 	public Clob getClob(int columnIndex)
 	throws SQLException
 	{
-		String str = this.getString(columnIndex);
+		String str = getString(columnIndex);
 		return (str == null) ? null :  new ClobValue(str);
 	}
 	
@@ -216,7 +216,7 @@ public abstract class ObjectResultSet extends AbstractResultSet
 	public Date getDate(int columnIndex)
 	throws SQLException
 	{
-		return (Date)this.getValue(columnIndex, Date.class);
+		return getValue(columnIndex, Date.class);
 	}
 
 	/**
@@ -226,7 +226,7 @@ public abstract class ObjectResultSet extends AbstractResultSet
 	public Date getDate(int columnIndex, Calendar cal)
 	throws SQLException
 	{
-		return (Date)this.getValue(columnIndex, Date.class, cal);
+		return getValue(columnIndex, Date.class, cal);
 	}
 
 	/**
@@ -236,7 +236,7 @@ public abstract class ObjectResultSet extends AbstractResultSet
 	public double getDouble(int columnIndex)
 	throws SQLException
 	{
-		Number d = this.getNumber(columnIndex, double.class);
+		Number d = getNumber(columnIndex, double.class);
 		return (d == null) ? 0 : d.doubleValue();
 	}
 
@@ -247,7 +247,7 @@ public abstract class ObjectResultSet extends AbstractResultSet
 	public float getFloat(int columnIndex)
 	throws SQLException
 	{
-		Number f = this.getNumber(columnIndex, float.class);
+		Number f = getNumber(columnIndex, float.class);
 		return (f == null) ? 0 : f.floatValue();
 	}
 
@@ -258,7 +258,7 @@ public abstract class ObjectResultSet extends AbstractResultSet
 	public int getInt(int columnIndex)
 	throws SQLException
 	{
-		Number i = this.getNumber(columnIndex, int.class);
+		Number i = getNumber(columnIndex, int.class);
 		return (i == null) ? 0 : i.intValue();
 	}
 
@@ -269,7 +269,7 @@ public abstract class ObjectResultSet extends AbstractResultSet
 	public long getLong(int columnIndex)
 	throws SQLException
 	{
-		Number l = this.getNumber(columnIndex, long.class);
+		Number l = getNumber(columnIndex, long.class);
 		return (l == null) ? 0 : l.longValue();
 	}
 
@@ -281,7 +281,7 @@ public abstract class ObjectResultSet extends AbstractResultSet
 	public final Object getObject(int columnIndex)
 	throws SQLException
 	{
-		Object value = this.getObjectValue(columnIndex);
+		Object value = getObjectValue(columnIndex);
 		m_wasNull = (value == null);
 		return value;
 	}
@@ -294,7 +294,7 @@ public abstract class ObjectResultSet extends AbstractResultSet
 	public final Object getObject(int columnIndex, Map map)
 	throws SQLException
 	{
-		Object value = this.getObjectValue(columnIndex, map);
+		Object value = getObjectValue(columnIndex, map);
 		m_wasNull = (value == null);
 		return value;
 	}
@@ -306,7 +306,7 @@ public abstract class ObjectResultSet extends AbstractResultSet
 	public Ref getRef(int columnIndex)
 	throws SQLException
 	{
-		return (Ref)this.getValue(columnIndex, Ref.class);
+		return getValue(columnIndex, Ref.class);
 	}
 
 	/**
@@ -316,7 +316,7 @@ public abstract class ObjectResultSet extends AbstractResultSet
 	public short getShort(int columnIndex)
 	throws SQLException
 	{
-		Number s = this.getNumber(columnIndex, short.class);
+		Number s = getNumber(columnIndex, short.class);
 		return (s == null) ? 0 : s.shortValue();
 	}
 
@@ -327,7 +327,7 @@ public abstract class ObjectResultSet extends AbstractResultSet
 	public String getString(int columnIndex)
 	throws SQLException
 	{
-		return (String)this.getValue(columnIndex, String.class);
+		return getValue(columnIndex, String.class);
 	}
 
 	/**
@@ -337,7 +337,7 @@ public abstract class ObjectResultSet extends AbstractResultSet
 	public Time getTime(int columnIndex)
 	throws SQLException
 	{
-		return (Time)this.getValue(columnIndex, Time.class);
+		return getValue(columnIndex, Time.class);
 	}
 
 	/**
@@ -347,7 +347,7 @@ public abstract class ObjectResultSet extends AbstractResultSet
 	public Time getTime(int columnIndex, Calendar cal)
 	throws SQLException
 	{
-		return (Time)this.getValue(columnIndex, Time.class, cal);
+		return getValue(columnIndex, Time.class, cal);
 	}
 
 	/**
@@ -357,7 +357,7 @@ public abstract class ObjectResultSet extends AbstractResultSet
 	public Timestamp getTimestamp(int columnIndex)
 	throws SQLException
 	{
-		return (Timestamp)this.getValue(columnIndex, Timestamp.class);
+		return getValue(columnIndex, Timestamp.class);
 	}
 
 	/**
@@ -367,7 +367,7 @@ public abstract class ObjectResultSet extends AbstractResultSet
 	public Timestamp getTimestamp(int columnIndex, Calendar cal)
 	throws SQLException
 	{
-		return (Timestamp)this.getValue(columnIndex, Timestamp.class, cal);
+		return getValue(columnIndex, Timestamp.class, cal);
 	}
 
 	/**
@@ -386,7 +386,7 @@ public abstract class ObjectResultSet extends AbstractResultSet
 	@Override
 	public URL getURL(int columnIndex) throws SQLException
 	{
-		return (URL)this.getValue(columnIndex, URL.class);
+		return getValue(columnIndex, URL.class);
 	}
 
 	/**
@@ -410,7 +410,7 @@ public abstract class ObjectResultSet extends AbstractResultSet
 	@Override
 	public void updateArray(int columnIndex, Array x) throws SQLException
 	{
-		this.updateObject(columnIndex, x);
+		updateObject(columnIndex, x);
 	}
 
 	/**
@@ -423,7 +423,7 @@ public abstract class ObjectResultSet extends AbstractResultSet
 	{
 		try
 		{
-			this.updateObject(columnIndex,
+			updateObject(columnIndex,
 				new ClobValue(new InputStreamReader(x, "US-ASCII"), length));
 		}
 		catch(UnsupportedEncodingException e)
@@ -440,7 +440,7 @@ public abstract class ObjectResultSet extends AbstractResultSet
 	public void updateBigDecimal(int columnIndex, BigDecimal x)
 	throws SQLException
 	{
-		this.updateObject(columnIndex, x);
+		updateObject(columnIndex, x);
 	}
 
 	/**
@@ -451,7 +451,7 @@ public abstract class ObjectResultSet extends AbstractResultSet
 	public void updateBinaryStream(int columnIndex, InputStream x, int length)
 	throws SQLException
 	{
-		this.updateBlob(columnIndex, (Blob) new BlobValue(x, length));
+		updateBlob(columnIndex, (Blob) new BlobValue(x, length));
 	}
 
 	/**
@@ -461,7 +461,7 @@ public abstract class ObjectResultSet extends AbstractResultSet
 	public void updateBlob(int columnIndex, Blob x)
 	throws SQLException
 	{
-		this.updateObject(columnIndex, x);
+		updateObject(columnIndex, x);
 	}
 
 	/**
@@ -471,7 +471,7 @@ public abstract class ObjectResultSet extends AbstractResultSet
 	public void updateBoolean(int columnIndex, boolean x)
 	throws SQLException
 	{
-		this.updateObject(columnIndex, x ? Boolean.TRUE : Boolean.FALSE);
+		updateObject(columnIndex, x);
 	}
 
 	/**
@@ -481,7 +481,7 @@ public abstract class ObjectResultSet extends AbstractResultSet
 	public void updateByte(int columnIndex, byte x)
 	throws SQLException
 	{
-		this.updateObject(columnIndex, new Byte(x));
+		updateObject(columnIndex, x);
 	}
 
 	/**
@@ -491,7 +491,7 @@ public abstract class ObjectResultSet extends AbstractResultSet
 	public void updateBytes(int columnIndex, byte[] x)
 	throws SQLException
 	{
-		this.updateObject(columnIndex, x);
+		updateObject(columnIndex, x);
 	}
 
 	/**
@@ -502,7 +502,7 @@ public abstract class ObjectResultSet extends AbstractResultSet
 	public void updateCharacterStream(int columnIndex, Reader x, int length)
 	throws SQLException
 	{
-		this.updateClob(columnIndex, (Clob) new ClobValue(x, length));
+		updateClob(columnIndex, (Clob) new ClobValue(x, length));
 	}
 
 	/**
@@ -512,7 +512,7 @@ public abstract class ObjectResultSet extends AbstractResultSet
 	public void updateClob(int columnIndex, Clob x)
 	throws SQLException
 	{
-		this.updateObject(columnIndex, x);
+		updateObject(columnIndex, x);
 	}
 
 	/**
@@ -522,7 +522,7 @@ public abstract class ObjectResultSet extends AbstractResultSet
 	public void updateDate(int columnIndex, Date x)
 	throws SQLException
 	{
-		this.updateObject(columnIndex, x);
+		updateObject(columnIndex, x);
 	}
 
 	/**
@@ -532,7 +532,7 @@ public abstract class ObjectResultSet extends AbstractResultSet
 	public void updateDouble(int columnIndex, double x)
 	throws SQLException
 	{
-		this.updateObject(columnIndex, new Double(x));
+		updateObject(columnIndex, x);
 	}
 
 	/**
@@ -542,7 +542,7 @@ public abstract class ObjectResultSet extends AbstractResultSet
 	public void updateFloat(int columnIndex, float x)
 	throws SQLException
 	{
-		this.updateObject(columnIndex, new Float(x));
+		updateObject(columnIndex, x);
 	}
 
 	/**
@@ -552,7 +552,7 @@ public abstract class ObjectResultSet extends AbstractResultSet
 	public void updateInt(int columnIndex, int x)
 	throws SQLException
 	{
-		this.updateObject(columnIndex, new Integer(x));
+		updateObject(columnIndex, x);
 	}
 
 	/**
@@ -562,7 +562,7 @@ public abstract class ObjectResultSet extends AbstractResultSet
 	public void updateLong(int columnIndex, long x)
 	throws SQLException
 	{
-		this.updateObject(columnIndex, new Long(x));
+		updateObject(columnIndex, x);
 	}
 
 	/**
@@ -572,7 +572,7 @@ public abstract class ObjectResultSet extends AbstractResultSet
 	public void updateNull(int columnIndex)
 	throws SQLException
 	{
-		this.updateObject(columnIndex, null);
+		updateObject(columnIndex, null);
 	}
 
 	/**
@@ -582,7 +582,7 @@ public abstract class ObjectResultSet extends AbstractResultSet
 	public void updateRef(int columnIndex, Ref x)
 	throws SQLException
 	{
-		this.updateObject(columnIndex, x);
+		updateObject(columnIndex, x);
 	}
 
 	/**
@@ -592,7 +592,7 @@ public abstract class ObjectResultSet extends AbstractResultSet
 	public void updateShort(int columnIndex, short x)
 	throws SQLException
 	{
-		this.updateObject(columnIndex, new Short(x));
+		updateObject(columnIndex, x);
 	}
 
 	/**
@@ -602,7 +602,7 @@ public abstract class ObjectResultSet extends AbstractResultSet
 	public void updateString(int columnIndex, String x)
 	throws SQLException
 	{
-		this.updateObject(columnIndex, x);
+		updateObject(columnIndex, x);
 	}
 
 	/**
@@ -612,7 +612,7 @@ public abstract class ObjectResultSet extends AbstractResultSet
 	public void updateTime(int columnIndex, Time x)
 	throws SQLException
 	{
-		this.updateObject(columnIndex, x);
+		updateObject(columnIndex, x);
 	}
 
 	/**
@@ -622,7 +622,7 @@ public abstract class ObjectResultSet extends AbstractResultSet
 	public void updateTimestamp(int columnIndex, Timestamp x)
 	throws SQLException
 	{
-		this.updateObject(columnIndex, x);
+		updateObject(columnIndex, x);
 	}
 
 	// ************************************************************
@@ -638,7 +638,7 @@ public abstract class ObjectResultSet extends AbstractResultSet
 	public final <T> T getObject(int columnIndex, Class<T> type)
 	throws SQLException
 	{
-		Object value = this.getObjectValue(columnIndex, type);
+		Object value = getObjectValue(columnIndex, type);
 		m_wasNull = (value == null);
 		if ( m_wasNull  ||  type.isInstance(value) )
 			return type.cast(value);
@@ -652,35 +652,35 @@ public abstract class ObjectResultSet extends AbstractResultSet
 
 	/**
 	 * Implemented over {@link #getObjectValue}, tracks {@code wasNull},
-	 * applies {@link SPIConnection#basicNumericCoersion} to {@code cls}.
+	 * applies {@link SPIConnection#basicNumericCoercion} to {@code cls}.
 	 */
 	protected final Number getNumber(int columnIndex, Class cls)
 	throws SQLException
 	{
-		Object value = this.getObjectValue(columnIndex);
+		Object value = getObjectValue(columnIndex);
 		m_wasNull = (value == null);
-		return SPIConnection.basicNumericCoersion(cls, value);
+		return SPIConnection.basicNumericCoercion(cls, value);
 	}
 
 	/**
 	 * Implemented over {@link #getObject},
-	 * applies {@link SPIConnection#basicCoersion} to {@code cls}.
+	 * applies {@link SPIConnection#basicCoercion} to {@code cls}.
 	 */
-	protected final Object getValue(int columnIndex, Class cls)
+	protected final <T> T getValue(int columnIndex, Class<T> cls)
 	throws SQLException
 	{
-		return SPIConnection.basicCoersion(cls, this.getObject(columnIndex));
+		return SPIConnection.basicCoercion(cls, getObject(columnIndex));
 	}
 
 	/**
 	 * Implemented over {@link #getObject},
-	 * applies {@link SPIConnection#basicCalendricalCoersion} to {@code cls}.
+	 * applies {@link SPIConnection#basicCalendricalCoercion} to {@code cls}.
 	 */
-	protected Object getValue(int columnIndex, Class cls, Calendar cal)
+	protected <T> T getValue(int columnIndex, Class<T> cls, Calendar cal)
 	throws SQLException
 	{
-		return SPIConnection.basicCalendricalCoersion(cls,
-			this.getObject(columnIndex), cal);
+		return SPIConnection.basicCalendricalCoercion(cls,
+			getObject(columnIndex), cal);
 	}
 
 	/**
@@ -691,7 +691,7 @@ public abstract class ObjectResultSet extends AbstractResultSet
 	throws SQLException
 	{
 		if(typeMap == null)
-			return this.getObjectValue(columnIndex);
+			return getObjectValue(columnIndex);
 		throw new UnsupportedFeatureException(
 			"Obtaining values using explicit Map");
 	}

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/SPIPreparedStatement.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/SPIPreparedStatement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2018 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2019 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -73,7 +73,7 @@ public class SPIPreparedStatement extends SPIStatement implements PreparedStatem
 			m_plan.close();
 			m_plan = null;
 		}
-		this.clearParameters();
+		clearParameters();
 		super.close();
 	}
 
@@ -81,101 +81,101 @@ public class SPIPreparedStatement extends SPIStatement implements PreparedStatem
 	public ResultSet executeQuery()
 	throws SQLException
 	{
-		this.execute();
-		return this.getResultSet();
+		execute();
+		return getResultSet();
 	}
 
 	@Override
 	public int executeUpdate()
 	throws SQLException
 	{
-		this.execute();
-		return this.getUpdateCount();
+		execute();
+		return getUpdateCount();
 	}
 
 	@Override
 	public void setNull(int columnIndex, int sqlType)
 	throws SQLException
 	{
-		this.setObject(columnIndex, null, sqlType);
+		setObject(columnIndex, null, sqlType);
 	}
 
 	@Override
 	public void setBoolean(int columnIndex, boolean value) throws SQLException
 	{
-		this.setObject(columnIndex, value ? Boolean.TRUE : Boolean.FALSE, Types.BOOLEAN);
+		setObject(columnIndex, value, Types.BOOLEAN);
 	}
 
 	@Override
 	public void setByte(int columnIndex, byte value) throws SQLException
 	{
-		this.setObject(columnIndex, new Byte(value), Types.TINYINT);
+		setObject(columnIndex, value, Types.TINYINT);
 	}
 
 	@Override
 	public void setShort(int columnIndex, short value) throws SQLException
 	{
-		this.setObject(columnIndex, new Short(value), Types.SMALLINT);
+		setObject(columnIndex, value, Types.SMALLINT);
 	}
 
 	@Override
 	public void setInt(int columnIndex, int value) throws SQLException
 	{
-		this.setObject(columnIndex, new Integer(value), Types.INTEGER);
+		setObject(columnIndex, value, Types.INTEGER);
 	}
 
 	@Override
 	public void setLong(int columnIndex, long value) throws SQLException
 	{
-		this.setObject(columnIndex, new Long(value), Types.BIGINT);
+		setObject(columnIndex, value, Types.BIGINT);
 	}
 
 	@Override
 	public void setFloat(int columnIndex, float value) throws SQLException
 	{
-		this.setObject(columnIndex, new Float(value), Types.FLOAT);
+		setObject(columnIndex, value, Types.FLOAT);
 	}
 
 	@Override
 	public void setDouble(int columnIndex, double value) throws SQLException
 	{
-		this.setObject(columnIndex, new Double(value), Types.DOUBLE);
+		setObject(columnIndex, value, Types.DOUBLE);
 	}
 
 	@Override
 	public void setBigDecimal(int columnIndex, BigDecimal value) throws SQLException
 	{
-		this.setObject(columnIndex, value, Types.DECIMAL);
+		setObject(columnIndex, value, Types.DECIMAL);
 	}
 
 	@Override
 	public void setString(int columnIndex, String value) throws SQLException
 	{
-		this.setObject(columnIndex, value, Types.VARCHAR);
+		setObject(columnIndex, value, Types.VARCHAR);
 	}
 
 	@Override
 	public void setBytes(int columnIndex, byte[] value) throws SQLException
 	{
-		this.setObject(columnIndex, value, Types.VARBINARY);
+		setObject(columnIndex, value, Types.VARBINARY);
 	}
 
 	@Override
 	public void setDate(int columnIndex, Date value) throws SQLException
 	{
-		this.setObject(columnIndex, value, Types.DATE);
+		setObject(columnIndex, value, Types.DATE);
 	}
 
 	@Override
 	public void setTime(int columnIndex, Time value) throws SQLException
 	{
-		this.setObject(columnIndex, value, Types.TIME);
+		setObject(columnIndex, value, Types.TIME);
 	}
 
 	@Override
 	public void setTimestamp(int columnIndex, Timestamp value) throws SQLException
 	{
-		this.setObject(columnIndex, value, Types.TIMESTAMP);
+		setObject(columnIndex, value, Types.TIMESTAMP);
 	}
 
 	@Override
@@ -183,7 +183,7 @@ public class SPIPreparedStatement extends SPIStatement implements PreparedStatem
 	{
 		try
 		{
-			this.setObject(columnIndex,
+			setObject(columnIndex,
 				new ClobValue(new InputStreamReader(value, "US-ASCII"), length),
 				Types.CLOB);
 		}
@@ -205,7 +205,7 @@ public class SPIPreparedStatement extends SPIStatement implements PreparedStatem
 	@Override
 	public void setBinaryStream(int columnIndex, InputStream value, int length) throws SQLException
 	{
-		this.setObject(columnIndex, new BlobValue(value, length), Types.BLOB);
+		setObject(columnIndex, new BlobValue(value, length), Types.BLOB);
 	}
 
 	@Override
@@ -223,7 +223,7 @@ public class SPIPreparedStatement extends SPIStatement implements PreparedStatem
 	public void setObject(int columnIndex, Object value, int sqlType, int scale)
 	throws SQLException
 	{
-		this.setObject(columnIndex, value, sqlType);
+		setObject(columnIndex, value, sqlType);
 	}
 
 	@Override
@@ -318,7 +318,7 @@ public class SPIPreparedStatement extends SPIStatement implements PreparedStatem
 		else
 			sqlType = Types.OTHER;
 
-		this.setObject(columnIndex, value, sqlType, vAlt);
+		setObject(columnIndex, value, sqlType, vAlt);
 	}
 
 	/**
@@ -350,8 +350,8 @@ public class SPIPreparedStatement extends SPIStatement implements PreparedStatem
 		if(m_plan == null)
 			m_plan = ExecutionPlan.prepare(m_statement, m_typeIds);
 
-		boolean result = this.executePlan(m_plan, m_values);
-		this.clearParameters(); // Parameters are cleared upon successful completion.
+		boolean result = executePlan(m_plan, m_values);
+		clearParameters(); // Parameters are cleared upon successful completion.
 		return result;
 	}
 
@@ -369,8 +369,8 @@ public class SPIPreparedStatement extends SPIStatement implements PreparedStatem
 	public void addBatch()
 	throws SQLException
 	{
-		this.internalAddBatch(new Object[]{m_values.clone(), m_sqlTypes.clone(), m_typeIds.clone()});
-		this.clearParameters(); // Parameters are cleared upon successful completion.
+		internalAddBatch(new Object[]{m_values.clone(), m_sqlTypes.clone(), m_typeIds.clone()});
+		clearParameters(); // Parameters are cleared upon successful completion.
 	}
 
 	/**
@@ -388,31 +388,31 @@ public class SPIPreparedStatement extends SPIStatement implements PreparedStatem
 	public void setCharacterStream(int columnIndex, Reader value, int length)
 	throws SQLException
 	{
-		this.setObject(columnIndex, new ClobValue(value, length), Types.CLOB);
+		setObject(columnIndex, new ClobValue(value, length), Types.CLOB);
 	}
 
 	@Override
 	public void setRef(int columnIndex, Ref value) throws SQLException
 	{
-		this.setObject(columnIndex, value, Types.REF);
+		setObject(columnIndex, value, Types.REF);
 	}
 
 	@Override
 	public void setBlob(int columnIndex, Blob value) throws SQLException
 	{
-		this.setObject(columnIndex, value, Types.BLOB);
+		setObject(columnIndex, value, Types.BLOB);
 	}
 
 	@Override
 	public void setClob(int columnIndex, Clob value) throws SQLException
 	{
-		this.setObject(columnIndex, value, Types.CLOB);
+		setObject(columnIndex, value, Types.CLOB);
 	}
 
 	@Override
 	public void setArray(int columnIndex, Array value) throws SQLException
 	{
-		this.setObject(columnIndex, value, Types.ARRAY);
+		setObject(columnIndex, value, Types.ARRAY);
 	}
 
 	/**
@@ -430,27 +430,30 @@ public class SPIPreparedStatement extends SPIStatement implements PreparedStatem
 	public void setDate(int columnIndex, Date value, Calendar cal)
 	throws SQLException
 	{
-		if(cal == null || cal == Calendar.getInstance())
-			this.setObject(columnIndex, value, Types.DATE);
-		throw new UnsupportedFeatureException("Setting date using explicit Calendar");
+		if(cal != null && cal != Calendar.getInstance())
+			throw new UnsupportedFeatureException(
+				"Setting date using explicit Calendar");
+		setObject(columnIndex, value, Types.DATE);
 	}
 
 	@Override
 	public void setTime(int columnIndex, Time value, Calendar cal)
 	throws SQLException
 	{
-		if(cal == null || cal == Calendar.getInstance())
-			this.setObject(columnIndex, value, Types.TIME);
-		throw new UnsupportedFeatureException("Setting time using explicit Calendar");
+		if(cal != null && cal != Calendar.getInstance())
+			throw new UnsupportedFeatureException(
+				"Setting time using explicit Calendar");
+		setObject(columnIndex, value, Types.TIME);
 	}
 
 	@Override
 	public void setTimestamp(int columnIndex, Timestamp value, Calendar cal)
 	throws SQLException
 	{
-		if(cal == null || cal == Calendar.getInstance())
-			this.setObject(columnIndex, value, Types.TIMESTAMP);
-		throw new UnsupportedFeatureException("Setting time using explicit Calendar");
+		if(cal != null && cal != Calendar.getInstance())
+			throw new UnsupportedFeatureException(
+				"Setting time using explicit Calendar");
+		setObject(columnIndex, value, Types.TIMESTAMP);
 	}
 
 	/**
@@ -500,7 +503,7 @@ public class SPIPreparedStatement extends SPIStatement implements PreparedStatem
 	@Override
 	public void setURL(int columnIndex, URL value) throws SQLException
 	{
-		this.setObject(columnIndex, value, Types.DATALINK);
+		setObject(columnIndex, value, Types.DATALINK);
 	}
 
 	public String toString()
@@ -521,7 +524,7 @@ public class SPIPreparedStatement extends SPIStatement implements PreparedStatem
 	public ParameterMetaData getParameterMetaData()
 	throws SQLException
 	{
-		return new SPIParameterMetaData(this.getSqlTypes());
+		return new SPIParameterMetaData(getSqlTypes());
 	}
 
 	protected long executeBatchEntry(Object batchEntry)
@@ -553,11 +556,11 @@ public class SPIPreparedStatement extends SPIStatement implements PreparedStatem
 			}
 		}
 
-		if(this.execute())
-			this.getResultSet().close();
+		if(execute())
+			getResultSet().close();
 		else
 		{
-			long updCount = this.getUpdateCount();
+			long updCount = getUpdateCount();
 			if(updCount >= 0)
 				ret = updCount;
 		}
@@ -588,7 +591,7 @@ public class SPIPreparedStatement extends SPIStatement implements PreparedStatem
 		throws SQLException
 	{
 		throw new SQLFeatureNotSupportedException
-			( this.getClass()
+			( getClass()
 			  + ".setNClob( int, Reader ) not implemented yet.",
 			  "0A000" );
 
@@ -600,7 +603,7 @@ public class SPIPreparedStatement extends SPIStatement implements PreparedStatem
 		throws SQLException
 	{
 		throw new SQLFeatureNotSupportedException
-			( this.getClass()
+			( getClass()
 			  + ".setNClob( int, NClob ) not implemented yet.",
 			  "0A000" );
 
@@ -612,7 +615,7 @@ public class SPIPreparedStatement extends SPIStatement implements PreparedStatem
 		throws SQLException
 	{
 		throw new SQLFeatureNotSupportedException
-			( this.getClass()
+			( getClass()
 			  + ".setNClob( int, Reader, long ) not "
 			  + "implemented yet.",
 			  "0A000" );
@@ -625,7 +628,7 @@ public class SPIPreparedStatement extends SPIStatement implements PreparedStatem
 		throws SQLException
 	{
 		throw new SQLFeatureNotSupportedException
-			( this.getClass()
+			( getClass()
 			  + ".setBlob( int, InputStream ) not "
 			  + "implemented yet.",
 			  "0A000" );
@@ -637,7 +640,7 @@ public class SPIPreparedStatement extends SPIStatement implements PreparedStatem
 		throws SQLException
 	{
 		throw new SQLFeatureNotSupportedException
-			( this.getClass()
+			( getClass()
 			  + ".setBlob( int, InputStream, long ) not "
 			  + "implemented yet.",
 			  "0A000" );
@@ -650,7 +653,7 @@ public class SPIPreparedStatement extends SPIStatement implements PreparedStatem
 		throws SQLException
 	{
 		throw new SQLFeatureNotSupportedException
-			( this.getClass()
+			( getClass()
 			  + ".setClob( int, Reader ) not implemented yet.",
 			  "0A000" );
 
@@ -662,7 +665,7 @@ public class SPIPreparedStatement extends SPIStatement implements PreparedStatem
 		throws SQLException
 	{
 		throw new SQLFeatureNotSupportedException
-			( this.getClass()
+			( getClass()
 			  + ".setClob( int, Reader, long ) not "
 			  + "implemented yet.",
 			  "0A000" );
@@ -675,7 +678,7 @@ public class SPIPreparedStatement extends SPIStatement implements PreparedStatem
 	    throws SQLException
 	{
 		throw new SQLFeatureNotSupportedException
-			( this.getClass()
+			( getClass()
 			  + ".setNCharacterStream( int, Reader ) not "
 			  + "implemented yet.",
 			  "0A000" );
@@ -688,7 +691,7 @@ public class SPIPreparedStatement extends SPIStatement implements PreparedStatem
 		throws SQLException
 	{
 		throw new SQLFeatureNotSupportedException
-			( this.getClass()
+			( getClass()
 			  + ".setNCharacterStream( int, Reader, long ) not "
 			  + "implemented yet.",
 			  "0A000" );
@@ -701,7 +704,7 @@ public class SPIPreparedStatement extends SPIStatement implements PreparedStatem
 		throws SQLException
 	{
 		throw new SQLFeatureNotSupportedException
-			( this.getClass()
+			( getClass()
 			  + ".setCharacterStream( int, Reader ) not "
 			  + "implemented yet.",
 			  "0A000" );
@@ -714,7 +717,7 @@ public class SPIPreparedStatement extends SPIStatement implements PreparedStatem
 		throws SQLException
 	{
 		throw new SQLFeatureNotSupportedException
-			( this.getClass()
+			( getClass()
 			  + ".setCharacterStream( int, Reader, long ) not "
 			  + "implemented yet.",
 			  "0A000" );
@@ -727,7 +730,7 @@ public class SPIPreparedStatement extends SPIStatement implements PreparedStatem
 		throws SQLException
 	{
 		throw new SQLFeatureNotSupportedException
-			( this.getClass()
+			( getClass()
 			  + ".setBinaryStream( int, InputStream ) not "
 			  + "implemented yet.",
 			  "0A000" );
@@ -740,7 +743,7 @@ public class SPIPreparedStatement extends SPIStatement implements PreparedStatem
 		throws SQLException
 	{
 		throw new SQLFeatureNotSupportedException
-			( this.getClass()
+			( getClass()
 			  + ".setBinaryStream( int, InputStream, long ) not "
 			  + "implemented yet.",
 			  "0A000" );
@@ -753,7 +756,7 @@ public class SPIPreparedStatement extends SPIStatement implements PreparedStatem
                     throws SQLException
 	{
 		throw new SQLFeatureNotSupportedException
-			( this.getClass()
+			( getClass()
 			  + ".setAsciiStream( int, InputStream ) not "
 			  + "implemented yet.",
 			  "0A000" );
@@ -766,7 +769,7 @@ public class SPIPreparedStatement extends SPIStatement implements PreparedStatem
 		throws SQLException
 	{
 		throw new SQLFeatureNotSupportedException
-			( this.getClass()
+			( getClass()
 			  + ".setAsciiStream( int, InputStream, long ) not "
 			  + "implemented yet.",
 			  "0A000" );
@@ -779,7 +782,7 @@ public class SPIPreparedStatement extends SPIStatement implements PreparedStatem
                 throws SQLException
 	{
 		throw new SQLFeatureNotSupportedException
-			( this.getClass()
+			( getClass()
 			  + ".setNString( int, String ) not implemented yet.",
 			  "0A000" );
 	}
@@ -790,7 +793,7 @@ public class SPIPreparedStatement extends SPIStatement implements PreparedStatem
 		throws SQLException
 	{
 		throw new SQLFeatureNotSupportedException
-			( this.getClass()
+			( getClass()
 			  + ".setRowId( int, RowId ) not implemented yet.",
 			  "0A000" );
 	}

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/SQLInputFromTuple.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/SQLInputFromTuple.java
@@ -74,7 +74,7 @@ public class SQLInputFromTuple extends SingleRowReader implements SQLInput
 	@Override
 	public Array readArray() throws SQLException
 	{
-		return (Array)this.readValue(Array.class);
+		return readValue(Array.class);
 	}
 
 	/**
@@ -83,7 +83,7 @@ public class SQLInputFromTuple extends SingleRowReader implements SQLInput
 	@Override
 	public InputStream readAsciiStream() throws SQLException
 	{
-		Clob c = this.readClob();
+		Clob c = readClob();
 		return (c == null) ? null : c.getAsciiStream();
 	}
 
@@ -93,7 +93,7 @@ public class SQLInputFromTuple extends SingleRowReader implements SQLInput
 	@Override
 	public BigDecimal readBigDecimal() throws SQLException
 	{
-		return (BigDecimal)this.readValue(BigDecimal.class);
+		return readValue(BigDecimal.class);
 	}
 
 	/**
@@ -102,7 +102,7 @@ public class SQLInputFromTuple extends SingleRowReader implements SQLInput
 	@Override
 	public InputStream readBinaryStream() throws SQLException
 	{
-		Blob b = this.readBlob();
+		Blob b = readBlob();
 		return (b == null) ? null : b.getBinaryStream();
 	}
 
@@ -112,7 +112,7 @@ public class SQLInputFromTuple extends SingleRowReader implements SQLInput
 	@Override
 	public Blob readBlob() throws SQLException
 	{
-		byte[] bytes = this.readBytes();
+		byte[] bytes = readBytes();
 		return (bytes == null) ? null :  new BlobValue(bytes);
 	}
 
@@ -122,7 +122,7 @@ public class SQLInputFromTuple extends SingleRowReader implements SQLInput
 	@Override
 	public boolean readBoolean() throws SQLException
 	{
-		Boolean b = (Boolean)this.readValue(Boolean.class);
+		Boolean b = readValue(Boolean.class);
 		return (b == null) ? false : b.booleanValue();
 	}
 
@@ -132,7 +132,7 @@ public class SQLInputFromTuple extends SingleRowReader implements SQLInput
 	@Override
 	public byte readByte() throws SQLException
 	{
-		Number b = this.readNumber(byte.class);
+		Number b = readNumber(byte.class);
 		return (b == null) ? 0 : b.byteValue();
 	}
 
@@ -142,7 +142,7 @@ public class SQLInputFromTuple extends SingleRowReader implements SQLInput
 	@Override
 	public byte[] readBytes() throws SQLException
 	{
-		return (byte[])this.readValue(byte[].class);
+		return readValue(byte[].class);
 	}
 
 	/**
@@ -150,7 +150,7 @@ public class SQLInputFromTuple extends SingleRowReader implements SQLInput
 	 */
 	public Reader readCharacterStream() throws SQLException
 	{
-		Clob c = this.readClob();
+		Clob c = readClob();
 		return (c == null) ? null : c.getCharacterStream();
 	}
 
@@ -159,7 +159,7 @@ public class SQLInputFromTuple extends SingleRowReader implements SQLInput
 	 */
 	public Clob readClob() throws SQLException
 	{
-		String str = this.readString();
+		String str = readString();
 		return (str == null) ? null :  new ClobValue(str);
 	}
 
@@ -169,7 +169,7 @@ public class SQLInputFromTuple extends SingleRowReader implements SQLInput
 	@Override
 	public Date readDate() throws SQLException
 	{
-		return (Date)this.readValue(Date.class);
+		return readValue(Date.class);
 	}
 
 	/**
@@ -178,7 +178,7 @@ public class SQLInputFromTuple extends SingleRowReader implements SQLInput
 	@Override
 	public double readDouble() throws SQLException
 	{
-		Number d = this.readNumber(double.class);
+		Number d = readNumber(double.class);
 		return (d == null) ? 0 : d.doubleValue();
 	}
 
@@ -188,7 +188,7 @@ public class SQLInputFromTuple extends SingleRowReader implements SQLInput
 	@Override
 	public float readFloat() throws SQLException
 	{
-		Number f = this.readNumber(float.class);
+		Number f = readNumber(float.class);
 		return (f == null) ? 0 : f.floatValue();
 	}
 
@@ -198,7 +198,7 @@ public class SQLInputFromTuple extends SingleRowReader implements SQLInput
 	@Override
 	public int readInt() throws SQLException
 	{
-		Number i = this.readNumber(int.class);
+		Number i = readNumber(int.class);
 		return (i == null) ? 0 : i.intValue();
 	}
 
@@ -208,7 +208,7 @@ public class SQLInputFromTuple extends SingleRowReader implements SQLInput
 	@Override
 	public long readLong() throws SQLException
 	{
-		Number l = this.readNumber(long.class);
+		Number l = readNumber(long.class);
 		return (l == null) ? 0 : l.longValue();
 	}
 
@@ -224,7 +224,7 @@ public class SQLInputFromTuple extends SingleRowReader implements SQLInput
 	@Override
 	public Ref readRef() throws SQLException
 	{
-		return (Ref)this.readValue(Ref.class);
+		return readValue(Ref.class);
 	}
 
 	/**
@@ -233,7 +233,7 @@ public class SQLInputFromTuple extends SingleRowReader implements SQLInput
 	@Override
 	public short readShort() throws SQLException
 	{
-		Number s = this.readNumber(short.class);
+		Number s = readNumber(short.class);
 		return (s == null) ? 0 : s.shortValue();
 	}
 
@@ -243,7 +243,7 @@ public class SQLInputFromTuple extends SingleRowReader implements SQLInput
 	@Override
 	public String readString() throws SQLException
 	{
-		return (String)this.readValue(String.class);
+		return readValue(String.class);
 	}
 
 	/**
@@ -252,7 +252,7 @@ public class SQLInputFromTuple extends SingleRowReader implements SQLInput
 	@Override
 	public Time readTime() throws SQLException
 	{
-		return (Time)this.readValue(Time.class);
+		return readValue(Time.class);
 	}
 
 	/**
@@ -261,7 +261,7 @@ public class SQLInputFromTuple extends SingleRowReader implements SQLInput
 	@Override
 	public Timestamp readTimestamp() throws SQLException
 	{
-		return (Timestamp)this.readValue(Timestamp.class);
+		return readValue(Timestamp.class);
 	}
 
 	/**
@@ -270,7 +270,7 @@ public class SQLInputFromTuple extends SingleRowReader implements SQLInput
 	@Override
 	public URL readURL() throws SQLException
 	{
-		return (URL)this.readValue(URL.class);
+		return readValue(URL.class);
 	}
 
 	// ************************************************************
@@ -284,7 +284,7 @@ public class SQLInputFromTuple extends SingleRowReader implements SQLInput
 	public SQLXML readSQLXML()
 		throws SQLException
 	{
-		return this.readObject(SQLXML.class);
+		return readObject(SQLXML.class);
 	}
 
 	// ************************************************************
@@ -297,7 +297,7 @@ public class SQLInputFromTuple extends SingleRowReader implements SQLInput
                 throws SQLException
 	{
 		throw new SQLFeatureNotSupportedException
-			( this.getClass()
+			( getClass()
 			  + ".readRowId() not implemented yet.",
 			  "0A000" );
 	}
@@ -308,7 +308,7 @@ public class SQLInputFromTuple extends SingleRowReader implements SQLInput
 		throws SQLException
 	{
 		throw new SQLFeatureNotSupportedException
-			( this.getClass()
+			( getClass()
 			  + ".readNString() not implemented yet.",
 			  "0A000" );
 		
@@ -320,7 +320,7 @@ public class SQLInputFromTuple extends SingleRowReader implements SQLInput
 	       throws SQLException
 	{
 		throw new SQLFeatureNotSupportedException
-			( this.getClass()
+			( getClass()
 			  + ".readNClob() not implemented yet.",
 		  "0A000" );
 		
@@ -345,7 +345,7 @@ public class SQLInputFromTuple extends SingleRowReader implements SQLInput
 		return getNumber(nextIndex(), numberClass);
 	}
 
-	private Object readValue(Class valueClass) throws SQLException
+	private <T> T readValue(Class<T> valueClass) throws SQLException
 	{
 		return getValue(nextIndex(), valueClass);
 	}

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/SQLOutputToTuple.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/SQLOutputToTuple.java
@@ -1,10 +1,15 @@
 /*
- * Copyright (c) 2004, 2005, 2006 TADA AB - Taby Sweden
+ * Copyright (c) 2004-2019 Tada AB and other contributors, as listed below.
  * Copyright (c) 2010, 2011 PostgreSQL Global Development Group
  *
- * Distributed under the terms shown in the file COPYRIGHT
- * found in the root directory of this distribution or at
- * http://wiki.tada.se/index.php?title=PLJava_License
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Tada AB
+ *   Chapman Flack
  */
 package org.postgresql.pljava.jdbc;
 
@@ -75,7 +80,7 @@ public class SQLOutputToTuple implements SQLOutput
 
 	public void writeArray(Array value) throws SQLException
 	{
-		this.writeValue(value);
+		writeValue(value);
 	}
 
 	public void writeAsciiStream(InputStream value) throws SQLException
@@ -83,7 +88,7 @@ public class SQLOutputToTuple implements SQLOutput
 		try
 		{
 			Reader rdr = new BufferedReader(new InputStreamReader(value, "US-ASCII"));
-			this.writeClob(new ClobValue(rdr, ClobValue.getReaderLength(rdr)));
+			writeClob(new ClobValue(rdr, ClobValue.getReaderLength(rdr)));
 		}
 		catch(UnsupportedEncodingException e)
 		{
@@ -93,111 +98,111 @@ public class SQLOutputToTuple implements SQLOutput
 
 	public void writeBigDecimal(BigDecimal value) throws SQLException
 	{
-		this.writeValue(value);
+		writeValue(value);
 	}
 
 	public void writeBinaryStream(InputStream value) throws SQLException
 	{
 		if(!value.markSupported())
 			value = new BufferedInputStream(value);
-		this.writeBlob(new BlobValue(value, BlobValue.getStreamLength(value)));
+		writeBlob(new BlobValue(value, BlobValue.getStreamLength(value)));
 	}
 
 	public void writeBlob(Blob value) throws SQLException
 	{
-		this.writeValue(value);
+		writeValue(value);
 	}
 
 	public void writeBoolean(boolean value) throws SQLException
 	{
-		this.writeValue(value ? Boolean.TRUE : Boolean.FALSE);
+		writeValue(value);
 	}
 
 	public void writeByte(byte value) throws SQLException
 	{
-		this.writeValue(new Byte(value));
+		writeValue(value);
 	}
 
 	public void writeBytes(byte[] value) throws SQLException
 	{
-		this.writeValue(value);
+		writeValue(value);
 	}
 
 	public void writeCharacterStream(Reader value) throws SQLException
 	{
 		if(!value.markSupported())
 			value = new BufferedReader(value);
-		this.writeClob(new ClobValue(value, ClobValue.getReaderLength(value)));
+		writeClob(new ClobValue(value, ClobValue.getReaderLength(value)));
 	}
 
 	public void writeClob(Clob value) throws SQLException
 	{
-		this.writeValue(value);
+		writeValue(value);
 	}
 
 	public void writeDate(Date value) throws SQLException
 	{
-		this.writeValue(value);
+		writeValue(value);
 	}
 
 	public void writeDouble(double value) throws SQLException
 	{
-		this.writeValue(new Double(value));
+		writeValue(value);
 	}
 
 	public void writeFloat(float value) throws SQLException
 	{
-		this.writeValue(new Float(value));
+		writeValue(value);
 	}
 
 	public void writeInt(int value) throws SQLException
 	{
-		this.writeValue(new Integer(value));
+		writeValue(value);
 	}
 
 	public void writeLong(long value) throws SQLException
 	{
-		this.writeValue(new Long(value));
+		writeValue(value);
 	}
 
 	public void writeObject(SQLData value) throws SQLException
 	{
-		this.writeValue(value);
+		writeValue(value);
 	}
 
 	public void writeRef(Ref value) throws SQLException
 	{
-		this.writeValue(value);
+		writeValue(value);
 	}
 
 	public void writeShort(short value) throws SQLException
 	{
-		this.writeValue(new Short(value));
+		writeValue(value);
 	}
 
 	public void writeString(String value) throws SQLException
 	{
-		this.writeValue(value);
+		writeValue(value);
 	}
 
 	public void writeStruct(Struct value) throws SQLException
 	{
-		this.writeValue(value);
+		writeValue(value);
 	}
 
 	public void writeTime(Time value) throws SQLException
 	{
-		this.writeValue(value);
+		writeValue(value);
 	}
 
 	public void writeTimestamp(Timestamp value) throws SQLException
 	{
-		this.writeValue(value);
+		writeValue(value);
 	}
 
 	public void writeURL(URL value) throws SQLException
 	{
-		this.writeValue(value.toString());
+		writeValue(value.toString());
 	}
 
 	// ************************************************************
@@ -210,7 +215,7 @@ public class SQLOutputToTuple implements SQLOutput
 	public void writeSQLXML(SQLXML x)
 		throws SQLException
 	{
-		this.writeValue(x);
+		writeValue(x);
 	}
 
 	// ************************************************************
@@ -221,7 +226,7 @@ public class SQLOutputToTuple implements SQLOutput
                 throws SQLException
 	{
 		throw new SQLFeatureNotSupportedException
-			( this.getClass()
+			( getClass()
 			  + ".writeNClob( NClob ) not implemented yet.",
 			  "0A000" );
 	}
@@ -230,7 +235,7 @@ public class SQLOutputToTuple implements SQLOutput
 		throws SQLException
 		{
 		throw new SQLFeatureNotSupportedException
-			( this.getClass()
+			( getClass()
 			  + ".writeNString( String ) not implemented yet.",
 		  "0A000" );
 		}
@@ -239,7 +244,7 @@ public class SQLOutputToTuple implements SQLOutput
                 throws SQLException
 	{
 		throw new SQLFeatureNotSupportedException
-			( this.getClass()
+			( getClass()
 			  + ".writeRowId( RowId ) not implemented yet.",
 			  "0A000" );
 	}

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/SingleRowWriter.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/SingleRowWriter.java
@@ -95,14 +95,14 @@ public class SingleRowWriter extends SingleRowResultSet
 		&& !(c == byte[].class && (x instanceof BlobValue)))
 		{
 			if(Number.class.isAssignableFrom(c))
-				x = SPIConnection.basicNumericCoersion(c, x);
+				x = SPIConnection.basicNumericCoercion(c, x);
 			else
 			if(Time.class.isAssignableFrom(c)
 			|| Date.class.isAssignableFrom(c)
 			|| Timestamp.class.isAssignableFrom(c))
-				x = SPIConnection.basicCalendricalCoersion(c, x, Calendar.getInstance());
+				x = SPIConnection.basicCalendricalCoercion(c, x, Calendar.getInstance());
 			else
-				x = SPIConnection.basicCoersion(c, x);
+				x = SPIConnection.basicCoercion(c, x);
 		}
 		m_values[columnIndex-1] = null == xAlt ? x : xAlt;
 	}

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/SyntheticResultSet.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/SyntheticResultSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2018 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2019 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -27,9 +27,9 @@ import java.util.HashMap;
  */
 public class SyntheticResultSet extends ResultSetBase
 {
-	private final ResultSetField[] m_fields;
-	private final ArrayList        m_tuples;
-    private final HashMap          m_fieldIndexes;
+	private final ResultSetField[]        m_fields;
+	private final ArrayList<Object[]>     m_tuples;
+	private final HashMap<String,Integer> m_fieldIndexes;
 
 	/**
 	 * Construct a {@code SyntheticResultSet} whose column types are described
@@ -41,7 +41,7 @@ public class SyntheticResultSet extends ResultSetBase
 	 * {@link ResultSetField#canContain canContain} method of the
 	 * {@code ResultSetField} instance at index <em>j</em>.
 	 */
-	SyntheticResultSet(ResultSetField[] fields, ArrayList tuples)
+	SyntheticResultSet(ResultSetField[] fields, ArrayList<Object[]> tuples)
 	throws SQLException
 	{
 		super(tuples.size());
@@ -50,7 +50,7 @@ public class SyntheticResultSet extends ResultSetBase
         m_fieldIndexes = new HashMap();
         int i = m_fields.length;
         while(--i >= 0)
-            m_fieldIndexes.put(m_fields[i].getColumnLabel(), new Integer(i+1));
+            m_fieldIndexes.put(m_fields[i].getColumnLabel(), i+1);
 
 		Object[][] tupleTest = (Object[][]) m_tuples.toArray(new Object[0][]);
 		Object value;
@@ -84,10 +84,10 @@ public class SyntheticResultSet extends ResultSetBase
 	public int findColumn(String columnName)
 	throws SQLException
 	{
-        Integer idx = (Integer)m_fieldIndexes.get(columnName.toUpperCase());
+        Integer idx = m_fieldIndexes.get(columnName.toUpperCase());
         if(idx != null)
         {
-            return idx.intValue();
+            return idx;
         }
         throw new SQLException("No such field: '" + columnName + "'");
 	}
@@ -112,7 +112,7 @@ public class SyntheticResultSet extends ResultSetBase
     	int row = this.getRow();
 		if(row < 1 || row > m_tuples.size())
 			throw new SQLException("ResultSet is not positioned on a valid row");
-		return (Object[])m_tuples.get(row-1);
+		return m_tuples.get(row-1);
 	}
 
 	@Override

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/TriggerResultSet.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/TriggerResultSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2018 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2019 Tada AB and other contributors, as listed below.
  * Copyright (c) 2010, 2011 PostgreSQL Global Development Group
  *
  * All rights reserved. This program and the accompanying materials
@@ -94,7 +94,7 @@ public class TriggerResultSet extends SingleRowResultSet
 		if(m_tupleChanges == null)
 			m_tupleChanges = new ArrayList();
 
-		m_tupleChanges.add(new Integer(columnIndex));
+		m_tupleChanges.add(columnIndex);
 		m_tupleChanges.add(x);
 	}
 

--- a/pljava/src/main/java/org/postgresql/pljava/management/Commands.java
+++ b/pljava/src/main/java/org/postgresql/pljava/management/Commands.java
@@ -821,13 +821,13 @@ public class Commands
 		}
 
 		PreparedStatement stmt;
-		ArrayList entries = null;
+		ArrayList<Integer> entries = null;
 		if(path != null && path.length() > 0)
 		{
 			// Collect and verify that all entries in the path represents a
 			// valid jar
 			//
-			entries = new ArrayList();
+			entries = new ArrayList<Integer>();
 			stmt = SQLUtils.getDefaultConnection().prepareStatement(
 				"SELECT jarId FROM sqlj.jar_repository " +
 				"WHERE jarName OPERATOR(pg_catalog.=) ?");
@@ -850,7 +850,7 @@ public class Commands
 						throw new SQLNonTransientException(
 							"No such jar: " + jarName, "46102");
 
-					entries.add(new Integer(jarId));
+					entries.add(jarId);
 					if(colon < 0)
 						break;
 				}
@@ -889,7 +889,7 @@ public class Commands
 				int top = entries.size();
 				for(int idx = 0; idx < top; ++idx)
 				{
-					int jarId = ((Integer)entries.get(idx)).intValue();
+					int jarId = entries.get(idx);
 					stmt.setString(1, schemaName);
 					stmt.setInt(2, idx + 1);
 					stmt.setInt(3, jarId);

--- a/pljava/src/main/java/org/postgresql/pljava/sqlj/Loader.java
+++ b/pljava/src/main/java/org/postgresql/pljava/sqlj/Loader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2018 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2019 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -95,9 +95,11 @@ public class Loader extends ClassLoader
 	}
 	private static final String PUBLIC_SCHEMA = "public";
 
-	private static final Map s_schemaLoaders = new HashMap();
+	private static final Map<String,ClassLoader>
+		s_schemaLoaders = new HashMap<String,ClassLoader>();
 
-	private static final Map s_typeMap = new HashMap();
+	private static final Map<String,Map<Oid,Class<? extends SQLData>>>
+		s_typeMap = new HashMap<String,Map<Oid,Class<? extends SQLData>>>();
 
 	/**
 	 * Removes all cached schema loaders, functions, and type maps. This
@@ -154,7 +156,7 @@ public class Loader extends ClassLoader
 		else
 			schemaName = schemaName.toLowerCase();
 
-		ClassLoader loader = (ClassLoader)s_schemaLoaders.get(schemaName);
+		ClassLoader loader = s_schemaLoaders.get(schemaName);
 		if(loader != null)
 			return loader;
 
@@ -249,9 +251,12 @@ public class Loader extends ClassLoader
 	 * @param schema The schema
 	 * @return The Map, possibly empty but never <code>null</code>.
 	 */
-	public static Map getTypeMap(final String schema) throws SQLException
+	public static Map<Oid,Class<? extends SQLData>> getTypeMap(
+		final String schema)
+		throws SQLException
 	{
-		Map typesForSchema = (Map)s_typeMap.get(schema);
+		Map<Oid,Class<? extends SQLData>> typesForSchema =
+			s_typeMap.get(schema);
 		if(typesForSchema != null)
 			return typesForSchema;
 
@@ -282,7 +287,7 @@ public class Loader extends ClassLoader
 						throw new SQLException("Class " + javaClassName + " does not implement java.sql.SQLData");
 					
 					Oid typeOid = Oid.forTypeName(sqlName);
-					typesForSchema.put(typeOid, cls);
+					typesForSchema.put(typeOid, cls.asSubclass(SQLData.class));
 					s_logger.finer("Adding type mapping for OID " + typeOid + " -> class " + cls.getName() + " for schema " + schema);
 				}
 				catch(ClassNotFoundException e)


### PR DESCRIPTION
A solid, if non-exhaustive, effort to bring the code up to date with
Java generics and transparent boxing/unboxing, based on a simplistic
mechanical search for places where unnecessary explicit casting/boxing/
unboxing was being done.

In the files touched, also elide a bunch of 'this.' qualifications on
instance method calls. And fix the spelling of 'Coercion' in three methods.

Bonus: fix three very old thinkos in SPIPreparedStatement that no one
ever seems to have run into or reported.