### PR TITLE
Fix array-index exception in Java 13 build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>
-				<version>2.6</version>
+				<version>3.0.2</version>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
This seems to be a minimal sufficient change to build successfully
with Java 13, avoiding the `ArrayIndexOutOfBoundsException` reported
in #236.