### PR TITLE
Tweaks from another review pass over DualState

### DIFF
--- a/pljava/src/main/java/org/postgresql/pljava/internal/DualState.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/DualState.java
@@ -753,10 +753,9 @@ public abstract class DualState<T> extends WeakReference<T>
 	 * used in a caller (such as a {@code close} or {@code free} operation) that
 	 * will have nothing to do and return immediately if this method returns
 	 * true.
-	 * @throws SQLException if the native state or the Java state has been
-	 * released.
 	 * @throws CancellationException if the thread is interrupted while waiting.
-	 */public final boolean pinUnlessReleased() throws SQLException
+	 */
+	public final boolean pinUnlessReleased()
 	{
 		return !z(_pin());
 	}
@@ -766,7 +765,7 @@ public abstract class DualState<T> extends WeakReference<T>
 	 * @return zero if the pin was obtained, otherwise {@code NATIVE_RELEASED},
 	 * {@code JAVA_RELEASED}, or both.
 	 */
-	private final int _pin() throws SQLException
+	private final int _pin()
 	{
 		if ( s_pinCount.pin(this) )
 			return 0; // reentrant pin, no need for sync effort
@@ -991,7 +990,7 @@ public abstract class DualState<T> extends WeakReference<T>
 	 * @return the {@code NATIVE_RELEASED} and {@code JAVA_RELEASED} bits of
 	 * the state
 	 */
-	private int backoutPinAfterPark(int s, int t) throws SQLException
+	private int backoutPinAfterPark(int s, int t)
 	{
 		boolean wasHolds = !z(t & MUTATOR_HOLDS); // t, the pre-park state
 		/*

--- a/pljava/src/main/java/org/postgresql/pljava/internal/DualState.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/DualState.java
@@ -718,6 +718,25 @@ public abstract class DualState<T> extends WeakReference<T>
 	}
 
 	/**
+	 * Throws {@code UnsupportedOperationException}; client code should already
+	 * hold a reference.
+	 */
+	@Override
+	public final T get()
+	{
+		throw new UnsupportedOperationException(
+			"directly calling get() on a DualState object is not supported.");
+	}
+
+	/**
+	 * Used internally to obtain this object's referent.
+	 */
+	protected final T referent()
+	{
+		return super.get();
+	}
+
+	/**
 	 * Obtain a pin on this state, throwing an appropriate exception if it
 	 * is not still valid, blocking if necessary until release of a lock.
 	 *<p>
@@ -1074,11 +1093,11 @@ public abstract class DualState<T> extends WeakReference<T>
 	 */
 	private void scheduleJavaReleased(int s)
 	{
-		T r = get();
+		T r = referent();
 		/*
-		 * If get() returned a non-null reference, clearly the garbage collector
-		 * has not cleared this yet (and is now prevented from doing so, by the
-		 * strong reference r).
+		 * If referent() returned a non-null reference, clearly the garbage
+		 * collector has not cleared this yet (and is now prevented from doing
+		 * so, by the strong reference r ... barring JIT optimizations!).
 		 *
 		 * Clearing it here explicitly relieves the garbage collector of further
 		 * need to track it for later enqueueing.
@@ -1339,7 +1358,7 @@ public abstract class DualState<T> extends WeakReference<T>
 	protected String identifierForMessage()
 	{
 		String id;
-		Object referent = get();
+		Object referent = referent();
 		if ( null != referent )
 			id = referent.getClass().getName();
 		else
@@ -1486,7 +1505,7 @@ public abstract class DualState<T> extends WeakReference<T>
 				{
 					++ release;
 					s.nativeStateReleased(
-						z(JAVA_RELEASED & state)  &&  null != s.get());
+						z(JAVA_RELEASED & state)  &&  null != s.referent());
 				}
 			}
 			finally

--- a/pljava/src/main/java/org/postgresql/pljava/internal/VarlenaWrapper.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/VarlenaWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2019 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -136,19 +136,11 @@ public interface VarlenaWrapper extends Closeable
 
 		/**
 		 * Wrapper around the {@code pinUnlessReleased} method of the native
-		 * state, for sites where an {@code IOException} is needed rather than
-		 * {@code SQLException}.
+		 * state.
 		 */
-		private boolean pinUnlessReleased() throws IOException
+		private boolean pinUnlessReleased()
 		{
-			try
-			{
-				return ((State)m_state).pinUnlessReleased();
-			}
-			catch ( SQLException e )
-			{
-				throw new IOException(e.getMessage(), e);
-			}
+			return ((State)m_state).pinUnlessReleased();
 		}
 
 		/*
@@ -515,19 +507,11 @@ public interface VarlenaWrapper extends Closeable
 
 		/**
 		 * Wrapper around the {@code pinUnlessReleased} method of the native
-		 * state, for sites where an {@code IOException} is needed rather than
-		 * {@code SQLException}.
+		 * state.
 		 */
-		private boolean pinUnlessReleased() throws IOException
+		private boolean pinUnlessReleased()
 		{
-			try
-			{
-				return m_state.pinUnlessReleased();
-			}
-			catch ( SQLException e )
-			{
-				throw new IOException(e.getMessage(), e);
-			}
+			return m_state.pinUnlessReleased();
 		}
 
 		@Override


### PR DESCRIPTION
It is not necessary for `pinUnlessReleased` to throw any checked exception, so remove the `throws` clause, simplifying callers.

Although not likely and not seen in practice, there's a conceivable race condition between explicit `releaseFromJava()` and unreachability detected by GC, depending on when code doing the explicit release last holds a strong reference. The case may never arise, but should be handled gracefully if it does.