### PR TITLE
One line missed in finalizers refactoring

### DIFF
--- a/pljava-so/src/main/c/PgSavepoint.c
+++ b/pljava-so/src/main/c/PgSavepoint.c
@@ -162,6 +162,7 @@ Java_org_postgresql_pljava_internal_PgSavepoint__1rollback(JNIEnv* env, jclass c
 	PG_TRY();
 	{
 		unwind(RollbackAndReleaseCurrentSubTransaction, xid, nestLevel);
+		SPI_restore_connection();
 	}
 	PG_CATCH();
 	{


### PR DESCRIPTION
Only caught when tested in PG 9.6 or earlier, because the function
was already a no-op upstream since PG 10 (postgres/postgres@1833f1a).

Addresses issue #221.