### PR TITLE
Allow Javadoc to build with Java 13

### DIFF
--- a/pljava-api/src/main/java/org/postgresql/pljava/Adjusting.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/Adjusting.java
@@ -36,7 +36,7 @@ public final class Adjusting
 	/**
 	 * Class that collects adjustment APIs for affecting the behavior of
 	 * PL/Java's XML support.
-	 *<h1>XML parser behavior adjustments</h1>
+	 *<h2>XML parser behavior adjustments</h2>
 	 *<p>
 	 * Retrieving or verifying the XML content in a JDBC {@code SQLXML} object
 	 * can involve applying an XML parser. The full XML specification includes

--- a/pljava-deploy/src/main/java/org/postgresql/pljava/deploy/Deployer.java
+++ b/pljava-deploy/src/main/java/org/postgresql/pljava/deploy/Deployer.java
@@ -27,15 +27,13 @@ import java.util.ArrayList;
  * PostgreSQL distribution. The former contains the code for the deployer
  * command and the second includes the PostgreSQL JDBC driver. You then run the
  * deployer with the command:
- * <p>
  * <blockquote><code>
  * java -cp &lt;your classpath&gt; org.postgresql.pljava.deploy.Deployer [ options ]
  * </code></blockquote>
  * <p>
  * It's recommended that create a shell script or a .bat script that does this
  * for you so that you don't have to do this over and over again.
- * </p>
- * <h3>Deployer options</h3>
+ * <h2>Deployer options</h2>
  * <blockquote><table><caption>Options for Deployer</caption>
  * <tr>
  * <th>Option</th>

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/saxon/S9.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/saxon/S9.java
@@ -135,8 +135,8 @@ import org.xml.sax.SAXException;
  * CREATE TABLE catalog_as_xml(x) AS
  *   SELECT schema_to_xml('pg_catalog', false, true, '');
  *</pre>
- *<h1>Functions/predicates from ISO 9075-14 SQL/XML</h1>
- *<h2>XMLQUERY</h2>
+ *<h2>Functions/predicates from ISO 9075-14 SQL/XML</h2>
+ *<h3>XMLQUERY</h3>
  *<p>
  * In the syntax of the SQL/XML standard, here is a query that would return
  * an XML element representing the declaration of a function with a specified
@@ -167,9 +167,9 @@ import org.xml.sax.SAXException;
  * query function.
  *<p>
  * Because of an unconditional uppercasing that PL/Java's JDBC driver currently
- * applies to column names, any parameter names, such as `FUNCNAME` above, must
- * be spelled in uppercase where used in the XQuery text, or they will not be
- * recognized. Because the unconditional uppercasing is highly likely to be
+ * applies to column names, any parameter names, such as {@code FUNCNAME} above,
+ * must be spelled in uppercase where used in the XQuery text, or they will not
+ * be recognized. Because the unconditional uppercasing is highly likely to be
  * dropped in a future PL/Java release, it is wisest until then to use only
  * parameter names that really are uppercase, both in the XQuery text where they
  * are used and in the SQL expression that supplies them. In PostgreSQL,
@@ -184,7 +184,7 @@ import org.xml.sax.SAXException;
  * provides no way for {@code BY REF} semantics to be implemented, so everything
  * happening here happens {@code BY VALUE} implicitly, and does not need to be
  * specified.
- *<h2>XMLEXISTS</h2>
+ *<h3>XMLEXISTS</h3>
  *<p>
  * The function {@link #xmlexists xmlexists} here implements the
  * standard function of the same name. Because it is the same name, it has to
@@ -205,7 +205,7 @@ import org.xml.sax.SAXException;
  * FROM catalog_as_xml,
  * LATERAL (SELECT x AS ".", 'numeric_avg' AS "FUNCNAME") AS p;
  *</pre>
- *<h2>XMLTABLE</h2>
+ *<h3>XMLTABLE</h3>
  *<p>
  * The function {@link #xmltable xmltable} here implements (much of) the
  * standard function of the same name. Because it is the same name, it has to
@@ -245,7 +245,7 @@ import org.xml.sax.SAXException;
  * The {@code DPREMIER} parameter passed from SQL to the XQuery expression is
  * spelled in uppercase (and also, in the SQL expression supplying it, quoted),
  * for the reasons explained above for the {@code xq_ret_content} function.
- *<h1>XQuery regular-expression functions in ISO 9075-2 Foundations</h1>
+ *<h2>XQuery regular-expression functions in ISO 9075-2 Foundations</h2>
  * The methods {@link #like_regex like_regex},
  * {@link #occurrences_regex occurrences_regex},
  * {@link #position_regex position_regex},
@@ -257,8 +257,8 @@ import org.xml.sax.SAXException;
  * specifies, not in the more-flexible Unicode-compatible way ISO SQL specifies,
  * and for the ones where ISO SQL allows {@code USING CHARACTERS} or
  * {@code USING OCTETS}, only {@code USING CHARACTERS} will work.
- *<h1>Extensions</h1>
- *<h2>XQuery module prolog allowed</h2>
+ *<h2>Extensions</h2>
+ *<h3>XQuery module prolog allowed</h3>
  *<p>
  * Where any function here accepts an XQuery
  *<a href='https://www.w3.org/TR/xquery-31/#id-expressions'
@@ -266,7 +266,7 @@ import org.xml.sax.SAXException;
  *<a href='https://www.w3.org/TR/xquery-31/#dt-main-module'
  *>"main module"</a> will be accepted. Therefore, the query can be preceded by
  * a prolog declaring namespaces, options, local variables and functions, etc.
- *<h2>Saxon extension to XQuery regular expressions</h2>
+ *<h3>Saxon extension to XQuery regular expressions</h3>
  *<p>
  * Saxon's implementation of XQuery regular expressions will accept a
  * nonstandard <em>flag</em> string ending with {@code ;j} to use Java regular
@@ -1108,7 +1108,7 @@ public class S9 implements ResultSetProvider
 	 * ordered list of the steps to apply:
 	 *<ul>
 	 *<li>Any item in the sequence that is an array is flattened (its elements
-	 * become items in the sequence)
+	 * become items in the sequence).
 	 *<li>If any item is a function, {@code err:XQTY0105} is raised.
 	 *<li>Any sequence {@code $s} of adjacent atomic values is replaced by
 	 * {@code string-join($s, ' ')}.

--- a/pljava/src/main/java/org/postgresql/pljava/management/Commands.java
+++ b/pljava/src/main/java/org/postgresql/pljava/management/Commands.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2015 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2019 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -55,16 +55,16 @@ import static org.postgresql.pljava.annotation.Function.Security.DEFINER;
 
 /**
  * This methods of this class are implementations of SQLJ commands.
- * <h1>SQLJ functions</h1>
- * <h2>install_jar</h2>
+ * <h2>SQLJ functions</h2>
+ * <h3>install_jar</h3>
  * The install_jar command loads a jar file from a location appointed by an URL
  * or a binary image that constitutes the contents of a jar file into the SQLJ
  * jar repository. It is an error if a jar with the given name already exists in
  * the repository.
- * <h3>Usage 1</h3>
+ * <h4>Usage 1</h4>
  * <blockquote><code>SELECT sqlj.install_jar(&lt;jar_url&gt;, &lt;jar_name&gt;, &lt;deploy&gt;);</code>
  * </blockquote>
- * <h3>Parameters</h3>
+ * <h4>Parameters</h4>
  * <blockquote><table><caption>Parameters for sqlj.install_jar(url...)</caption>
  * <tr>
  * <td valign="top"><b>jar_url</b></td>
@@ -82,10 +82,10 @@ import static org.postgresql.pljava.annotation.Function.Security.DEFINER;
  * descriptor}, false otherwise</td>
  * </tr>
  * </table></blockquote>
- * <h3>Usage 2</h3>
+ * <h4>Usage 2</h4>
  * <blockquote><code>SELECT sqlj.install_jar(&lt;jar_image&gt;, &lt;jar_name&gt;, &lt;deploy&gt;);</code>
  * </blockquote>
- * <h3>Parameters</h3>
+ * <h4>Parameters</h4>
  * <blockquote><table><caption>Parameters for
  * sqlj.install_jar(bytea...)</caption>
  * <tr>
@@ -105,13 +105,13 @@ import static org.postgresql.pljava.annotation.Function.Security.DEFINER;
  * descriptor}, false otherwise</td>
  * </tr>
  * </table></blockquote>
- * <h2>replace_jar</h2>
+ * <h3>replace_jar</h3>
  * The replace_jar will replace a loaded jar with another jar. Use this command
  * to update already loaded files. It's an error if the jar is not found.
- * <h3>Usage 1</h3>
+ * <h4>Usage 1</h4>
  * <blockquote><code>SELECT sqlj.replace_jar(&lt;jar_url&gt;, &lt;jar_name&gt;, &lt;redeploy&gt;);</code>
  * </blockquote>
- * <h3>Parameters</h3>
+ * <h4>Parameters</h4>
  * <blockquote><table><caption>Parameters for sqlj.replace_jar(url...)</caption>
  * <tr>
  * <td valign="top"><b>jar_url</b></td>
@@ -129,10 +129,10 @@ import static org.postgresql.pljava.annotation.Function.Security.DEFINER;
  * descriptors}, false otherwise</td>
  * </tr>
  * </table></blockquote>
- * <h3>Usage 2</h3>
+ * <h4>Usage 2</h4>
  * <blockquote><code>SELECT sqlj.replace_jar(&lt;jar_image&gt;, &lt;jar_name&gt;, &lt;redeploy&gt;);</code>
  * </blockquote>
- * <h3>Parameters</h3>
+ * <h4>Parameters</h4>
  * <blockquote><table><caption>Parameters for
  * sqlj.replace_jar(bytea...)</caption>
  * <tr>
@@ -152,14 +152,14 @@ import static org.postgresql.pljava.annotation.Function.Security.DEFINER;
  * descriptors}, false otherwise</td>
  * </tr>
  * </table></blockquote>
- * <h2>remove_jar</h2>
+ * <h3>remove_jar</h3>
  * The remove_jar will drop the jar from the jar repository. Any classpath that
  * references this jar will be updated accordingly. It's an error if the jar is
  * not found.
- * <h3>Usage</h3>
+ * <h4>Usage</h4>
  * <blockquote><code>SELECT sqlj.remove_jar(&lt;jar_name&gt;, &lt;undeploy&gt;);</code>
  * </blockquote>
- * <h3>Parameters</h3>
+ * <h4>Parameters</h4>
  * <blockquote><table><caption>Parameters for sqlj.remove_jar</caption>
  * <tr>
  * <td valign="top"><b>jar_name</b></td>
@@ -172,29 +172,29 @@ import static org.postgresql.pljava.annotation.Function.Security.DEFINER;
  * descriptor}, false otherwise</td>
  * </tr>
  * </table></blockquote>
- * <h2>get_classpath</h2>
+ * <h3>get_classpath</h3>
  * The get_classpath will return the classpath that has been defined for the
  * given schema or NULL if the schema has no classpath. It's an error if the
  * given schema does not exist.
- * <h3>Usage</h3>
+ * <h4>Usage</h4>
  * <blockquote><code>SELECT sqlj.get_classpath(&lt;schema&gt;);</code>
  * </blockquote>
- * <h3>Parameters</h3>
+ * <h4>Parameters</h4>
  * <blockquote><table><caption>Parameters for sqlj.get_classpath</caption>
  * <tr>
  * <td><b>schema</b></td>
  * <td>The name of the schema</td>
  * </tr>
  * </table></blockquote>
- * <h2>set_classpath</h2>
+ * <h3>set_classpath</h3>
  * The set_classpath will define a classpath for the given schema. A classpath
  * consists of a colon separated list of jar names. It's an error if the given
  * schema does not exist or if one or more jar names references non existent
  * jars.
- * <h3>Usage</h3>
+ * <h4>Usage</h4>
  * <blockquote><code>SELECT sqlj.set_classpath(&lt;schema&gt;, &lt;classpath&gt;);</code>
  * </blockquote>
- * <h3>Parameters</h3>
+ * <h4>Parameters</h4>
  * <blockquote><table><caption>Parameters for sqlj.set_classpath</caption>
  * <tr>
  * <td><b>schema</b></td>
@@ -205,13 +205,13 @@ import static org.postgresql.pljava.annotation.Function.Security.DEFINER;
  * <td>The colon separated list of jar names</td>
  * </tr>
  * </table></blockquote>
- * <h2>add_type_mapping</h2>
+ * <h3>add_type_mapping</h3>
  * The add_type_mapping defines the mapping between an SQL type and a Java
  * class.
- * <h3>Usage</h3>
+ * <h4>Usage</h4>
  * <blockquote><code>SELECT sqlj.add_type_mapping(&lt;sqlTypeName&gt;, &lt;className&gt;);</code>
  * </blockquote>
- * <h3>Parameters</h3>
+ * <h4>Parameters</h4>
  * <blockquote><table><caption>Parameters for sqlj.add_type_mapping</caption>
  * <tr>
  * <td><b>sqlTypeName</b></td>
@@ -225,13 +225,13 @@ import static org.postgresql.pljava.annotation.Function.Security.DEFINER;
  * effect for the current schema</td>
  * </tr>
  * </table></blockquote>
- * <h2>drop_type_mapping</h2>
+ * <h3>drop_type_mapping</h3>
  * The drop_type_mapping removes the mapping between an SQL type and a Java
  * class.
- * <h3>Usage</h3>
+ * <h4>Usage</h4>
  * <blockquote><code>SELECT sqlj.drop_type_mapping(&lt;sqlTypeName&gt;);</code>
  * </blockquote>
- * <h3>Parameters</h3>
+ * <h4>Parameters</h4>
  * <blockquote><table><caption>Parameters for sqlj.drop_type_mapping</caption>
  * <tr>
  * <td><b>sqlTypeName</b></td>

--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,9 @@
 					</plugin>
 				</plugins>
 			</build>
+			<properties>
+				<version.javadoc.plugin>2.10.3</version.javadoc.plugin>
+			</properties>
 		</profile>
 		<profile>
 			<id>release6</id>
@@ -103,6 +106,9 @@
 					</plugin>
 				</plugins>
 			</build>
+			<properties>
+				<version.javadoc.plugin>3.1.1</version.javadoc.plugin>
+			</properties>
 		</profile>
 		<profile>
 			<id>release7</id>
@@ -121,6 +127,9 @@
 					</plugin>
 				</plugins>
 			</build>
+			<properties>
+				<version.javadoc.plugin>3.1.1</version.javadoc.plugin>
+			</properties>
 		</profile>
 	</profiles>
 
@@ -192,10 +201,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>2.10.3</version>
-				<configuration>
-					<source>8</source>
-				</configuration>
+				<version>${version.javadoc.plugin}</version>
 				<reportSets>
 					<reportSet>
 						<reports>


### PR DESCRIPTION
For Java 13, the version of the `maven-javadoc-plugin` must be
advanced to avoid pulling in a version of `commons-lang` whose
`getJavaVersionAsFloat()` method is broken by a change to the
version property values reported in 13.

There seems to be no choice of `maven-javadoc-plugin` version
that will work with 13 and also back to 6, so use profiles
based on the build-time JDK version to select the plugin version
to use.

A benefit of advancing the `maven-javadoc-plugin` version is that
the `<source>` element added in a28db9f can be removed again, as the
newer plugin does not need it.

Javadoc 13 is more strict in checking HTML5 structure, and disallows
`<h1>` in a doc comment (a level-1 header is generated by Javadoc itself),
requiring `h` elements to be used in proper sequence with `h2` outermost.

There is nothing like a tedious bout of header renumbering to find
a few other assorted typos in doc comments.