### PR TITLE
Bugs caught ramping down to 1.5.3

### DIFF
--- a/pljava-so/src/main/c/Backend.c
+++ b/pljava-so/src/main/c/Backend.c
@@ -653,6 +653,7 @@ static void initsequencer(enum initstage is, bool tolerant)
 				errhint("The most common reason is that \"pljava.classpath\" "
 					"needs to be set, naming the proper \"pljava.jar\" file.")
 					));
+			pljava_DualState_unregister();
 			_destroyJavaVM(0, 0);
 			goto check_tolerant;
 		}

--- a/pljava-so/src/main/c/DualState.c
+++ b/pljava-so/src/main/c/DualState.c
@@ -247,6 +247,11 @@ void pljava_DualState_initialize(void)
 	pljava_VarlenaWrapper_initialize();
 }
 
+void pljava_DualState_unregister(void)
+{
+	UnregisterResourceReleaseCallback(resourceReleaseCB, NULL);
+}
+
 static void resourceReleaseCB(ResourceReleasePhase phase,
 							  bool isCommit, bool isTopLevel, void *arg)
 {

--- a/pljava-so/src/main/include/pljava/DualState.h
+++ b/pljava-so/src/main/include/pljava/DualState.h
@@ -27,6 +27,8 @@ extern void pljava_DualState_cleanEnqueuedInstances(void);
 
 extern void pljava_DualState_initialize(void);
 
+extern void pljava_DualState_unregister(void);
+
 extern void pljava_DualState_nativeRelease(void *);
 
 #ifdef __cplusplus

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/Invocation.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/Invocation.java
@@ -21,6 +21,20 @@ import org.postgresql.pljava.internal.Backend;
 import org.postgresql.pljava.internal.PgSavepoint;
 
 /**
+ * One invocation, from PostgreSQL, of functionality implemented using PL/Java.
+ *<p>
+ * This class is the Java counterpart of the {@code struct Invocation_} in the
+ * C code, but while there is a new stack-allocated C structure on every entry
+ * from PG to PL/Java, no instance of this class is created unless requested
+ * (with {@link #current current()}; once requested, a reference to it is saved
+ * in the C struct for the duration of the invocation.
+ *<p>
+ * One further piece of magic applies to set-returning functions. Under the
+ * value-per-call protocol, there is technically a new entry into PL/Java, and
+ * a new C {@code Invocation_} struct, for every row to be returned, but that
+ * low-level complication is hidden at this level: a single instance of this
+ * class, if once requested, will be remembered throughout the value-per-call
+ * sequence of calls.
  * @author Thomas Hallgren
  */
 public class Invocation


### PR DESCRIPTION
A couple bugs not reported from the field but noticed in the rampdown to 1.5.3.

One involves the relatively recent addition of the `DualState` class and only affects behavior when PL/Java's startup fails.

One has been around much longer, in the management of SPI connections for set-returning functions, but is easier to expose with the heavier use of composite-parameter-and-return-typed functions in the recently added example code.