### PR TITLE
One change left out of PR #229

### DIFF
--- a/pljava-so/src/main/c/Invocation.c
+++ b/pljava-so/src/main/c/Invocation.c
@@ -153,7 +153,8 @@ void Invocation_popInvocation(bool wasException)
 	 */
 	if(currentInvocation->invocation != 0)
 	{
-		JNI_callVoidMethod(currentInvocation->invocation, s_Invocation_onExit,
+		JNI_callVoidMethodLocked(
+			currentInvocation->invocation, s_Invocation_onExit,
 			(wasException || currentInvocation->errorOccurred)
 			? JNI_TRUE : JNI_FALSE);
 		JNI_deleteGlobalRef(currentInvocation->invocation);


### PR DESCRIPTION
Code added to PgSavepoint.onInvocationExit() in 53aaa42 relies on executing in the PG thread; don't relinquish the monitor in the upcall from C. This should have been included in PR #229.