### PR TITLE
Allow 1.5 series to build with Java 9 and later

### DIFF
--- a/pljava-so/build.xml
+++ b/pljava-so/build.xml
@@ -80,7 +80,9 @@
 			</filterchain>
 		</loadresource>
 
-		<script language="javascript"><![CDATA[
+		<script
+			language="javascript"
+			classpathref="maven.plugin.classpath"><![CDATA[
 			var msvc_version = parseInt(project.getProperty('MSVC_VER'));
 			var knows_rint = project.getProperty('KNOWS_MSVC_RINT');
 			if (msvc_version >= 1800  && knows_rint === null) {

--- a/pljava-so/pom.xml
+++ b/pljava-so/pom.xml
@@ -301,7 +301,9 @@
 						</goals>
 						<configuration>
 							<target>
-								<script language='javascript'>
+								<script
+									language='javascript'
+									classpathref='maven.plugin.classpath'>
 <![CDATA[
 /* This regex supports a function to wrap a string in the quoting needed for a
    C string literal. Capturing group 1 captures those special characters that
@@ -380,7 +382,9 @@ if ( null !== jvmdflt )
 
 								<!-- Converts pg_config output
 									 to "pgsql.properties" -->
-								<ant />
+								<ant>
+									<reference refid='maven.plugin.classpath'/>
+								</ant>
 							</target>
 						</configuration>
 					</execution>

--- a/pljava-so/pom.xml
+++ b/pljava-so/pom.xml
@@ -323,6 +323,9 @@
 									<includePath>${basedir}/src/main/include/fallback/jdbc</includePath>
 								</includePaths>
 							</c>
+							<java>
+								<include>true</include>
+							</java>
 						</configuration>
 					</plugin>
 				</plugins>

--- a/pljava-so/pom.xml
+++ b/pljava-so/pom.xml
@@ -272,6 +272,62 @@
 				<pgsql.pgconfig>pg_config</pgsql.pgconfig>
 			</properties>
 		</profile>
+
+		<profile>
+			<id>hasjavah</id>
+			<activation>
+				<jdk>[1.6,10)</jdk>
+			</activation>
+			<properties>
+				<javah.include>${basedir}/target/nar/javah-include/</javah.include>
+			</properties>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>com.github.maven-nar</groupId>
+						<artifactId>nar-maven-plugin</artifactId>
+						<configuration>
+							<!-- Generates C header files from Java class files. -->
+							<javah>
+								<classPaths>
+									<classPath>${basedir}/../pljava/target/classes/</classPath>
+									<classPath>${basedir}/../pljava-api/target/classes/</classPath>
+								</classPaths>
+								<classDirectory>${basedir}/../pljava/target/classes/</classDirectory>
+								<extraClasses>
+									<extraClass>java.sql.Types</extraClass>
+								</extraClasses>
+							</javah>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+
+		<profile>
+			<id>lacksjavah</id>
+			<activation>
+				<jdk>[10,)</jdk>
+			</activation>
+			<properties>
+				<javah.include>${basedir}/../pljava/target/javah-include/</javah.include>
+			</properties>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>com.github.maven-nar</groupId>
+						<artifactId>nar-maven-plugin</artifactId>
+						<configuration>
+							<c>
+								<includePaths combine.children='append'>
+									<includePath>${basedir}/src/main/include/fallback/jdbc</includePath>
+								</includePaths>
+							</c>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
 	</profiles>
 
 	<build>
@@ -423,17 +479,6 @@ if ( null !== jvmdflt )
 
 				<configuration>
 					<maxCores>${nar.cores}</maxCores>
-					<!-- Generates C header files from Java class files. -->
-					<javah>
-						<classPaths>
-							<classPath>${basedir}/../pljava/target/classes/</classPath>
-							<classPath>${basedir}/../pljava-api/target/classes/</classPath>
-						</classPaths>
-						<classDirectory>${basedir}/../pljava/target/classes/</classDirectory>
-						<extraClasses>
-							<extraClass>java.sql.Types</extraClass>
-						</extraClasses>
-					</javah>
 
 					<!-- Compiles the C sources to object files. -->
 					<c>
@@ -448,7 +493,7 @@ if ( null !== jvmdflt )
 							<includePath>${PGSQL_INCLUDEDIR}</includePath>
 							<includePath>${PGSQL_INCLUDEDIR-SERVER}</includePath>
 							<includePath>${basedir}/src/main/include/</includePath>
-							<includePath>${basedir}/target/nar/javah-include/</includePath>
+							<includePath>${javah.include}</includePath>
 						</includePaths>
 						<debug>${so.debug}</debug>
 						<optimize>${so.optimize}</optimize>

--- a/pljava-so/src/main/include/fallback/jdbc/java_sql_Types.h
+++ b/pljava-so/src/main/include/fallback/jdbc/java_sql_Types.h
@@ -1,0 +1,101 @@
+/*
+ * FALLBACK COPY of machine-generated file from Java 8.
+ * This file can be generated from the java.sql.Types class using the javah
+ * utility present in JDK versions through 9. Java 10 eliminates the javah
+ * utility, in favor of the -h option to javac, leaving no way to h a class,
+ * like java.sql.Types, for which the source is not present. Hence, when
+ * building on Java 10 or later, this fallback file will be used. As of Java 12,
+ * there have been no changes to these constants since Java 8, and this file is
+ * only needed by one PL/Java source file (type/Oid.c) that will probably go
+ * away soon. Therefore, no more elaborate workaround seems necessary.
+ */
+#include <jni.h>
+/* Header for class java_sql_Types */
+
+#ifndef _Included_java_sql_Types
+#define _Included_java_sql_Types
+#ifdef __cplusplus
+extern "C" {
+#endif
+#undef java_sql_Types_BIT
+#define java_sql_Types_BIT -7L
+#undef java_sql_Types_TINYINT
+#define java_sql_Types_TINYINT -6L
+#undef java_sql_Types_SMALLINT
+#define java_sql_Types_SMALLINT 5L
+#undef java_sql_Types_INTEGER
+#define java_sql_Types_INTEGER 4L
+#undef java_sql_Types_BIGINT
+#define java_sql_Types_BIGINT -5L
+#undef java_sql_Types_FLOAT
+#define java_sql_Types_FLOAT 6L
+#undef java_sql_Types_REAL
+#define java_sql_Types_REAL 7L
+#undef java_sql_Types_DOUBLE
+#define java_sql_Types_DOUBLE 8L
+#undef java_sql_Types_NUMERIC
+#define java_sql_Types_NUMERIC 2L
+#undef java_sql_Types_DECIMAL
+#define java_sql_Types_DECIMAL 3L
+#undef java_sql_Types_CHAR
+#define java_sql_Types_CHAR 1L
+#undef java_sql_Types_VARCHAR
+#define java_sql_Types_VARCHAR 12L
+#undef java_sql_Types_LONGVARCHAR
+#define java_sql_Types_LONGVARCHAR -1L
+#undef java_sql_Types_DATE
+#define java_sql_Types_DATE 91L
+#undef java_sql_Types_TIME
+#define java_sql_Types_TIME 92L
+#undef java_sql_Types_TIMESTAMP
+#define java_sql_Types_TIMESTAMP 93L
+#undef java_sql_Types_BINARY
+#define java_sql_Types_BINARY -2L
+#undef java_sql_Types_VARBINARY
+#define java_sql_Types_VARBINARY -3L
+#undef java_sql_Types_LONGVARBINARY
+#define java_sql_Types_LONGVARBINARY -4L
+#undef java_sql_Types_NULL
+#define java_sql_Types_NULL 0L
+#undef java_sql_Types_OTHER
+#define java_sql_Types_OTHER 1111L
+#undef java_sql_Types_JAVA_OBJECT
+#define java_sql_Types_JAVA_OBJECT 2000L
+#undef java_sql_Types_DISTINCT
+#define java_sql_Types_DISTINCT 2001L
+#undef java_sql_Types_STRUCT
+#define java_sql_Types_STRUCT 2002L
+#undef java_sql_Types_ARRAY
+#define java_sql_Types_ARRAY 2003L
+#undef java_sql_Types_BLOB
+#define java_sql_Types_BLOB 2004L
+#undef java_sql_Types_CLOB
+#define java_sql_Types_CLOB 2005L
+#undef java_sql_Types_REF
+#define java_sql_Types_REF 2006L
+#undef java_sql_Types_DATALINK
+#define java_sql_Types_DATALINK 70L
+#undef java_sql_Types_BOOLEAN
+#define java_sql_Types_BOOLEAN 16L
+#undef java_sql_Types_ROWID
+#define java_sql_Types_ROWID -8L
+#undef java_sql_Types_NCHAR
+#define java_sql_Types_NCHAR -15L
+#undef java_sql_Types_NVARCHAR
+#define java_sql_Types_NVARCHAR -9L
+#undef java_sql_Types_LONGNVARCHAR
+#define java_sql_Types_LONGNVARCHAR -16L
+#undef java_sql_Types_NCLOB
+#define java_sql_Types_NCLOB 2011L
+#undef java_sql_Types_SQLXML
+#define java_sql_Types_SQLXML 2009L
+#undef java_sql_Types_REF_CURSOR
+#define java_sql_Types_REF_CURSOR 2012L
+#undef java_sql_Types_TIME_WITH_TIMEZONE
+#define java_sql_Types_TIME_WITH_TIMEZONE 2013L
+#undef java_sql_Types_TIMESTAMP_WITH_TIMEZONE
+#define java_sql_Types_TIMESTAMP_WITH_TIMEZONE 2014L
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/pljava/pom.xml
+++ b/pljava/pom.xml
@@ -16,6 +16,29 @@
 			<version>${project.version}</version>
 		</dependency>
 	</dependencies>
+
+	<profiles>
+		<profile>
+			<id>usejavac-h</id>
+			<activation>
+				<jdk>[10,)</jdk>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-compiler-plugin</artifactId>
+						<configuration>
+							<compilerArguments>
+								<h>${basedir}/target/javah-include</h>
+							</compilerArguments>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
+
 	<build>
 		<plugins>
 			<plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -90,9 +90,6 @@
 					<source>1.6</source>
 					<target>1.6</target>
 					<encoding>${project.build.sourceEncoding}</encoding>
-					<compilerArguments>
-						<bootclasspath>${env.JAVA_HOME}/jre/lib/rt.jar</bootclasspath>
-					</compilerArguments>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,45 @@
 		</site>
 	</distributionManagement>
 
+	<profiles>
+		<profile>
+			<id>srctgt6</id>
+			<activation>
+				<jdk>[1.6,12)</jdk>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-compiler-plugin</artifactId>
+						<configuration>
+							<source>1.6</source>
+							<target>1.6</target>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+		<profile>
+			<id>srctgt7</id>
+			<activation>
+				<jdk>[12,)</jdk>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-compiler-plugin</artifactId>
+						<configuration>
+							<source>7</source>
+							<target>7</target>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
+
 	<build>
 		<pluginManagement>
 			<plugins>
@@ -87,8 +126,6 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>2.5.1</version>
 				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
 					<encoding>${project.build.sourceEncoding}</encoding>
 				</configuration>
 			</plugin>

--- a/src/site/markdown/build/build.md
+++ b/src/site/markdown/build/build.md
@@ -12,6 +12,7 @@ To do that, continue with the [installation instructions][inst].
 [orjava]: http://www.oracle.com/technetwork/java/javase/downloads/index.html
 [OpenJDK]: https://adoptopenjdk.net/
 [hsj9]: https://www.eclipse.org/openj9/oj9_faq.html
+[GraalVM]: https://www.graalvm.org/downloads/
 
 **In case of build difficulties:**
 
@@ -33,14 +34,12 @@ There is a "troubleshooting the build" section at the end of this page.
 
         javac  -version
 
-    just works. [Oracle Java][orjava] or [OpenJDK][] can be used, the latter
-    with [either the Hotspot or the OpenJ9 JVM][hsj9]. It is not necessary to
-    use the same JDK to build PL/Java that will later be used to run it in the
-    database, as long as the one used for building is not newer than that used
-    at run time. In particular, because the build procedure has not been updated
-    for Java 9 and later, PL/Java requires a Java 8, 7, or 6 JDK to build, but
-    can then use a later Java version at run time, and support PL/Java
-    applications using the newer Java features.
+    just works. PL/Java can be built with [Oracle Java][orjava] or [OpenJDK][],
+    the latter with [either the Hotspot or the OpenJ9 JVM][hsj9], or with
+    [GraalVM][]. It is not necessary to use the same JDK to build PL/Java that
+    will later be used to run it in the database, and PL/Java applications can
+    generally take advantage of recent features in whatever Java version is
+    used at run time. (See more on [version compatibility](versions.html).)
 
 0. The PostgreSQL server version that you intend to use should be installed,
     and on your search path so that the command

--- a/src/site/markdown/build/versions.md
+++ b/src/site/markdown/build/versions.md
@@ -1,6 +1,6 @@
 # Versions of external packages needed to build and use PL/Java
 
-As of October 2018, the following version constraints are known.
+As of June 2019, the following version constraints are known.
 
 ## Java
 
@@ -14,10 +14,12 @@ implemented. Since Java 8, even JDBC additions have not caused problems for
 existing PL/Java code, as they have taken advantage of the default-methods
 feature introduced in that release.
 
-In the PL/Java 1.5.x series, the build system has not been reworked for
-building with Java 9 or newer. However, PL/Java can be built with Java 8
-and use a newer JVM at run time, simply by setting
-[the `pljava.libjvm_location` variable][jvml] to the newer version's library.
+In the PL/Java 1.5.x series, the build can be done with Java 6 or newer (but
+builds with 6 or 7
+[may be difficult](#Maven_failures_when_downloading_dependencies)).
+Once built, PL/Java is able to use another Java 6 or later JVM at run time,
+simply by setting
+[the `pljava.libjvm_location` variable][jvml] to the desired version's library.
 
 That allows PL/Java to run application code written for the latest Java
 versions, and also to take advantage of recent Java implementation advances
@@ -25,7 +27,13 @@ such as [class data sharing][cds].
 
 PL/Java has been successfully used with [Oracle Java][orj] and with
 [OpenJDK][], which is available with
-[either the Hotspot or the OpenJ9 JVM][hsj9].
+[either the Hotspot or the OpenJ9 JVM][hsj9]. It can also be built and used
+with [GraalVM][].
+
+As of Java 12, the Java compiler can no longer generate code targeting a Java 6
+runtime. If PL/Java is built with Java 12 or newer, it will not run with a JRE
+older than 7. If it is necessary to build a PL/Java that will run on 6, it must
+be built with 11 or earlier.
 
 ### Maven failures when downloading dependencies
 
@@ -41,6 +49,7 @@ newer protocol versions needed to reach the servers.
 [orj]: https://www.oracle.com/technetwork/java/javase/downloads/index.html
 [OpenJDK]: https://adoptopenjdk.net/
 [hsj9]: https://www.eclipse.org/openj9/oj9_faq.html
+[GraalVM]: https://www.graalvm.org/
 
 ## Maven
 


### PR DESCRIPTION
To this point, PL/Java 1.5.x has required a Java 8 (or 7, or with considerable nursing, 6) JDK to build, though it can then run on later JREs (and user code can be written to the later language standards and APIs). Java 9 introduced changes that threatened to be hard to work into the build system while preserving 1.5.x's ability to be built in the older environments. The original plan was to keep the 1.5.x build requirements unchanged, and make the next major version purely Java 9 and later (and drop some of the ancient-PG-release support as well).

But issue #212 raised the stakes, as apparently Debian distros are out now or imminently that won't have a Java 8 development kit handy for package building. So, this PR tweaks 1.5.x as minimally as possible with the aim of _allowing_ it to be built on Java 9 or later, without giving up its compatibility with older versions. The plan is still not to _require_ Java 9 until the still-work-in-progress next major version.