### PR TITLE
Allow 1.5 to build with Java 9 or later, and work earlier

### DIFF
--- a/pljava-examples/pom.xml
+++ b/pljava-examples/pom.xml
@@ -11,8 +11,39 @@
 	<description>Examples of Java stored procedures using PL/Java</description>
 
 	<profiles>
+		<!--
+		  - This profile has to precede saxon-examples, because both set
+		  - the property pljava.examples.apitarget; a property set in more than
+		  - one active profile gets the later value, and that has to be the
+		  - Java 8 target set by saxon-examples, if those examples are built.
+		  -->
+		<profile>
+			<id>jdk9plus</id>
+			<activation>
+				<jdk>[9,)</jdk>
+			</activation>
+			<properties>
+				<pljava.examples.apitarget>7</pljava.examples.apitarget>
+			</properties>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-compiler-plugin</artifactId>
+						<version>3.8.1</version>
+						<configuration>
+							<release>${pljava.examples.apitarget}</release>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+
 		<profile>
 			<id>saxon-examples</id>
+			<properties>
+				<pljava.examples.apitarget>8</pljava.examples.apitarget>
+			</properties>
 			<dependencies>
 				<dependency>
 					<groupId>net.sf.saxon</groupId>
@@ -36,6 +67,7 @@
 		</profile>
 
 		<profile>
+			<id>jdk7plus</id>
 			<activation>
 				<jdk>[1.7,)</jdk>
 			</activation>

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/saxon/S9.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/saxon/S9.java
@@ -46,6 +46,9 @@ import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import javax.xml.transform.Source;
+import javax.xml.transform.Result;
+
 import static javax.xml.XMLConstants.W3C_XML_SCHEMA_NS_URI;
 import static javax.xml.XMLConstants.XML_NS_URI;
 import static javax.xml.XMLConstants.XML_NS_PREFIX;
@@ -346,8 +349,9 @@ public class S9 implements ResultSetProvider
 			}
 
 			SQLXML rsx = s_dbc.createSQLXML();
+			Result rslt = rsx.setResult(null);
 			QueryResult.serializeSequence(
-				x1s, s_s9p.getUnderlyingConfiguration(), rsx.setResult(null),
+				x1s, s_s9p.getUnderlyingConfiguration(), rslt,
 				new Properties());
 			return rsx;
 		}
@@ -612,7 +616,10 @@ public class S9 implements ResultSetProvider
 				return true;
 			XdmValue ci;
 			if ( cve instanceof SQLXML ) // XXX support SEQUENCE input someday
-				ci = dBuilder.build(((SQLXML)cve).getSource(null));
+			{
+				Source src = ((SQLXML)cve).getSource(null);
+				ci = dBuilder.build(src);
+			}
 			else
 				ci = xmlCastAsSequence(
 					cve, XMLBinary.HEX, passing.contextItem().typeXS());
@@ -641,7 +648,10 @@ public class S9 implements ResultSetProvider
 			if ( null == v )
 				vv = XdmEmptySequence.getInstance();
 			else if ( v instanceof SQLXML ) // XXX support SEQUENCE someday
-				vv = dBuilder.build(((SQLXML)v).getSource(null));
+			{
+				Source src = ((SQLXML)v).getSource(null);
+				vv = dBuilder.build(src);
+			}
 			else
 				vv = xmlCastAsSequence(
 					v, XMLBinary.HEX, p.typeXS().getItemType());

--- a/pom.xml
+++ b/pom.xml
@@ -70,13 +70,14 @@
 		<profile>
 			<id>srctgt6</id>
 			<activation>
-				<jdk>[1.6,12)</jdk>
+				<jdk>[1.6,9)</jdk>
 			</activation>
 			<build>
 				<plugins>
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-compiler-plugin</artifactId>
+						<version>2.5.1</version>
 						<configuration>
 							<source>1.6</source>
 							<target>1.6</target>
@@ -86,7 +87,25 @@
 			</build>
 		</profile>
 		<profile>
-			<id>srctgt7</id>
+			<id>release6</id>
+			<activation>
+				<jdk>[9,12)</jdk>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-compiler-plugin</artifactId>
+						<version>3.8.1</version>
+						<configuration>
+							<release>6</release>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+		<profile>
+			<id>release7</id>
 			<activation>
 				<jdk>[12,)</jdk>
 			</activation>
@@ -95,9 +114,9 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-compiler-plugin</artifactId>
+						<version>3.8.1</version>
 						<configuration>
-							<source>7</source>
-							<target>7</target>
+							<release>7</release>
 						</configuration>
 					</plugin>
 				</plugins>
@@ -124,7 +143,6 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>2.5.1</version>
 				<configuration>
 					<encoding>${project.build.sourceEncoding}</encoding>
 				</configuration>


### PR DESCRIPTION
Follow-on to PR #222. When building with Java 9 or later, it is possible to use `--release` to specify the target runtime release, replacing the older `-source` and `-target`. But more than "possible", it is _necessary_ to do so, as otherwise API changes in Java 9 will get baked into the compiled classes, causing even unchanged Java 6 compatible source code to compile to classes that will throw link errors in a pre-Java-9 runtime.