### PR TITLE
Fix runtime errors caught on i386 builds

### DIFF
--- a/pljava-so/src/main/c/ExecutionPlan.c
+++ b/pljava-so/src/main/c/ExecutionPlan.c
@@ -74,8 +74,8 @@ void pljava_ExecutionPlan_initialize(void)
 	};
 	PgObject_registerNatives("org/postgresql/pljava/internal/ExecutionPlan", methods);
 
-	s_ExecutionPlan_class = (jclass)PgObject_getJavaClass(
-		"org/postgresql/pljava/internal/ExecutionPlan");
+	s_ExecutionPlan_class = (jclass)JNI_newGlobalRef(PgObject_getJavaClass(
+		"org/postgresql/pljava/internal/ExecutionPlan"));
 	s_ExecutionPlan_init = PgObject_getJavaMethod(s_ExecutionPlan_class,
 		"<init>",
 		"(Lorg/postgresql/pljava/internal/DualState$Key;J"

--- a/pljava-so/src/main/c/ExecutionPlan.c
+++ b/pljava-so/src/main/c/ExecutionPlan.c
@@ -333,8 +333,8 @@ Java_org_postgresql_pljava_internal_ExecutionPlan__1prepare(JNIEnv* env, jclass 
 #endif
 			result = JNI_newObjectLocked(
 				s_ExecutionPlan_class, s_ExecutionPlan_init,
-				/* 0L as resource owner as the saved plan isn't transient */
-				pljava_DualState_key(), 0L, key, p2l.longVal);
+				/* (jlong)0 as resource owner: the saved plan isn't transient */
+				pljava_DualState_key(), (jlong)0, key, p2l.longVal);
 		}
 	}
 	PG_CATCH();

--- a/pljava-so/src/main/c/PgSavepoint.c
+++ b/pljava-so/src/main/c/PgSavepoint.c
@@ -63,8 +63,8 @@ void PgSavepoint_initialize(void)
 	PgObject_registerNatives("org/postgresql/pljava/internal/PgSavepoint",
 		methods);
 
-	jclass s_PgSavepoint_class = PgObject_getJavaClass(
-		"org/postgresql/pljava/internal/PgSavepoint");
+	jclass s_PgSavepoint_class = JNI_newGlobalRef(PgObject_getJavaClass(
+		"org/postgresql/pljava/internal/PgSavepoint"));
 	s_forId =
 		PgObject_getStaticJavaMethod(s_PgSavepoint_class, "forId",
 			"(I)Lorg/postgresql/pljava/internal/PgSavepoint;");

--- a/pljava-so/src/main/c/VarlenaWrapper.c
+++ b/pljava-so/src/main/c/VarlenaWrapper.c
@@ -457,8 +457,8 @@ void pljava_VarlenaWrapper_initialize(void)
 		s_VarlenaWrapper_class, "adopt",
 		"(Lorg/postgresql/pljava/internal/DualState$Key;)J");
 
-	clazz = (jclass)JNI_newGlobalRef(PgObject_getJavaClass(
-			"org/postgresql/pljava/internal/VarlenaWrapper$Input$State"));
+	clazz = PgObject_getJavaClass(
+			"org/postgresql/pljava/internal/VarlenaWrapper$Input$State");
 
 	PgObject_registerNatives2(clazz, methodsIn);
 
@@ -467,8 +467,8 @@ void pljava_VarlenaWrapper_initialize(void)
 
 	JNI_deleteLocalRef(clazz);
 
-	clazz = (jclass)JNI_newGlobalRef(PgObject_getJavaClass(
-			"org/postgresql/pljava/internal/VarlenaWrapper$Output$State"));
+	clazz = PgObject_getJavaClass(
+			"org/postgresql/pljava/internal/VarlenaWrapper$Output$State");
 
 	PgObject_registerNatives2(clazz, methodsOut);
 

--- a/pljava-so/src/main/c/type/ErrorData.c
+++ b/pljava-so/src/main/c/type/ErrorData.c
@@ -35,13 +35,13 @@ jobject pljava_ErrorData_getCurrentError(void)
 	p2l.longVal = 0L; /* ensure that the rest is zeroed out */
 	p2l.ptrVal = errorData;
 	/*
-	 * Passing NULL as the ResourceOwner means this will never be matched by a
-	 * nativeRelease call; that's appropriate (for now) as the ErrorData copy is
-	 * being made into JavaMemoryContext, which never gets reset, so only
+	 * Passing (jlong)0 as the ResourceOwner means this will never be matched by
+	 * a nativeRelease call; that's appropriate (for now) as the ErrorData copy
+	 * is being made into JavaMemoryContext, which never gets reset, so only
 	 * unreachability from the Java side will free it.
 	 */
 	jed = JNI_newObjectLocked(s_ErrorData_class, s_ErrorData_init,
-		pljava_DualState_key(), NULL, p2l.longVal);
+		pljava_DualState_key(), (jlong)0, p2l.longVal);
 	return jed;
 }
 

--- a/pljava-so/src/main/c/type/Relation.c
+++ b/pljava-so/src/main/c/type/Relation.c
@@ -35,6 +35,7 @@ static jmethodID s_Relation_init;
 jobject pljava_Relation_create(Relation r)
 {
 	Ptr2Long p2lr;
+	Ptr2Long p2lro;
 
 	if ( NULL == r )
 		return NULL;
@@ -42,11 +43,14 @@ jobject pljava_Relation_create(Relation r)
 	p2lr.longVal = 0L;
 	p2lr.ptrVal = r;
 
+	p2lro.longVal = 0L;
+	p2lro.ptrVal = currentInvocation;
+
 	return JNI_newObjectLocked(
 			s_Relation_class,
 			s_Relation_init,
 			pljava_DualState_key(),
-			currentInvocation,
+			p2lro.longVal,
 			p2lr.longVal);
 }
 

--- a/pljava-so/src/main/c/type/TriggerData.c
+++ b/pljava-so/src/main/c/type/TriggerData.c
@@ -32,6 +32,7 @@ static jmethodID s_TriggerData_getTriggerReturnTuple;
 jobject pljava_TriggerData_create(TriggerData* triggerData)
 {
 	Ptr2Long p2ltd;
+	Ptr2Long p2lro;
 
 	if ( NULL == triggerData )
 		return NULL;
@@ -39,11 +40,14 @@ jobject pljava_TriggerData_create(TriggerData* triggerData)
 	p2ltd.longVal = 0L;
 	p2ltd.ptrVal = triggerData;
 
+	p2lro.longVal = 0L;
+	p2lro.ptrVal = currentInvocation;
+
 	return JNI_newObjectLocked(
 			s_TriggerData_class,
 			s_TriggerData_init,
 			pljava_DualState_key(),
-			currentInvocation,
+			p2lro.longVal,
 			p2ltd.longVal);
 }
 

--- a/pljava-so/src/main/c/type/Tuple.c
+++ b/pljava-so/src/main/c/type/Tuple.c
@@ -65,14 +65,14 @@ jobject pljava_Tuple_internalCreate(HeapTuple ht, bool mustCopy)
 	htH.longVal = 0L; /* ensure that the rest is zeroed out */
 	htH.ptrVal = ht;
 	/*
-	 * Passing NULL as the ResourceOwner means this will never be matched by a
+	 * Passing (jlong)0 as the ResourceOwner means this will never be matched by a
 	 * nativeRelease call; that's appropriate (for now) as the Tuple copy is
 	 * being made into JavaMemoryContext, which never gets reset, so only
 	 * unreachability from the Java side will free it.
 	 * XXX? this seems like a lot of tuple copying.
 	 */
 	jht = JNI_newObjectLocked(s_Tuple_class, s_Tuple_init,
-		pljava_DualState_key(), NULL, htH.longVal);
+		pljava_DualState_key(), (jlong)0, htH.longVal);
 	return jht;
 }
 

--- a/pljava-so/src/main/c/type/TupleDesc.c
+++ b/pljava-so/src/main/c/type/TupleDesc.c
@@ -55,14 +55,14 @@ jobject pljava_TupleDesc_internalCreate(TupleDesc td)
 	tdH.longVal = 0L; /* ensure that the rest is zeroed out */
 	tdH.ptrVal = td;
 	/*
-	 * Passing NULL as the ResourceOwner means this will never be matched by a
+	 * Passing (jlong)0 as the ResourceOwner means this will never be matched by a
 	 * nativeRelease call; that's appropriate (for now) as the TupleDesc copy is
 	 * being made into JavaMemoryContext, which never gets reset, so only
 	 * unreachability from the Java side will free it.
 	 * XXX what about invalidating if DDL alters the column layout?
 	 */
 	jtd = JNI_newObjectLocked(s_TupleDesc_class, s_TupleDesc_init,
-		pljava_DualState_key(), NULL, tdH.longVal, (jint)td->natts);
+		pljava_DualState_key(), (jlong)0, tdH.longVal, (jint)td->natts);
 	return jtd;
 }
 

--- a/pljava-so/src/main/c/type/TupleDesc.c
+++ b/pljava-so/src/main/c/type/TupleDesc.c
@@ -233,7 +233,7 @@ Java_org_postgresql_pljava_internal_TupleDesc__1formTuple(JNIEnv* env, jclass cl
 		int    count   = self->natts;
 		Datum* values  = (Datum*)palloc(count * sizeof(Datum));
 		bool*  nulls   = palloc(count * sizeof(bool));
-		jobject typeMap = Invocation_getTypeMap();
+		jobject typeMap = Invocation_getTypeMap(); /* a global ref */
 
 		memset(values, 0,  count * sizeof(Datum));
 		memset(nulls, true, count * sizeof(bool));/*all values null initially*/
@@ -246,6 +246,7 @@ Java_org_postgresql_pljava_internal_TupleDesc__1formTuple(JNIEnv* env, jclass cl
 				Type type = Type_fromOid(SPI_gettypeid(self, idx + 1), typeMap);
 				values[idx] = Type_coerceObjectBridged(type, value);
 				nulls[idx] = false;
+				JNI_deleteLocalRef(value);
 			}
 		}
 


### PR DESCRIPTION
The big refactoring in PR #206, away from finalizers and to the `DualState` class, introduced a few places where a C `long` or pointer to be represented as a Java `long` (which is how the resource owner is handled when constructing an object based on `DualState`) was not properly widened to `jlong`. That only affected architectures where a C `long` or pointer is narrower than `jlong`.

Also, a few mishandlings of JNI local and global references were found, which would be latent problems on any architecture, but only surfaced on 32-bit, probably because of higher memory pressure. It is good to have those fixed for all architectures.

This episode underscores how very helpful it would be to get CI going for this project, with test builds for a range of architectures. Short of that, it also highlights the value of doing occasional test runs with `-Xcheck:jni` during development.

Addresses #246.