### PR TITLE
Provide correct JDBC Savepoint behavior

### DIFF
--- a/pljava-api/src/main/java/org/postgresql/pljava/SavepointListener.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/SavepointListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2015 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2019 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -20,7 +20,12 @@ import java.sql.Savepoint;
  * savepoints. To receive such notifications, implement this interface, with
  * the three methods that will be called in those three cases, and pass an
  * instance to {@link Session#addSavepointListener}.
- *
+ *<p>
+ * It is possible for a listener method to be called with <em>savepoint</em>
+ * null, or <em>parent</em> null, or both; that can happen if the application
+ * code has not kept a strong reference to the {@code Savepoint} object in
+ * question.
+ *<p>
  * <code>SavepointListener</code> exposes a
  * <a href=
 'http://doxygen.postgresql.org/xact_8h.html#aceb46988cbad720cc8a2d7ac6951f0ef'
@@ -30,9 +35,12 @@ import java.sql.Savepoint;
  */
 public interface SavepointListener
 {
-	void onAbort(Session session, Savepoint savepoint, Savepoint parent) throws SQLException;
+	void onAbort(Session session, Savepoint savepoint, Savepoint parent)
+	throws SQLException;
 
-	void onCommit(Session session, Savepoint savepoint, Savepoint parent) throws SQLException;
+	void onCommit(Session session, Savepoint savepoint, Savepoint parent)
+	throws SQLException;
 
-	void onStart(Session session, Savepoint savepoint, Savepoint parent) throws SQLException;
+	void onStart(Session session, Savepoint savepoint, Savepoint parent)
+	throws SQLException;
 }

--- a/pljava-examples/src/main/resources/deployment/examples.ddr
+++ b/pljava-examples/src/main/resources/deployment/examples.ddr
@@ -79,27 +79,6 @@ SQLActions[ ] = {
 			FOR EACH ROW
 			EXECUTE PROCEDURE moddatetime (moddate);
 
-		CREATE TABLE javatest.employees1
-			(
-			id		int PRIMARY KEY,
-			name	varchar(200),	
-			salary	int
-			);
-
-		CREATE TABLE javatest.employees2
-			(
-			id		int PRIMARY KEY,
-			name	varchar(200),
-			salary	int,
-			transferDay date,
-			transferTime time
-			);
-
-		CREATE FUNCTION javatest.transferPeople(int)
-			RETURNS int
-			AS 'org.postgresql.pljava.example.SPIActions.transferPeopleWithSalary'
-			LANGUAGE java;
-
 		CREATE TYPE javatest._testSetReturn
 			AS (base integer, incbase integer, ctime timestamptz);
 
@@ -131,16 +110,6 @@ SQLActions[ ] = {
 		CREATE FUNCTION javatest.hugeNonImmutableResult(int)
 			RETURNS SETOF javatest._testSetReturn
 			AS 'org.postgresql.pljava.example.HugeResultSet.executeSelect'
-			LANGUAGE java;
-
-		CREATE FUNCTION javatest.maxFromSetReturnExample(int, int)
-			RETURNS int
-			AS 'org.postgresql.pljava.example.SPIActions.maxFromSetReturnExample'
-			IMMUTABLE LANGUAGE java;
-
-		CREATE FUNCTION javatest.nestedStatements(int)
-			RETURNS void
-			AS 'org.postgresql.pljava.example.SPIActions.nestedStatements'
 			LANGUAGE java;
 
 		CREATE TYPE javatest._properties
@@ -175,26 +144,6 @@ SQLActions[ ] = {
 			RETURNS SETOF pg_user
 			AS 'org.postgresql.pljava.example.Users.listNonSupers'
 			LANGUAGE java;
-
-		CREATE FUNCTION javatest.testSavepointSanity()
-			RETURNS int
-			AS 'org.postgresql.pljava.example.SPIActions.testSavepointSanity'
-			IMMUTABLE LANGUAGE java;
-
-		CREATE FUNCTION javatest.testTransactionRecovery()
-			RETURNS int
-			AS 'org.postgresql.pljava.example.SPIActions.testTransactionRecovery'
-			IMMUTABLE LANGUAGE java;
-
-		CREATE FUNCTION javatest.getDateAsString()
-			RETURNS varchar
-			AS 'org.postgresql.pljava.example.SPIActions.getDateAsString'
-			STABLE LANGUAGE java;
-
-		CREATE FUNCTION javatest.getTimeAsString()
-			RETURNS varchar
-			AS 'org.postgresql.pljava.example.SPIActions.getTimeAsString'
-			STABLE LANGUAGE java;
 
 		CREATE FUNCTION javatest.logMessage(varchar, varchar)
 			RETURNS void

--- a/pljava-so/src/main/c/Invocation.c
+++ b/pljava-so/src/main/c/Invocation.c
@@ -59,7 +59,7 @@ void Invocation_initialize(void)
 
 	cls = PgObject_getJavaClass("org/postgresql/pljava/jdbc/Invocation");
 	PgObject_registerNatives2(cls, invocationMethods);
-	s_Invocation_onExit = PgObject_getJavaMethod(cls, "onExit", "()V");
+	s_Invocation_onExit = PgObject_getJavaMethod(cls, "onExit", "(Z)V");
 	JNI_deleteLocalRef(cls);
 }
 
@@ -148,13 +148,14 @@ void Invocation_popInvocation(bool wasException)
 
 	/*
 	 * If a Java Invocation instance was created and associated with this
-	 * invocation, delete the reference (after calling its onExit method, for
-	 * non-exceptional returns).
+	 * invocation, delete the reference (after calling its onExit method,
+	 * indicating whether the return is exceptional or not).
 	 */
 	if(currentInvocation->invocation != 0)
 	{
-		if(!wasException)
-			JNI_callVoidMethod(currentInvocation->invocation, s_Invocation_onExit);
+		JNI_callVoidMethod(currentInvocation->invocation, s_Invocation_onExit,
+			(wasException || currentInvocation->errorOccurred)
+			? JNI_TRUE : JNI_FALSE);
 		JNI_deleteGlobalRef(currentInvocation->invocation);
 	}
 

--- a/pljava-so/src/main/c/SubXactListener.c
+++ b/pljava-so/src/main/c/SubXactListener.c
@@ -28,6 +28,9 @@ static void subXactCB(SubXactEvent event, SubTransactionId mySubid, SubTransacti
 	 * Map the subids to PgSavepoints first - this function upcalls into Java
 	 * without releasing the Backend.THREADLOCK monitor, so the called methods
 	 * can know they're on the PG thread; Backend.threadMayEnterPG() is true.
+	 * It is important to look up mySubid before parentSubid, as it is possible
+	 * a new PgSavepoint instance is under construction in the 'nursery', and
+	 * will be assigned the first id to be looked up.
 	 */
 	jobject     sp = pljava_PgSavepoint_forId(mySubid);
 	jobject parent = pljava_PgSavepoint_forId(parentSubid);

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/Invocation.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/Invocation.java
@@ -73,13 +73,13 @@ public class Invocation
 	 * Called from the backend when the invokation exits. Should
 	 * not be invoked any other way.
 	 */
-	public void onExit()
+	public void onExit(boolean withError)
 	throws SQLException
 	{
 		try
 		{
 			if(m_savepoint != null)
-				m_savepoint.onInvocationExit(SPIDriver.getDefault());
+				m_savepoint.onInvocationExit(withError);
 		}
 		finally
 		{

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/SPIConnection.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/SPIConnection.java
@@ -356,7 +356,6 @@ public class SPIConnection implements Connection
 		PgSavepoint sp = (PgSavepoint)savepoint;
 		Invocation.clearErrorCondition();
 		sp.rollback();
-		forgetSavepoint(sp);
 	}
 
 	/**
@@ -680,7 +679,7 @@ public class SPIConnection implements Connection
 	}
 
 	/*
-	 * An implementation factor of releaseSavepoint() and rollback(Savepoint)
+	 * An implementation factor of releaseSavepoint()
 	 * undoing the registration done by rememberSavepoint().
 	 */
 	private static void forgetSavepoint(PgSavepoint sp)


### PR DESCRIPTION
Addresses issue #228.

Per JDBC, a `Savepoint` still exists after being used in a `rollback` and can be used again, while only those `Savepoint`s created after it are invalidated by the rollback.

That behavior should be familiar, as it is the same as PostgreSQL's own SQL `SAVEPOINT` behavior. It is also found in pgJDBC, which has test coverage to confirm it.

PL/Java has been doing it wrong for a long time, because the behavior of PostgreSQL's "internal subtransaction" API is different, and that's the API that has to be used inside of a function. Those things are used up after a rollback.

Getting the right behavior simply requires transparently establishing a new "internal subtransaction" as the last step of a JDBC `Savepoint` rollback. That will be a behavior change, but largely transparent to old code. The fact that a savepoint remains usable after the old code has forgotten about it should not get in the way, and if the code (now unnecessarily) creates a new savepoint on top of it, even with the same name, it doesn't hurt anything. (Names are informational only, not checked for uniqueness or needed for identification; what you need to do a `rollback` or `releaseSavepoint` is the `Savepoint` instance.)

However, at function exit, PL/Java does have to mop up these "internal subtransactions" if any are lying around, and in old code that has used one in a `rollback` and forgotten about it, there will be one lying around when there was not before fixing this issue.

Ordinarily, PL/Java logs a warning in that case, and will either release (i.e. commit) or roll back the savepoint according to the `pljava.release_lingering_savepoints` GUC, which defaults to a rollback. Neither the warning nor the rollback would be desired in this case.

Hence, to preserve compatibility with old code, a `Savepoint` should also remember whether it has been used at least once in a `rollback`, and a savepoint that has been, and is found unreaped at function exit, should be silently released (or silently rolled back, if the function is completing abruptly).