### PR TITLE
Fix a Javadoc build issue with Java 11+

### DIFF
--- a/pljava-deploy/src/main/java/org/postgresql/pljava/deploy/Deployer.java
+++ b/pljava-deploy/src/main/java/org/postgresql/pljava/deploy/Deployer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2013 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2019 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -56,20 +56,20 @@ import java.util.ArrayList;
  * <td>Drops the Java language and the sqjl procedures and loaded jars</td>
  * </tr>
  * <tr>
- * <td nowrap="true" valign="top">-user &lt;user name&gt;</td>
+ * <td valign="top">-user &lt;user name&gt;</td>
  * <td>Name of user that connects to the database. Default is current user</td>
  * </tr>
  * <tr>
- * <td nowrap="true" valign="top">-password &lt;password&gt;</td>
+ * <td valign="top">-password &lt;password&gt;</td>
  * <td>Password of user that connects to the database. Default is no password
  * </td>
  * </tr>
  * <tr>
- * <td nowrap="true" valign="top">-database &lt;database&gt;</td>
+ * <td valign="top">-database &lt;database&gt;</td>
  * <td>The name of the database to connect to. Default is current user</td>
  * </tr>
  * <tr>
- * <td nowrap="true" valign="top">-host &lt;hostname&gt;</td>
+ * <td valign="top">-host &lt;hostname&gt;</td>
  * <td>Name of the host. Default is "localhost"</td>
  * </tr>
  * <tr>

--- a/pom.xml
+++ b/pom.xml
@@ -193,6 +193,9 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
 				<version>2.10.3</version>
+				<configuration>
+					<source>8</source>
+				</configuration>
 				<reportSets>
 					<reportSet>
 						<reports>


### PR DESCRIPTION
As reported in #239, javadoc with an 11 or newer JDK can
fail with a message about code in modules being linked to
Java API code in the unnamed package. The Java bug report
indicates a fix was rolled out (adding code to detect when
the 'module' being detected is really an automatic module),
but it seems a `<source>` element in the configuration of the
`maven-javadoc-plugin` is still needed. That will just specify
a hardcoded 8 for now (even if the `--release` given to `javac`
will be 7 or 6); javadoc doesn't seem to mind if it is not
an exact match. (Even an actual javadoc 7 seems not to object
to source 8.)

In passing: with that hurdle cleared, javadoc 12 proceeds to
complain about non-HTML5 attributes in `Deployer`'s javadoc, so
those are removed here (even though `Deployer` itself is on the
way out).