### PR TITLE
Accept SQLXML objects from other JDBC drivers

### DIFF
--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/PassXML.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/PassXML.java
@@ -606,6 +606,19 @@ public class PassXML implements SQLData
 				 * included in OpenJDK doesn't implement the case where the
 				 * Source argument is a StAXSource! Two lines would do it.
 				 */
+				/*
+				 * Because of a regression in Java 9 and later, the line below,
+				 * while working in Java 8 and earlier, will produce a
+				 * ClassCastException in Java 9 through (for sure) 12, (almost
+				 * certainly) 13, and on until some future version fixes the
+				 * regression, if ever, if 'str' wraps any XMLStreamWriter
+				 * implementation other than the inaccessible one from the guts
+				 * of the JDK itself. The bug has been reported but (as of this
+				 * writing) is still in the maddening limbo phase of the Java
+				 * bug reporting cycle, where no bug number can refer to it. See
+				 * lowLevelXMLEcho() above for code to do this copy successfully
+				 * using an Adjusting.XML.SourceResult.
+				 */
 				XMLEventWriter xew = xof.createXMLEventWriter(str);
 				xew.add(xer);
 				xew.close();

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/PassXML.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/PassXML.java
@@ -424,6 +424,15 @@ public class PassXML implements SQLData
 					xr = XMLReaderFactory.createXMLReader();
 					xr.setFeature("http://xml.org/sax/features/namespaces",
 									true);
+					/*
+					 * Important: before copying this example code for another
+					 * use, consider whether the input XML might be untrusted.
+					 * If so, the new XMLReader created here should have several
+					 * features given safe default settings as outlined in the
+					 * OWASP guidelines. (This branch is not reached when sx is
+					 * a PL/Java native SQLXML instance, as xr will be non-null
+					 * and already configured.)
+					 */
 				}
 				ContentHandler ch = sxr.getHandler();
 				xr.setContentHandler(ch);
@@ -440,8 +449,6 @@ public class PassXML implements SQLData
 			case 6:
 				StAXSource sts = sx.getSource(StAXSource.class);
 				StAXResult str = rx.setResult(StAXResult.class);
-				XMLInputFactory  xif = XMLInputFactory .newFactory();
-				xif.setProperty(xif.IS_NAMESPACE_AWARE, true);
 				XMLOutputFactory xof = XMLOutputFactory.newFactory();
 				/*
 				 * The Source has either an event reader or a stream reader. Use
@@ -450,7 +457,20 @@ public class PassXML implements SQLData
 				 */
 				XMLEventReader xer = sts.getXMLEventReader();
 				if ( null == xer )
+				{
+					XMLInputFactory  xif = XMLInputFactory .newFactory();
+					xif.setProperty(xif.IS_NAMESPACE_AWARE, true);
+					/*
+					 * Important: before copying this example code for another
+					 * use, consider whether the input XML might be untrusted.
+					 * If so, the new XMLInputFactory created here should have
+					 * several properties given safe default settings as
+					 * outlined in the OWASP guidelines. (This branch is not
+					 * reached when sx is a PL/Java native SQLXML instance, as
+					 * xer will be non-null and already configured.)
+					 */
 					xer = xif.createXMLEventReader(sts.getXMLStreamReader());
+				}
 				/*
 				 * Were you thinking the above could be simply
 				 * createXMLEventReader(sts) by analogy with the writer below?

--- a/pljava-so/src/main/c/type/SQLXMLImpl.c
+++ b/pljava-so/src/main/c/type/SQLXMLImpl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2018-2019 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -62,8 +62,8 @@ static jvalue _SQLXML_coerceDatum(Type self, Datum arg)
 
 static Datum _SQLXML_coerceObject(Type self, jobject sqlxml)
 {
-	jobject vw = JNI_callObjectMethodLocked(
-		sqlxml, s_SQLXML_adopt, Type_getOid(self));
+	jobject vw = JNI_callStaticObjectMethodLocked(
+		s_SQLXML_class, s_SQLXML_adopt, sqlxml, Type_getOid(self));
 	Datum d = pljava_VarlenaWrapper_adopt(vw);
 	JNI_deleteLocalRef(vw);
 #if PG_VERSION_NUM >= 90500
@@ -151,8 +151,8 @@ void pljava_SQLXMLImpl_initialize(void)
 
 	s_SQLXML_class = JNI_newGlobalRef(PgObject_getJavaClass(
 		"org/postgresql/pljava/jdbc/SQLXMLImpl"));
-	s_SQLXML_adopt = PgObject_getJavaMethod(s_SQLXML_class,
-		"adopt", "(I)Lorg/postgresql/pljava/internal/VarlenaWrapper;");
+	s_SQLXML_adopt = PgObject_getStaticJavaMethod(s_SQLXML_class, "adopt",
+		"(Ljava/sql/SQLXML;I)Lorg/postgresql/pljava/internal/VarlenaWrapper;");
 
 	s_SQLXML_Readable_class = JNI_newGlobalRef(PgObject_getJavaClass(
 		"org/postgresql/pljava/jdbc/SQLXMLImpl$Readable"));

--- a/pljava/src/main/java/org/postgresql/pljava/internal/MarkableSequenceReader.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/MarkableSequenceReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2019 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2019 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -11,8 +11,7 @@
  */
 package org.postgresql.pljava.internal;
 
-import java.io.InputStream;
-import java.io.SequenceInputStream;
+import java.io.Reader;
 import java.io.IOException;
 
 import java.lang.reflect.UndeclaredThrowableException;
@@ -21,88 +20,57 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.ListIterator;
 
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.CancellationException;
-
 /**
- * Version of {@link SequenceInputStream} that supports
- * {@code mark} and {@code reset}, to the extent its constituent input streams
- * do.
+ * Like a {@link MarkableSequenceInputStream} but for characters.
  *<p>
  * This class implements {@code mark} and {@code reset} by calling the
- * corresponding methods on the underlying streams; it does not add buffering
+ * corresponding methods on the underlying readers; it does not add buffering
  * or have any means of providing {@code mark} and {@code reset} support if
- * the underlying streams do not.
+ * the underlying readers do not.
  *<p>
- * As with {@code SequenceInputStream}, each underlying stream, when completely
+ * As with {@code SequenceInputStream}, each underlying reader, when completely
  * read and no longer needed, is closed to free resources. This instance itself
  * will remain in "open at EOF" condition until explicitly closed, but does not
- * prevent reclamation of the underlying streams.
+ * prevent reclamation of the underlying readers.
  *<p>
- * Unlike {@code SequenceInputStream}, this class can keep underlying streams
+ * Unlike {@code SequenceInputStream}, this class can keep underlying readers
  * open, after fully reading them, if a {@code mark} has been set, so that
  * {@code reset} will be possible. When a mark is no longer needed, it can be
  * canceled (by calling {@code mark} with a {@code readlimit} of 0) to again
- * allow the underlying streams to be reclaimed as soon as possible.
+ * allow the underlying readers to be reclaimed as soon as possible.
  */
-public class MarkableSequenceInputStream extends InputStream
+public class MarkableSequenceReader extends Reader
 {
-	/**
-	 * A sentinel value, needed because a {@code BlockingQueue} does not allow
-	 * a null value to be enqueued.
-	 */
-	public static final InputStream NO_MORE = new InputStream()
-	{
-		@Override public int read() { return -1; }
-	};
-
 	private boolean m_closed = false;
-	private InputStream m_markedStream = null;
+	private Reader m_markedStream = null;
 
-	private ListIterator<InputStream> m_streams;
+	private ListIterator<Reader> m_streams;
 	private int m_readlimit_orig;
 	private int m_readlimit_curr;
 	private boolean m_markSupported;
 	private boolean m_markSupported_determined;
 
 	/**
-	 * Create a {@code MarkableSequenceInputStream} from one or more existing
-	 * input streams.
-	 * @param streams Sequence of {@code InputStream}s that will be read from
+	 * Create a {@code MarkableSequenceReader} from one or more existing
+	 * readers.
+	 * @param streams Sequence of {@code Reader}s that will be read from
 	 * in order.
 	 * @throws NullPointerException if {@code streams} is {@code null}, or
 	 * contains {@code null} for any stream.
 	 */
-	public MarkableSequenceInputStream(InputStream... streams)
+	public MarkableSequenceReader(Reader... streams)
 	{
 		if ( null == streams )
-			throw new NullPointerException("MarkableSequenceInputStream(null)");
-		LinkedList<InputStream> isl = new LinkedList<InputStream>();
-		for ( InputStream s : streams )
+			throw new NullPointerException("MarkableSequenceReader(null)");
+		LinkedList<Reader> isl = new LinkedList<Reader>();
+		for ( Reader s : streams )
 		{
 			if ( null == s )
 				throw new NullPointerException(
-					"MarkableSequenceInputStream(..., null, ...)");
+					"MarkableSequenceReader(..., null, ...)");
 			isl.add(s);
 		}
 		m_streams =  isl.listIterator();
-	}
-
-	/**
-	 * A {@code MarkableSequenceInputStream} that will receive streams to read,
-	 * in order, over a {@code BlockingQueue}.
-	 *<p>
-	 * The thread supplying the queue should enqueue the value {@link #NO_MORE}
-	 * following the last actual {@code InputStream} to read. (The sentinel is
-	 * needed because a {@code BlockingQueue} does not allow null values.)
-	 * @param queue Source of input streams to read.
-	 * @throws NullPointerException if {@code queue} is {@code null}.
-	 */
-	public MarkableSequenceInputStream(BlockingQueue<InputStream> queue)
-	{
-		m_streams =
-			new FetchingListIterator(
-				new LinkedList<InputStream>(), queue, NO_MORE);
 	}
 
 	/*
@@ -111,10 +79,10 @@ public class MarkableSequenceInputStream extends InputStream
 	 * is responsible for preserving that invariant by calling previous() once
 	 * after obtaining, but not hitting EOF on, a stream from next().
 	 */
-	private InputStream currentStream() throws IOException
+	private Reader currentStream() throws IOException
 	{
 		if ( m_closed )
-			throw new IOException("I/O on closed InputStream");
+			throw new IOException("I/O on closed Reader");
 		if ( m_streams.hasNext() )
 			return m_streams.next();
 		return null;
@@ -125,7 +93,7 @@ public class MarkableSequenceInputStream extends InputStream
 	 * can be re-obtained with previous(). This should not be called unless
 	 * there is nothing left to read from that stream.
 	 */
-	private InputStream nextStream() throws IOException
+	private Reader nextStream() throws IOException
 	{
 		if ( null == m_markedStream )
 		{
@@ -137,14 +105,14 @@ public class MarkableSequenceInputStream extends InputStream
 		}
 		else if ( m_streams.hasNext() )
 		{
-			InputStream is = m_streams.next();
+			Reader is = m_streams.next();
 			is.mark(m_readlimit_curr);
 			return is;
 		}
 		return null;
 	}
 
-	private void decrementLimit(long bytes)
+	private void decrementLimit(long bytes) throws IOException
 	{
 		assert 0 < bytes;
 		if ( null == m_markedStream )
@@ -162,7 +130,7 @@ public class MarkableSequenceInputStream extends InputStream
 	{
 		synchronized ( this )
 		{
-			for ( InputStream s = currentStream(); null != s; s = nextStream() )
+			for ( Reader s = currentStream(); null != s; s = nextStream() )
 			{
 				int c = s.read();
 				if ( -1 != c )
@@ -177,11 +145,11 @@ public class MarkableSequenceInputStream extends InputStream
 	}
 
 	@Override
-	public int read(byte[] b, int off, int len) throws IOException
+	public int read(char[] b, int off, int len) throws IOException
 	{
 		synchronized ( this )
 		{
-			for ( InputStream s = currentStream(); null != s; s = nextStream() )
+			for ( Reader s = currentStream(); null != s; s = nextStream() )
 			{
 				int rslt = s.read(b, off, len);
 				if ( -1 != rslt )
@@ -202,7 +170,7 @@ public class MarkableSequenceInputStream extends InputStream
 		{
 			long skipped;
 			long totalSkipped = 0;
-			InputStream s = currentStream();
+			Reader s = currentStream();
 			while ( null != s )
 			{
 				skipped = s.skip(n);
@@ -235,21 +203,6 @@ public class MarkableSequenceInputStream extends InputStream
 	}
 
 	@Override
-	public int available() throws IOException
-	{
-		synchronized ( this )
-		{
-			if ( m_closed )
-				return 0;
-			InputStream s = currentStream();
-			if ( null == s )
-				return 0;
-			m_streams.previous(); /* maintain "current" invariant */
-			return s.available();
-		}
-	}
-
-	@Override
 	public void close() throws IOException
 	{
 		synchronized ( this )
@@ -266,20 +219,20 @@ public class MarkableSequenceInputStream extends InputStream
 	}
 
 	/**
-	 * Marks the current position in this input stream. In this implementation,
+	 * Marks the current position in this reader. In this implementation,
 	 * it is possible to 'cancel' a mark, by passing this method a
-	 * {@code readlimit} of zero, returning the stream immediately to the state
+	 * {@code readlimit} of zero, returning the reader immediately to the state
 	 * of having no mark.
 	 */
 	@Override
-	public void mark(int readlimit)
+	public void mark(int readlimit) throws IOException
 	{
 		synchronized ( this )
 		{
 			if ( m_closed )
 				return;
 
-			InputStream activeStream = null;
+			Reader activeStream = null;
 			if ( m_streams.hasNext() )
 			{
 				m_streams.next();
@@ -288,7 +241,7 @@ public class MarkableSequenceInputStream extends InputStream
 
 			if ( null != m_markedStream )
 			{
-				for ( InputStream is = activeStream; is != m_markedStream; )
+				for ( Reader is = activeStream; is != m_markedStream; )
 					is = m_streams.previous();
 				/*
 				 * Whether the above loop executed zero or more times, the last
@@ -300,7 +253,7 @@ public class MarkableSequenceInputStream extends InputStream
 				 * It is safe to start off this loop with next(), because it
 				 * will return the formerly marked stream, known to exist.
 				 */
-				for ( InputStream is = m_streams.next(); is != activeStream; )
+				for ( Reader is = m_streams.next(); is != activeStream; )
 				{
 					try
 					{
@@ -340,7 +293,7 @@ public class MarkableSequenceInputStream extends InputStream
 		synchronized ( this )
 		{
 			if ( m_closed )
-				throw new IOException("reset on closed InputStream");
+				throw new IOException("reset on closed Reader");
 
 			if ( null == m_markedStream )
 			{
@@ -349,7 +302,7 @@ public class MarkableSequenceInputStream extends InputStream
 				throw new IOException("reset without mark");
 			}
 
-			InputStream is = currentStream();
+			Reader is = currentStream();
 			/*
 			 * 'is' right now is the active stream, or null if we are at EOF;
 			 * either way the first call to previous() coming up below will
@@ -375,17 +328,16 @@ public class MarkableSequenceInputStream extends InputStream
 	}
 
 	/**
-	 * Tests if this input stream supports the mark and reset methods.
+	 * Tests if this reader supports the mark and reset methods.
 	 *<p>
-	 * By the API spec, this method's return is "an invariant property of a
-	 * particular input stream instance." For any instance of this class, the
+	 * For any instance of this class, the
 	 * result is determined by the first call to this method, and does not
 	 * change thereafter. At the first call, the result is determined only by
-	 * the underlying input streams remaining to be read (or, if a mark has been
+	 * the underlying readers remaining to be read (or, if a mark has been
 	 * set, which is possible before checking this method, then by the
-	 * underlying input streams including and following the one that was current
+	 * underlying readers including and following the one that was current
 	 * when the mark was set). The result will be {@code true} unless any of
-	 * those underlying streams reports it as {@code false}.
+	 * those underlying readers reports it as {@code false}.
 	 */
 	@Override
 	public boolean markSupported()
@@ -396,8 +348,8 @@ public class MarkableSequenceInputStream extends InputStream
 				return m_markSupported;
 			if ( m_closed )
 				return false;
-			
-			InputStream activeStream = null;
+
+			Reader activeStream = null;
 			if ( m_streams.hasNext() )
 			{
 				m_streams.next();
@@ -406,7 +358,7 @@ public class MarkableSequenceInputStream extends InputStream
 
 			if ( null != m_markedStream )
 			{
-				for ( InputStream is = activeStream; is != m_markedStream; )
+				for ( Reader is = activeStream; is != m_markedStream; )
 					is = m_streams.previous();
 			}
 
@@ -422,7 +374,7 @@ public class MarkableSequenceInputStream extends InputStream
 			 * We've run to the end of the streams list. Back up to the active
 			 * one.
 			 */
-			for ( InputStream is = null; is != activeStream; )
+			for ( Reader is = null; is != activeStream; )
 				is = m_streams.previous();
 
 			/*
@@ -431,98 +383,5 @@ public class MarkableSequenceInputStream extends InputStream
 			m_markSupported_determined = true;
 			return m_markSupported;
 		}
-	}
-
-	/**
-	 * A {@code ListIterator} that will fetch an element from a
-	 * {@code BlockingQueue} whenever {@code hasNext} would (otherwise)
-	 * return {@code false}, adding it to the end of the list where the next
-	 * {@code next()} will retrieve it.'
-	 *<p>
-	 * It is possible for the {@code hasNext}, {@code next}, and
-	 * {@code nextIndex} methods to throw {@link CancellationException}, if the
-	 * thread is interrupted while they await something on the queue.
-	 */
-	public static class FetchingListIterator<E> implements ListIterator<E>
-	{
-		private final ListIterator<E> m_li;
-		private BlockingQueue<E> m_q;
-		private final E m_sentinel;
-
-		/**
-		 * Construct a {@code FetchingListIterator} given an existing list,
-		 * a {@code BlockingQueue}, and a particular instance of the list's
-		 * element type to use as an end-of-queue sentinel (it is not possible
-		 * to enqueue a null value on a {@code BlockingQueue}).
-		 * @param list An existing list.
-		 * @param queue A blocking queue whose elements will be taken in order
-		 * following any existing elements in the original list.
-		 * @param sentinel A value that the supplier, feeding the blocking
-		 * queue, will enqueue when no more actual values will be forthcoming.
-		 * When an element is dequeued that matches this sentinel (per reference
-		 * equality), it is not added to the list, and nothing more will be
-		 * fetched from the queue.
-		 * @throws NullPointerException if any parameter is null.
-		 */
-		public FetchingListIterator(
-			List<E> list, BlockingQueue<E> queue, E sentinel)
-		{
-			if ( null == list  ||  null == queue  ||  null == sentinel )
-				throw new NullPointerException(
-					"a null parameter was passed to FetchingListIterator");
-
-			m_li = list.listIterator();
-			m_q = queue;
-			m_sentinel = sentinel;
-		}
-
-		@Override
-		public boolean hasNext()
-		{
-			boolean has = m_li.hasNext();
-			E e;
-			if ( has  ||  null == m_q )
-				return has;
-			try
-			{
-				e = m_q.take();
-			}
-			catch ( InterruptedException ex )
-			{
-				m_q = null;
-				throw (CancellationException)
-					new CancellationException("Interrupted waiting for input")
-						.initCause(ex);
-			}
-			if ( m_sentinel == e )
-			{
-				m_q = null;
-				return has;
-			}
-			m_li.add(e);
-			m_li.previous();
-			return true;
-		}
-
-		@Override
-		public E next()
-		{
-			hasNext();
-			return m_li.next();
-		}
-
-		@Override
-		public int nextIndex()
-		{
-			hasNext();
-			return m_li.nextIndex();
-		}
-
-		@Override public void add(E e) { m_li.add(e); }
-		@Override public boolean hasPrevious() { return m_li.hasPrevious(); }
-		@Override public E previous() { return m_li.previous(); }
-		@Override public int previousIndex() { return m_li.previousIndex(); }
-		@Override public void remove() { m_li.remove(); }
-		@Override public void set(E e) { m_li.set(e); }
 	}
 }

--- a/pljava/src/main/java/org/postgresql/pljava/internal/VarlenaWrapper.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/VarlenaWrapper.java
@@ -134,6 +134,23 @@ public interface VarlenaWrapper extends Closeable
 			}
 		}
 
+		/**
+		 * Wrapper around the {@code pinUnlessReleased} method of the native
+		 * state, for sites where an {@code IOException} is needed rather than
+		 * {@code SQLException}.
+		 */
+		private boolean pinUnlessReleased() throws IOException
+		{
+			try
+			{
+				return ((State)m_state).pinUnlessReleased();
+			}
+			catch ( SQLException e )
+			{
+				throw new IOException(e.getMessage(), e);
+			}
+		}
+
 		/*
 		 * Unpin for use in {@code ByteBufferInputStream} or here; no
 		 * throws-clause difference to blotch things up.
@@ -225,7 +242,8 @@ public interface VarlenaWrapper extends Closeable
 		@Override
 		public void close() throws IOException
 		{
-			pin();
+			if ( pinUnlessReleased() )
+				return;
 			try
 			{
 				super.close();
@@ -495,6 +513,23 @@ public interface VarlenaWrapper extends Closeable
 			}
 		}
 
+		/**
+		 * Wrapper around the {@code pinUnlessReleased} method of the native
+		 * state, for sites where an {@code IOException} is needed rather than
+		 * {@code SQLException}.
+		 */
+		private boolean pinUnlessReleased() throws IOException
+		{
+			try
+			{
+				return m_state.pinUnlessReleased();
+			}
+			catch ( SQLException e )
+			{
+				throw new IOException(e.getMessage(), e);
+			}
+		}
+
 		@Override
 		public void write(int b) throws IOException
 		{
@@ -536,7 +571,8 @@ public interface VarlenaWrapper extends Closeable
 		@Override
 		public void close() throws IOException
 		{
-			pin();
+			if ( pinUnlessReleased() )
+				return;
 			try
 			{
 				if ( ! m_open )

--- a/pljava/src/main/java/org/postgresql/pljava/internal/VarlenaWrapper.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/VarlenaWrapper.java
@@ -577,6 +577,7 @@ public interface VarlenaWrapper extends Closeable
 			{
 				if ( ! m_open )
 					return;
+				m_state.setVerifierIfNone();
 				buf(0);
 				m_open = false;
 				m_state.verify();
@@ -704,6 +705,17 @@ public interface VarlenaWrapper extends Closeable
 				if ( null == v )
 					throw new NullPointerException("Null Verifier parameter");
 				m_verifier = v.schedule();
+			}
+
+			/*
+			 * Only for use in close() in case of early closing before the
+			 * caller has set a verifier; make sure at least the NoOp verifier
+			 * is there.
+			 */
+			private void setVerifierIfNone()
+			{
+				if ( null == m_verifier )
+					m_verifier = Verifier.NoOp.INSTANCE;
 			}
 
 			private void cancelVerifier()

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/SQLXMLImpl.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/SQLXMLImpl.java
@@ -3704,7 +3704,8 @@ public abstract class SQLXMLImpl<V extends VarlenaWrapper> implements SQLXML
 		@Override
 		public AdjustingStAXSource expandEntityReferences(boolean v)
 		{
-			return this;
+			return setFirstSupportedFeature( v,
+				XMLInputFactory.IS_REPLACING_ENTITY_REFERENCES);
 		}
 
 		@Override

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/XMLEventToStreamConsumer.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/XMLEventToStreamConsumer.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright (c) 2019 Tada AB and other contributors, as listed below.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Chapman Flack
+ */
+package org.postgresql.pljava.jdbc;
+
+import java.util.Iterator;
+
+import javax.xml.namespace.QName;
+
+import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamWriter;
+
+import javax.xml.stream.events.*;
+
+import javax.xml.stream.util.XMLEventConsumer;
+
+/**
+ * Consume a stream of StAX {@code XMLEvent}s, writing them to an
+ * {@code XMLStreamWriter}.
+ *<p>
+ * This entire class would be completely unnecessary if not for the
+ * regression in Java 9 and later that leaves
+ * {@code XMLOutputFactory.createXMLEventWriter} throwing a
+ * {@code ClassCastException} if passed a {@code StAXResult} wrapping an
+ * arbitrary {@code XMLStreamWriter} implementation, which works perfectly
+ * up through Java 8. Java 9 breaks it, demanding this soul-crushing workaround.
+ */
+class XMLEventToStreamConsumer
+implements XMLEventConsumer, XMLStreamConstants
+{
+	private final XMLStreamWriter m_xsw;
+
+	/**
+	 * Construct an {@code XMLEventToStreamConsumer} that writes to the
+	 * given {@code XMLStreamWriter}.
+	 */
+	XMLEventToStreamConsumer(XMLStreamWriter xsw)
+	{
+		if ( null == xsw )
+			throw new NullPointerException("XMLEventToStreamConsumer");
+		m_xsw = xsw;
+	}
+
+	/**
+	 * Dispatch an {@code XMLEvent} to the corresponding specialized
+	 * {@code add} method.
+	 */
+	@Override
+	public void add(XMLEvent event) throws XMLStreamException
+	{
+		if ( null == event )
+			throw new NullPointerException("XMLEventToStreamConsumer.add");
+
+		switch ( event.getEventType() )
+		{
+		case COMMENT:                add(              (Comment) event); break;
+		case PROCESSING_INSTRUCTION: add((ProcessingInstruction) event); break;
+		case CDATA:      // fallthrough
+		case CHARACTERS:             add(           (Characters) event); break;
+		case DTD:                    add(                  (DTD) event); break;
+		case ENTITY_REFERENCE:       add(      (EntityReference) event); break;
+		case START_DOCUMENT:         add(        (StartDocument) event); break;
+		case END_DOCUMENT:           add(          (EndDocument) event); break;
+		case START_ELEMENT:          add(         (StartElement) event); break;
+		case END_ELEMENT:            add(           (EndElement) event); break;
+		default:
+			throw new XMLStreamException(
+				"Unexpected XMLEvent type " + event.getEventType());
+		}
+	}
+
+	protected void add(Comment event) throws XMLStreamException
+	{
+		m_xsw.writeComment(event.getText());
+	}
+
+	protected void add(ProcessingInstruction event) throws XMLStreamException
+	{
+		m_xsw.writeProcessingInstruction(event.getTarget(), event.getData());
+	}
+
+	protected void add(Characters event) throws XMLStreamException
+	{
+		String content = event.getData();
+		if ( event.isCData() )
+			m_xsw.writeCData(content);
+		else
+			m_xsw.writeCharacters(content);
+	}
+
+	protected void add(DTD event) throws XMLStreamException
+	{
+		m_xsw.writeDTD(event.getDocumentTypeDeclaration());
+	}
+
+	protected void add(EntityReference event) throws XMLStreamException
+	{
+		m_xsw.writeEntityRef(event.getName());
+	}
+
+	protected void add(StartDocument event) throws XMLStreamException
+	{
+		String  version = event.getVersion();
+		String encoding = event.getCharacterEncodingScheme();
+		if ( event.encodingSet() )
+			m_xsw.writeStartDocument(encoding, version);
+		else
+			m_xsw.writeStartDocument(version);
+	}
+
+	protected void add(EndDocument event) throws XMLStreamException
+	{
+		m_xsw.writeEndDocument();
+	}
+
+	protected void add(StartElement event) throws XMLStreamException
+	{
+		QName qn = event.getName();
+		m_xsw.writeStartElement(
+			qn.getPrefix(), qn.getLocalPart(), qn.getNamespaceURI());
+		for ( Namespace n : namespaces(event) )
+			add(n);
+		for ( Attribute a : attributes(event) )
+			add(a);
+	}
+
+	protected void add(EndElement event) throws XMLStreamException
+	{
+		m_xsw.writeEndElement();
+	}
+
+	protected void add(Attribute a) throws XMLStreamException
+	{
+		QName n = a.getName();
+		m_xsw.writeAttribute(
+			n.getPrefix(), n.getNamespaceURI(), n.getLocalPart(), a.getValue());
+	}
+
+	protected void add(Namespace n) throws XMLStreamException
+	{
+		m_xsw.writeNamespace(n.getPrefix(), n.getNamespaceURI());
+	}
+
+	/*
+	 * XXX Do the below with lambdas once Java back horizon >= 8.
+	 */
+	protected Attributes attributes(StartElement event)
+	{
+		Attributes as = new Attributes();
+		as.m_event = event;
+		return as;
+	}
+
+	protected Namespaces namespaces(StartElement event)
+	{
+		Namespaces ns = new Namespaces();
+		ns.m_event = event;
+		return ns;
+	}
+
+	static abstract class ElementIterable<T> implements Iterable<T>
+	{
+		protected StartElement m_event;
+
+		@Override
+		public abstract Iterator<T> iterator();
+	}
+
+	static class Attributes extends ElementIterable<Attribute>
+	{
+		@Override
+		public Iterator<Attribute> iterator()
+		{
+			return (Iterator<Attribute>)m_event.getAttributes();
+		}
+	}
+
+	static class Namespaces extends ElementIterable<Namespace>
+	{
+		@Override
+		public Iterator<Namespace> iterator()
+		{
+			return (Iterator<Namespace>)m_event.getNamespaces();
+		}
+	}
+}


### PR DESCRIPTION
It should be possible for a PL/Java function to use another JDBC driver connected to another database, obtain an `SQLXML` object from that (which will not, of course, be PL/Java's implementation), and return or pass that to PostgreSQL. That simply requires detecting that an instance of `SQLXML` isn't an instance of PL/Java's implementing class, and transparently creating a new empty one that is and copying the content to it. The foreign one must, of course, be in 'readable' state, and willing to provide its content as one of: `StreamSource`, `SAXSource`, `StAXSource`, or `DOMSource` (its `getSource` method will be passed `null`, so it gets to choose which of those flavors it prefers to provide).