### PR TITLE
Sop for javac's --release 6 check

### DIFF
--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/PassXML.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/PassXML.java
@@ -578,7 +578,7 @@ public class PassXML implements SQLData
 			case 6:
 				StAXSource sts = sx.getSource(StAXSource.class);
 				StAXResult str = rx.setResult(StAXResult.class);
-				XMLOutputFactory xof = XMLOutputFactory.newFactory();
+				XMLOutputFactory xof = XMLOutputFactory.newInstance();
 				/*
 				 * The Source has either an event reader or a stream reader. Use
 				 * the event reader directly, or create one around the stream
@@ -587,7 +587,7 @@ public class PassXML implements SQLData
 				XMLEventReader xer = sts.getXMLEventReader();
 				if ( null == xer )
 				{
-					XMLInputFactory  xif = XMLInputFactory .newFactory();
+					XMLInputFactory  xif = XMLInputFactory .newInstance();
 					xif.setProperty(xif.IS_NAMESPACE_AWARE, true);
 					/*
 					 * Important: before copying this example code for another

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/SQLXMLImpl.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/SQLXMLImpl.java
@@ -594,7 +594,7 @@ public abstract class SQLXMLImpl<V extends VarlenaWrapper> implements SQLXML
 		boolean mustBeDocument = false;
 		boolean cantBeDocument = false;
 
-		XMLInputFactory xif = XMLInputFactory.newFactory();
+		XMLInputFactory xif = XMLInputFactory.newInstance();
 		xif.setProperty(xif.IS_NAMESPACE_AWARE, true);
 		XMLStreamReader xsr = null;
 		try
@@ -781,7 +781,7 @@ public abstract class SQLXMLImpl<V extends VarlenaWrapper> implements SQLXML
 				if ( sourceClass.isAssignableFrom(StAXSource.class)
 					|| sourceClass.isAssignableFrom(AdjustingStAXSource.class) )
 				{
-					XMLInputFactory xif = XMLInputFactory.newFactory();
+					XMLInputFactory xif = XMLInputFactory.newInstance();
 					xif.setProperty(xif.IS_NAMESPACE_AWARE, true);
 					is = correctedDeclStream(is, false);
 					AdjustingStAXSource ss =
@@ -1118,7 +1118,7 @@ public abstract class SQLXMLImpl<V extends VarlenaWrapper> implements SQLXML
 
 				if ( resultClass.isAssignableFrom(StAXResult.class) )
 				{
-					XMLOutputFactory xof = XMLOutputFactory.newFactory();
+					XMLOutputFactory xof = XMLOutputFactory.newInstance();
 					os = new DeclCheckedOutputStream(os, m_serverCS);
 					XMLStreamWriter xsw = xof.createXMLStreamWriter(
 						os, m_serverCS.name());
@@ -2896,9 +2896,9 @@ public abstract class SQLXMLImpl<V extends VarlenaWrapper> implements SQLXML
 			{
 				StAXResult str = m_tgt.setResult(
 					m_tgt.backingIfNotFreed(), StAXResult.class);
-				XMLInputFactory  xif = XMLInputFactory.newFactory();
+				XMLInputFactory  xif = XMLInputFactory.newInstance();
 				xif.setProperty(xif.IS_NAMESPACE_AWARE, true);
-				XMLOutputFactory xof = XMLOutputFactory.newFactory();
+				XMLOutputFactory xof = XMLOutputFactory.newInstance();
 				/*
 				 * The Source has either an event reader or a stream reader. Use
 				 * the event reader directly, or create one around the stream


### PR DESCRIPTION
As reported in issue #235, the `--release` option in newer `javac`
versions will check against a `ct.sym` file included in the jdk
that is meant to record what API was available in which prior
releases, and that file (at least as shipped in Java 11) is
missing the `newFactory()` methods on `XMLInputFactory` and
`XMLOutputFactory` for release 6, so it reports them not found.

Happily, both no-arg `newFactory()` methods are equivalent to
the no-arg `newInstance()` methods. Deprecation tags were added
to the `newInstance(String,ClassLoader)` methods, but not to
the no-arg ones.