### PR TITLE
Allow a parameter's SQL name to be explicit.

### DIFF
--- a/pljava-api/src/main/java/org/postgresql/pljava/annotation/SQLType.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/annotation/SQLType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2016 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2019 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -63,4 +63,18 @@ public @interface SQLType
 	// Is it worth having a defaultRaw() for rare cases wanting some
 	// arbitrary SQL expression for the default?
 	// String[] defaultRaw() default {};
+
+	/**
+	 * SQL name for the parameter, to allow calling the function using named
+	 * parameter notation, in preference to the parameter's Java name.
+	 * By default, the SQL name is taken from the Java name, but in some cases
+	 * the SQL name expected by callers may be a reserved word in Java, or the
+	 * Java name may be reserved in SQL. The name specified here can simply be
+	 * different, or it can be given in quoted-identifier form to work around
+	 * the reservedness in SQL of the unquoted name. Callers, in that case, have
+	 * to quote the name also, but that may be acceptable for clarity's sake if
+	 * there is a particular name that is used in a standard or is otherwise the
+	 * most natural choice.
+	 */
+	String name() default "";
 }

--- a/pljava-api/src/main/java/org/postgresql/pljava/sqlgen/DDRProcessor.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/sqlgen/DDRProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2016 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2019 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -1102,9 +1102,11 @@ hunt:	for ( ExecutableElement ee : ees )
 	{
 		public String value() { return _value; }
 		public String[] defaultValue() { return _defaultValue; }
+		public String name() { return _name; }
 		
 		String _value;
 		String[] _defaultValue;
+		String _name;
 		
 		public void setValue( Object o, boolean explicit, Element e)
 		{
@@ -1116,6 +1118,20 @@ hunt:	for ( ExecutableElement ee : ees )
 		{
 			if ( explicit )
 				_defaultValue = avToArray( o, String.class);
+		}
+
+		public void setName( Object o, boolean explicit, Element e)
+		{
+			if ( ! explicit )
+				return;
+
+			_name = (String)o;
+			if ( _name.startsWith( "\"")
+				&& ! Lexicals.ISO_DELIMITED_IDENTIFIER.matcher( _name).matches()
+				|| ! Lexicals.ISO_AND_PG_REGULAR_IDENTIFIER.matcher( _name)
+					.matches()
+				)
+				msg( Kind.WARNING, e, "malformed parameter name: %s", _name);
 		}
 	}
 
@@ -1463,6 +1479,7 @@ hunt:	for ( ExecutableElement ee : ees )
 		TypeMirror setofComponent = null;
 		boolean trigger = false;
 		TypeMirror returnTypeMapKey = null;
+		SQLType[] paramTypeAnnotations;
 
 		FunctionImpl(ExecutableElement e)
 		{
@@ -1579,6 +1596,8 @@ hunt:	for ( ExecutableElement ee : ees )
 					"a function with triggers needs void return and " +
 					"one TriggerData parameter");
 
+			collectParameterTypeAnnotations();
+
 			/*
 			 * Report any unmappable types now that could appear in
 			 * deployStrings (return type or parameter types) ... so that the
@@ -1593,6 +1612,34 @@ hunt:	for ( ExecutableElement ee : ees )
 			for ( Trigger t : triggers() )
 				((TriggerImpl)t).characterize();
 			return true;
+		}
+
+		/*
+		 * Factored out of characterize() so it could be called if needed by
+		 * BaseUDTFunctionImpl.characterize(), which does not need anything else
+		 * from its super.characterize(). But for now it doesn't need this
+		 * either; it knows what parameters the base UDT functions take, and it
+		 * takes no heed of @SQLType annotations. Perhaps it should warn if such
+		 * annotations are used, but that's for another day.
+		 */
+		void collectParameterTypeAnnotations()
+		{
+			List<? extends VariableElement> ves = func.getParameters();
+			paramTypeAnnotations = new SQLType [ ves.size() ];
+			int i = 0;
+			for ( VariableElement ve : ves )
+			{
+				for ( AnnotationMirror am : elmu.getAllAnnotationMirrors( ve) )
+				{
+					if ( am.getAnnotationType().asElement().equals(AN_SQLTYPE) )
+					{
+						SQLTypeImpl sti = new SQLTypeImpl();
+						populateAnnotationImpl( sti, ve, am);
+						paramTypeAnnotations[i] = sti;
+					}
+				}
+				++ i;
+			}
 		}
 
 		/**
@@ -1623,13 +1670,24 @@ hunt:	for ( ExecutableElement ee : ees )
 				if ( complexViaInOut )
 					tms = tms.subList( 0, tms.size() - 1);
 				int s = tms.size();
+				int i = 0;
 				for ( TypeMirror tm : tms )
 				{
 					VariableElement ve = ves.next();
-					sb.append( "\n\t").append( ve.getSimpleName().toString());
+					/*
+					 * paramTypeAnnotations can be null if
+					 * collectParameterTypeAnnotations hasn't been called.
+					 * That's the case in BaseUDTFunctionImpl, but it also
+					 * overrides this method, so it isn't a problem.
+					 */
+					SQLType st = paramTypeAnnotations[i];
+					String name = null == st ? null : st.name();
+					if ( null == name )
+						name = ve.getSimpleName().toString();
+					sb.append( "\n\t").append( name);
 					sb.append( ' ');
-					sb.append( tmpr.getSQLType( tm, ve, true, dflts));
-					if ( 0 < -- s )
+					sb.append( tmpr.getSQLType( tm, ve, st, true, dflts));
+					if ( ++ i < s )
 						sb.append( ',');
 				}
 			}
@@ -2513,7 +2571,7 @@ hunt:	for ( ExecutableElement ee : ees )
 		 */
 		String getSQLType(TypeMirror tm, Element e)
 		{
-			return getSQLType( tm, e, false, false);
+			return getSQLType( tm, e, null, false, false);
 		}
 
 
@@ -2525,6 +2583,8 @@ hunt:	for ( ExecutableElement ee : ees )
 		 * @param tm Represents the type whose corresponding SQL type is wanted.
 		 * @param e Annotated element (chiefly for use as a location hint in
 		 * diagnostic messages).
+		 * @param st {@code SQLType} annotation, or null if none, explicitly
+		 * given for the element.
 		 * @param contravariant Indicates that the element whose type is wanted
 		 * is a function parameter and should be given the widest type that can
 		 * be assigned to it. If false, find the narrowest type that a function
@@ -2532,7 +2592,7 @@ hunt:	for ( ExecutableElement ee : ees )
 		 * @param withDefault Indicates whether any specified default value
 		 * information should also be included in the "type" string returned.
 		 */
-		String getSQLType(TypeMirror tm, Element e,
+		String getSQLType(TypeMirror tm, Element e, SQLType st,
 			boolean contravariant, boolean withDefault)
 		{
 			boolean array = false;
@@ -2541,15 +2601,10 @@ hunt:	for ( ExecutableElement ee : ees )
 			
 			String[] defaults = null;
 			
-			for ( AnnotationMirror am : elmu.getAllAnnotationMirrors( e) )
+			if ( null != st )
 			{
-				if ( am.getAnnotationType().asElement().equals( AN_SQLTYPE) )
-				{
-					SQLTypeImpl sti = new SQLTypeImpl();
-					populateAnnotationImpl( sti, e, am);
-					rslt = sti.value();
-					defaults = sti.defaultValue();
-				}
+				rslt = st.value();
+				defaults = st.defaultValue();
 			}
 
 			if ( tm.getKind().equals( TypeKind.ARRAY) )

--- a/pljava-api/src/main/java/org/postgresql/pljava/sqlgen/Lexicals.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/sqlgen/Lexicals.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015- Tada AB and other contributors, as listed below.
+ * Copyright (c) 2015-2019 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -55,6 +55,13 @@ public interface Lexicals {
 	Pattern ISO_REGULAR_IDENTIFIER_CAPTURING = Pattern.compile(String.format(
 		"(%1$s)", ISO_REGULAR_IDENTIFIER.pattern()
 	));
+
+	/** A complete delimited identifier as allowed by ISO. As it happens, this
+	 * is also the form PostgreSQL uses for elements of a LIST_QUOTE-typed GUC.
+	 */
+	public static final Pattern ISO_DELIMITED_IDENTIFIER = Pattern.compile(
+		"\"(?:[^\"]|\"\"){1,128}+\""
+	);
 
 	/** Allowed as the first character of a regular identifier by PostgreSQL
 	 * (PG 7.4 -).


### PR DESCRIPTION
The SQL generator has been emitting `CREATE FUNCTION` with parameter
names that match the Java names of the function parameters, so that
the SQL functions can be called with named-parameter notation.

But there can be cases when a different SQL name is wanted for the
parameter, whether because the Java name happens to be a reserved
SQL word, or because a particular SQL parameter name is wanted (comes
from a standard, maybe?) and happens to be a reserved Java word,
or just because.

Further overload the per-parameter `@SQLType` annotation (which is
already a little overloaded and misnamed, being able to supply
default values as well as type information) with a `name` property,
which can be a regular identifier or a delimited one (in case a
parameter name is really wanted with the same spelling as an SQL
reserved word).

Copy in the `ISO_DELIMITED_IDENTIFIER` regex from the master branch,
to allow checking that ... nothing else is really checked that
carefully yet, but everything has to start somewhere.