### PR TITLE
Advance minimum Java (for master branch/next major release) to Java 8

### DIFF
--- a/pljava-api/src/main/java/org/postgresql/pljava/sqlgen/DDRProcessor.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/sqlgen/DDRProcessor.java
@@ -122,7 +122,7 @@ import org.postgresql.pljava.annotation.MappedUDT;
   "ddr.implementor",     // implementor when not annotated, default "PostgreSQL"
   "ddr.output"           // name of ddr file to write
 })
-@SupportedSourceVersion(SourceVersion.RELEASE_7)
+@SupportedSourceVersion(SourceVersion.RELEASE_8)
 public class DDRProcessor extends AbstractProcessor
 {
 	private DDRProcessorImpl impl;

--- a/pljava-api/src/main/java/org/postgresql/pljava/sqlgen/DDRProcessor.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/sqlgen/DDRProcessor.java
@@ -32,6 +32,12 @@ import java.sql.Timestamp;
 
 import java.text.BreakIterator;
 
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.OffsetTime;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -2373,15 +2379,11 @@ hunt:	for ( ExecutableElement ee : ees )
 
 			this.addMap(byte[].class, "pg_catalog.bytea");
 
-			// (Once Java back horizon advances to 8, do these the easy way.)
-			//
-			this.addMapIfExists("java.time.LocalDate", "pg_catalog.date");
-			this.addMapIfExists("java.time.LocalTime", "pg_catalog.time");
-			this.addMapIfExists("java.time.OffsetTime", "pg_catalog.timetz");
-			this.addMapIfExists("java.time.LocalDateTime",
-				"pg_catalog.timestamp");
-			this.addMapIfExists("java.time.OffsetDateTime",
-				"pg_catalog.timestamptz");
+			this.addMap(LocalDate.class, "pg_catalog.date");
+			this.addMap(LocalTime.class, "pg_catalog.time");
+			this.addMap(OffsetTime.class, "pg_catalog.timetz");
+			this.addMap(LocalDateTime.class, "pg_catalog.timestamp");
+			this.addMap(OffsetDateTime.class, "pg_catalog.timestamptz");
 		}
 
 		private boolean mappingsFrozen()

--- a/pljava-examples/pom.xml
+++ b/pljava-examples/pom.xml
@@ -11,65 +11,8 @@
 	<description>Examples of Java stored procedures using PL/Java</description>
 
 	<profiles>
-		<!--
-		  - This profile has to precede saxon-examples, because both set
-		  - the property pljava.examples.apitarget; a property set in more than
-		  - one active profile gets the later value, and that has to be the
-		  - Java 8 target set by saxon-examples, if those examples are built.
-		  -->
-		<profile>
-			<id>jdk9plus</id>
-			<activation>
-				<jdk>[9,)</jdk>
-			</activation>
-			<properties>
-				<pljava.examples.apitarget>7</pljava.examples.apitarget>
-			</properties>
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-compiler-plugin</artifactId>
-						<version>3.8.1</version>
-						<configuration>
-							<release>${pljava.examples.apitarget}</release>
-						</configuration>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
-
-		<profile>
-			<id>jdkpre9</id>
-			<activation>
-				<jdk>[1.7,9)</jdk>
-			</activation>
-			<properties>
-				<!--
-				  - Building pre-9, we'll assume 7 here. It will be bumped to 8
-				  - if building saxon-examples.
-				  -->
-				<pljava.examples.apitarget>7</pljava.examples.apitarget>
-			</properties>
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-compiler-plugin</artifactId>
-						<configuration>
-							<source>${pljava.examples.apitarget}</source>
-							<target>${pljava.examples.apitarget}</target>
-						</configuration>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
-
 		<profile>
 			<id>saxon-examples</id>
-			<properties>
-				<pljava.examples.apitarget>8</pljava.examples.apitarget>
-			</properties>
 			<dependencies>
 				<dependency>
 					<groupId>net.sf.saxon</groupId>

--- a/pljava-examples/pom.xml
+++ b/pljava-examples/pom.xml
@@ -63,7 +63,6 @@
 					<includes>
 						<include>org/postgresql/pljava/example/*.java</include>
 						<include>org/postgresql/pljava/example/annotation/*.java</include>
-						<include>org/postgresql/pljava/example/jdk7/*.java</include>
 					</includes>
 				</configuration>
 			</plugin>

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/JDBC42_21.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/JDBC42_21.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018- Tada AB and other contributors, as listed below.
+ * Copyright (c) 2018-2020 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -9,12 +9,7 @@
  * Contributors:
  *   Chapman Flack
  */
-/*
- * At the moment, this is written so it will compile in jdk6, even though it
- * won't work before jdk8. It's in the exclude-prior-to-jdk7 package though,
- * because it has an order dependency on TypeRoundTripper, which is there.
- */
-package org.postgresql.pljava.example.jdk7;
+package org.postgresql.pljava.example.annotation;
 
 import org.postgresql.pljava.annotation.Function;
 import org.postgresql.pljava.annotation.SQLAction;
@@ -34,16 +29,7 @@ import org.postgresql.pljava.example.annotation.ConditionalDDR; // for javadoc
  */
 @SQLActions({
 	@SQLAction(
-		implementor="postgresql_ge_90300", requires="javaSpecificationGE",
-		install=
-		"SELECT CASE WHEN javatest.javaSpecificationGE('1.8')" +
-		" THEN set_config('pljava.implementors', 'pg_jdbc42_21,' || " +
-		" current_setting('pljava.implementors'), true) " +
-		"END"
-	),
-
-	@SQLAction(
-		implementor="pg_jdbc42_21", requires="TypeRoundTripper.roundTrip",
+		implementor="postgresql_ge_90300",requires="TypeRoundTripper.roundTrip",
 		install={
 		" SELECT" +
 		"  CASE WHEN every(orig = roundtripped)" +

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/TypeRoundTripper.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/TypeRoundTripper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018- Tada AB and other contributors, as listed below.
+ * Copyright (c) 2018-2020 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -9,7 +9,7 @@
  * Contributors:
  *   Chapman Flack
  */
-package org.postgresql.pljava.example.jdk7;
+package org.postgresql.pljava.example.annotation;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/jdk7/package-info.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/jdk7/package-info.java
@@ -1,5 +1,0 @@
-/**
- * Examples only built on Java 7 or later.
- * @author Chapman Flack
- */
-package org.postgresql.pljava.example.jdk7;

--- a/pljava-so/pom.xml
+++ b/pljava-so/pom.xml
@@ -276,7 +276,7 @@
 		<profile>
 			<id>hasjavah</id>
 			<activation>
-				<jdk>[1.7,10)</jdk>
+				<jdk>[1.8,10)</jdk>
 			</activation>
 			<properties>
 				<javah.include>${basedir}/target/nar/javah-include/</javah.include>

--- a/pljava-so/pom.xml
+++ b/pljava-so/pom.xml
@@ -16,6 +16,7 @@
 	<properties>
 		<!-- use -Dnar.cores=1 if non-interleaved warning messages wanted -->
 		<nar.cores>0</nar.cores>
+		<javah.include>${basedir}/../pljava/target/javah-include/</javah.include>
 	</properties>
 
 	<profiles>
@@ -272,65 +273,6 @@
 				<pgsql.pgconfig>pg_config</pgsql.pgconfig>
 			</properties>
 		</profile>
-
-		<profile>
-			<id>hasjavah</id>
-			<activation>
-				<jdk>[1.8,10)</jdk>
-			</activation>
-			<properties>
-				<javah.include>${basedir}/target/nar/javah-include/</javah.include>
-			</properties>
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>com.github.maven-nar</groupId>
-						<artifactId>nar-maven-plugin</artifactId>
-						<configuration>
-							<!-- Generates C header files from Java class files. -->
-							<javah>
-								<classPaths>
-									<classPath>${basedir}/../pljava/target/classes/</classPath>
-									<classPath>${basedir}/../pljava-api/target/classes/</classPath>
-								</classPaths>
-								<classDirectory>${basedir}/../pljava/target/classes/</classDirectory>
-								<extraClasses>
-									<extraClass>java.sql.Types</extraClass>
-								</extraClasses>
-							</javah>
-						</configuration>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
-
-		<profile>
-			<id>lacksjavah</id>
-			<activation>
-				<jdk>[10,)</jdk>
-			</activation>
-			<properties>
-				<javah.include>${basedir}/../pljava/target/javah-include/</javah.include>
-			</properties>
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>com.github.maven-nar</groupId>
-						<artifactId>nar-maven-plugin</artifactId>
-						<configuration>
-							<c>
-								<includePaths combine.children='append'>
-									<includePath>${basedir}/src/main/include/fallback/jdbc</includePath>
-								</includePaths>
-							</c>
-							<java>
-								<include>true</include>
-							</java>
-						</configuration>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
 	</profiles>
 
 	<build>
@@ -496,11 +438,16 @@ if ( null !== jvmdflt )
 							<includePath>${PGSQL_INCLUDEDIR}</includePath>
 							<includePath>${PGSQL_INCLUDEDIR-SERVER}</includePath>
 							<includePath>${basedir}/src/main/include/</includePath>
+							<includePath>${basedir}/src/main/include/fallback/jdbc</includePath>
 							<includePath>${javah.include}</includePath>
 						</includePaths>
 						<debug>${so.debug}</debug>
 						<optimize>${so.optimize}</optimize>
 					</c>
+
+					<java>
+						<include>true</include>
+					</java>
 
 					<!-- Options/extra libs/etc. for the linker go here. -->
 					<linker>

--- a/pljava-so/src/main/c/JNICalls.c
+++ b/pljava-so/src/main/c/JNICalls.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2019 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2020 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -1318,7 +1318,7 @@ void JNI_setThreadLock(jobject lockObject)
 {
 	BEGIN_JAVA
 	s_threadLock = (*env)->NewGlobalRef(env, lockObject);
-	if((*env)->MonitorEnter(env, s_threadLock) < 0)
+	if(NULL != s_threadLock  &&  (*env)->MonitorEnter(env, s_threadLock) < 0)
 		elog(ERROR, "Java enter monitor failure (initial)");
 	END_JAVA
 }

--- a/pljava-so/src/main/c/type/Oid.c
+++ b/pljava-so/src/main/c/type/Oid.c
@@ -138,8 +138,6 @@ Oid Oid_forSqlType(int sqlType)
 			typeId = InvalidOid;	/* Not yet mapped */
 			break;
 
-		/* JDBC 4.2 - conditionalize until only Java 8 and later supported */
-#ifdef	java_sql_Types_REF_CURSOR
 		case java_sql_Types_TIME_WITH_TIMEZONE:
 			typeId = TIMETZOID;
 			break;
@@ -147,7 +145,6 @@ Oid Oid_forSqlType(int sqlType)
 			typeId = TIMESTAMPTZOID;
 			break;
 		case java_sql_Types_REF_CURSOR:
-#endif
 		default:
 			typeId = InvalidOid;	/* Not yet mapped */
 			break;

--- a/pljava/pom.xml
+++ b/pljava/pom.xml
@@ -17,30 +17,17 @@
 		</dependency>
 	</dependencies>
 
-	<profiles>
-		<profile>
-			<id>usejavac-h</id>
-			<activation>
-				<jdk>[10,)</jdk>
-			</activation>
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-compiler-plugin</artifactId>
-						<configuration>
-							<compilerArguments>
-								<h>${basedir}/target/javah-include</h>
-							</compilerArguments>
-						</configuration>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
-	</profiles>
-
 	<build>
 		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<compilerArguments>
+						<h>${basedir}/target/javah-include</h>
+					</compilerArguments>
+				</configuration>
+			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>

--- a/pljava/src/main/java/org/postgresql/pljava/internal/AclId.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/AclId.java
@@ -1,10 +1,18 @@
 /*
- * Copyright (c) 2004, 2005, 2006 TADA AB - Taby Sweden
- * Distributed under the terms shown in the file COPYRIGHT
- * found in the root folder of this project or at
- * http://eng.tada.se/osprojects/COPYRIGHT.html
+ * Copyright (c) 2004-2019 Tada AB and other contributors, as listed below.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Tada AB
+ *   Chapman Flack
  */
 package org.postgresql.pljava.internal;
+
+import static org.postgresql.pljava.internal.Backend.doInPG;
 
 import java.sql.SQLException;
 
@@ -61,10 +69,7 @@ public final class AclId
 	 */
 	public static AclId getUser()
 	{
-		synchronized(Backend.THREADLOCK)
-		{
-			return _getUser();
-		}
+		return doInPG(AclId::_getUser);
 	}
 
 	/**
@@ -82,10 +87,7 @@ public final class AclId
 	 */
 	public static AclId getOuterUser()
 	{
-		synchronized(Backend.THREADLOCK)
-		{
-			return _getOuterUser();
-		}
+		return doInPG(AclId::_getOuterUser);
 	}
 
 	/**
@@ -111,10 +113,7 @@ public final class AclId
 	 */
 	public static AclId fromName(String name) throws SQLException
 	{
-		synchronized(Backend.THREADLOCK)
-		{
-			return _fromName(name);
-		}
+		return doInPG(() -> _fromName(name));
 	}
 
 	/**
@@ -122,10 +121,7 @@ public final class AclId
 	 */
 	public String getName()
 	{
-		synchronized(Backend.THREADLOCK)
-		{
-			return this._getName();
-		}
+		return doInPG(this::_getName);
 	}
 
 	/**
@@ -134,10 +130,7 @@ public final class AclId
 	 */
 	public boolean hasSchemaCreatePermission(Oid oid)
 	{
-		synchronized(Backend.THREADLOCK)
-		{
-			return this._hasSchemaCreatePermission(oid);
-		}
+		return doInPG(() -> _hasSchemaCreatePermission(oid));
 	}
 
 	/**
@@ -145,10 +138,7 @@ public final class AclId
 	 */
 	public boolean isSuperuser()
 	{
-		synchronized(Backend.THREADLOCK)
-		{
-			return this._isSuperuser();
-		}
+		return doInPG(this::_isSuperuser);
 	}
 
 	/**

--- a/pljava/src/main/java/org/postgresql/pljava/internal/Backend.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/Backend.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2015 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2019 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -58,6 +58,100 @@ public class Backend
 		if(s_session == null)
 			s_session = new Session();
 		return s_session;
+	}
+
+	/**
+	 * Do an operation on a thread with serialized access to call into
+	 * PostgreSQL, returning a result.
+	 */
+	public static <T, E extends Throwable> T doInPG(Checked.Supplier<T,E> op)
+	throws E
+	{
+		synchronized(THREADLOCK)
+		{
+			return op.get();
+		}
+	}
+
+	/**
+	 * Specialization of {@link #doInPG(Supplier) doInPG} for operations that
+	 * return no result. This version must be present, as the Java compiler will
+	 * not automagically match a void lambda or method reference to
+	 * {@code Supplier<Void>}.
+	 */
+	public static <E extends Throwable> void doInPG(Checked.Runnable<E> op)
+	throws E
+	{
+		synchronized(THREADLOCK)
+		{
+			op.run();
+		}
+	}
+
+	/**
+	 * Specialization of {@link #doInPG(Supplier) doInPG} for operations that
+	 * return a boolean result. This method need not be present: without it, the
+	 * Java compiler will happily match boolean lambdas or method references to
+	 * the generic method, at the small cost of some boxing/unboxing; providing
+	 * this method simply allows that to be avoided.
+	 */
+	public static <E extends Throwable> boolean doInPG(
+		Checked.BooleanSupplier<E> op)
+	throws E
+	{
+		synchronized(THREADLOCK)
+		{
+			return op.getAsBoolean();
+		}
+	}
+
+	/**
+	 * Specialization of {@link #doInPG(Supplier) doInPG} for operations that
+	 * return a double result. This method need not be present: without it, the
+	 * Java compiler will happily match double lambdas or method references to
+	 * the generic method, at the small cost of some boxing/unboxing; providing
+	 * this method simply allows that to be avoided.
+	 */
+	public static <E extends Throwable> double doInPG(
+		Checked.DoubleSupplier<E> op)
+	throws E
+	{
+		synchronized(THREADLOCK)
+		{
+			return op.getAsDouble();
+		}
+	}
+
+	/**
+	 * Specialization of {@link #doInPG(Supplier) doInPG} for operations that
+	 * return an int result. This method need not be present: without it, the
+	 * Java compiler will happily match int lambdas or method references to
+	 * the generic method, at the small cost of some boxing/unboxing; providing
+	 * this method simply allows that to be avoided.
+	 */
+	public static <E extends Throwable> int doInPG(Checked.IntSupplier<E> op)
+	throws E
+	{
+		synchronized(THREADLOCK)
+		{
+			return op.getAsInt();
+		}
+	}
+
+	/**
+	 * Specialization of {@link #doInPG(Supplier) doInPG} for operations that
+	 * return a long result. This method need not be present: without it, the
+	 * Java compiler will happily match int lambdas or method references to
+	 * the generic method, at the small cost of some boxing/unboxing; providing
+	 * this method simply allows that to be avoided.
+	 */
+	public static <E extends Throwable> long doInPG(Checked.LongSupplier<E> op)
+	throws E
+	{
+		synchronized(THREADLOCK)
+		{
+			return op.getAsLong();
+		}
 	}
 
 	/**

--- a/pljava/src/main/java/org/postgresql/pljava/internal/Checked.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/Checked.java
@@ -1,0 +1,1194 @@
+/*
+ * Copyright (c) 2020 Tada AB and other contributors, as listed below.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Chapman Flack
+ */
+package org.postgresql.pljava.internal;
+
+import java.util.NoSuchElementException;
+
+/**
+ * Functional interfaces handling checked exceptions.
+ *<p>
+ * It would be ideal if the compiler could preserve its union of possible
+ * thrown types as the inferred exception type of the functional interface
+ * method. Instead, it collapses the union to the nearest common supertype,
+ * which is less useful, as it becomes {@code Exception} rather quickly if
+ * the lambda can throw a few unrelated exceptions. It is still useful for
+ * short lambdas that throw only a few related exceptions.
+ *<p>
+ * Also, the Java API lacks primitive
+ * {@code Consumer}/{@code Supplier}/{@code Optional} types for {@code byte},
+ * {@code short}, {@code char}, {@code float}, and some of them for
+ * {@code boolean}. To allow a more orthogonal API for access to datum values,
+ * those are provided here, again supporting checked exceptions. Because these
+ * "bonus" types do not have checked-exception-less counterparts in the Java
+ * API, they have no need for the wrapper methods described next.
+ *<p>
+ * For interoperating with Java APIs that require the Java no-checked-exceptions
+ * versions of these interfaces, each checked interface here (for which a Java
+ * API no-checked version exists) has an {@code ederWrap} method that produces
+ * the Java no-checked version of the same interface, using a lightweight idiom
+ * advanced by Lukas Eder, developer of jOOλ. The checked exception is not
+ * wrapped, but simply flown under {@code javac}'s radar. That idiom is extended
+ * here with a corresponding {@code ederUnwrap} method to produce a checked
+ * interface again, re-exposing the checked exception type. That makes possible
+ * constructions like:
+ *
+ *<pre>
+ * Stream<String> strs = ...;
+ * Writer w = ...;
+ * var c = Checked.Consumer.of((String s) -> w.write(s)); // throws IOException!
+ * try {
+ *   c.ederUnwrap(() -> strs.forEach(c.ederWrap())).run();
+ * }
+ * catch ( IOException e ) { ... }
+ *</pre>
+ *
+ * where the {@code Stream.forEach} method requires a Java {@code Consumer}
+ * that declares no checked exceptions.
+ *<p>
+ * Such an idiom is, of course, contrary to an <a
+href='https://wiki.sei.cmu.edu/confluence/display/java/ERR06-J.+Do+not+throw+undeclared+checked+exceptions'
+>SEI CERT coding standard</a>,
+ * and likely to produce surprises if the exception will be 'flown' through deep
+ * layers of code by others that may contain {@code catch} blocks. That said, as
+ * a convenience for dealing with checked exceptions and simple Java APIs that
+ * cannot accept them, it can be useful as long as the intervening code between
+ * {@code ederWrap} and {@code ederUnwrap} is simple and short.
+ *<p>
+ * Static {@code composed()} methods are provided here in place of the instance
+ * {@code compose} or {@code andThen} methods in Java's function API, which seem
+ * to challenge {@code javac}'s type inference when exception types are thrown
+ * in. A static {@code composed} method can substitute for {@code compose} or
+ * {@code andThen}, by ordering the parameters as desired.
+ */
+public interface Checked<WT, EX extends Throwable>
+{
+	@SuppressWarnings("unchecked")
+	static <E extends Throwable> E ederThrow(Throwable t) throws E
+	{
+		throw (E) t;
+	}
+
+	WT ederWrap();
+
+	/*
+	 * ederUnwrap() methods.
+	 */
+
+	default <RT> Supplier<RT,EX> ederUnwrap(java.util.function.Supplier<RT> s)
+	{
+		return () -> s.get();
+	}
+
+	default Runnable<EX> ederUnwrap(java.lang.Runnable r)
+	{
+		return () -> r.run();
+	}
+
+	default BooleanSupplier<EX> ederUnwrap(java.util.function.BooleanSupplier s)
+	{
+		return () -> s.getAsBoolean();
+	}
+
+	default DoubleSupplier<EX> ederUnwrap(java.util.function.DoubleSupplier s)
+	{
+		return () -> s.getAsDouble();
+	}
+
+	default IntSupplier<EX> ederUnwrap(java.util.function.IntSupplier s)
+	{
+		return () -> s.getAsInt();
+	}
+
+	default LongSupplier<EX> ederUnwrap(java.util.function.LongSupplier s)
+	{
+		return () -> s.getAsLong();
+	}
+
+	default <T,R> Function<T,R,EX> ederUnwrap(
+		java.util.function.Function<T,R> f)
+	{
+		return (v) -> f.apply(v);
+	}
+
+	default <T> Consumer<T,EX> ederUnwrap(java.util.function.Consumer<T> c)
+	{
+		return (v) -> c.accept(v);
+	}
+
+	default DoubleConsumer<EX> ederUnwrap(java.util.function.DoubleConsumer c)
+	{
+		return (v) -> c.accept(v);
+	}
+
+	default IntConsumer<EX> ederUnwrap(java.util.function.IntConsumer c)
+	{
+		return (v) -> c.accept(v);
+	}
+
+	default LongConsumer<EX> ederUnwrap(java.util.function.LongConsumer c)
+	{
+		return (v) -> c.accept(v);
+	}
+
+	/*
+	 * composed() methods.
+	 */
+
+	static <T, R, V, E extends Throwable>
+		Function<T,R,E> composed(
+			Function<? super T, ? extends V, ? extends E> first,
+			Function<? super V, ? extends R, ? extends E> after)
+	{
+		return t -> after.apply(first.apply(t));
+	}
+
+	static <T, E extends Throwable>
+		Consumer<T,E> composed(
+			Consumer<? super T, ? extends E> first,
+			Consumer<? super T, ? extends E> after)
+	{
+		return t ->
+		{
+			first.accept(t);
+			after.accept(t);
+		};
+	}
+
+	static <E extends Throwable>
+		DoubleConsumer<E> composed(
+			DoubleConsumer<? extends E> first,
+			DoubleConsumer<? extends E> after)
+	{
+		return t ->
+		{
+			first.accept(t);
+			after.accept(t);
+		};
+	}
+
+	static <E extends Throwable>
+		IntConsumer<E> composed(
+			IntConsumer<? extends E> first,
+			IntConsumer<? extends E> after)
+	{
+		return t ->
+		{
+			first.accept(t);
+			after.accept(t);
+		};
+	}
+
+	static <E extends Throwable>
+		LongConsumer<E> composed(
+			LongConsumer<? extends E> first,
+			LongConsumer<? extends E> after)
+	{
+		return t ->
+		{
+			first.accept(t);
+			after.accept(t);
+		};
+	}
+
+	/*
+	 * Runnable.
+	 */
+
+	@FunctionalInterface
+	interface Runnable<E extends Throwable>
+	extends Checked<java.lang.Runnable, E>
+	{
+		void run() throws E;
+
+		@Override
+		default java.lang.Runnable ederWrap()
+		{
+			return () ->
+			{
+				try
+				{
+					run();
+				}
+				catch ( Throwable t )
+				{
+					throw Checked.<RuntimeException>ederThrow(t);
+				}
+			};
+		}
+	}
+
+	/*
+	 * Suppliers that have checked-exception-less counterparts in the Java API.
+	 */
+
+	@FunctionalInterface
+	interface Supplier<T, E extends Throwable>
+	extends Checked<java.util.function.Supplier<T>, E>
+	{
+		T get() throws E;
+
+		@Override
+		default java.util.function.Supplier<T> ederWrap()
+		{
+			return () ->
+			{
+				try
+				{
+					return get();
+				}
+				catch ( Throwable t )
+				{
+					throw Checked.<RuntimeException>ederThrow(t);
+				}
+			};
+		}
+	}
+
+	@FunctionalInterface
+	interface BooleanSupplier<E extends Throwable>
+	extends Checked<java.util.function.BooleanSupplier, E>
+	{
+		boolean getAsBoolean() throws E;
+
+		@Override
+		default java.util.function.BooleanSupplier ederWrap()
+		{
+			return () ->
+			{
+				try
+				{
+					return getAsBoolean();
+				}
+				catch ( Throwable t )
+				{
+					throw Checked.<RuntimeException>ederThrow(t);
+				}
+			};
+		}
+	}
+
+	@FunctionalInterface
+	interface DoubleSupplier<E extends Throwable>
+	extends Checked<java.util.function.DoubleSupplier, E>
+	{
+		double getAsDouble() throws E;
+
+		@Override
+		default java.util.function.DoubleSupplier ederWrap()
+		{
+			return () ->
+			{
+				try
+				{
+					return getAsDouble();
+				}
+				catch ( Throwable t )
+				{
+					throw Checked.<RuntimeException>ederThrow(t);
+				}
+			};
+		}
+	}
+
+	@FunctionalInterface
+	interface IntSupplier<E extends Throwable>
+	extends Checked<java.util.function.IntSupplier, E>
+	{
+		int getAsInt() throws E;
+
+		@Override
+		default java.util.function.IntSupplier ederWrap()
+		{
+			return () ->
+			{
+				try
+				{
+					return getAsInt();
+				}
+				catch ( Throwable t )
+				{
+					throw Checked.<RuntimeException>ederThrow(t);
+				}
+			};
+		}
+	}
+
+	@FunctionalInterface
+	interface LongSupplier<E extends Throwable>
+	extends Checked<java.util.function.LongSupplier, E>
+	{
+		long getAsLong() throws E;
+
+		@Override
+		default java.util.function.LongSupplier ederWrap()
+		{
+			return () ->
+			{
+				try
+				{
+					return getAsLong();
+				}
+				catch ( Throwable t )
+				{
+					throw Checked.<RuntimeException>ederThrow(t);
+				}
+			};
+		}
+	}
+
+	/*
+	 * Suppliers without checked-exception-less Java API counterparts.
+	 */
+
+	@FunctionalInterface
+	interface ByteSupplier<E extends Throwable>
+	{
+		byte getAsByte() throws E;
+	}
+
+	@FunctionalInterface
+	interface ShortSupplier<E extends Throwable>
+	{
+		short getAsShort() throws E;
+	}
+
+	@FunctionalInterface
+	interface CharSupplier<E extends Throwable>
+	{
+		char getAsChar() throws E;
+	}
+
+	@FunctionalInterface
+	interface FloatSupplier<E extends Throwable>
+	{
+		float getAsFloat() throws E;
+	}
+
+	/*
+	 * Functions that have checked-exception-less counterparts in the Java API.
+	 */
+
+	@FunctionalInterface
+	interface Function<T,R,E extends Throwable>
+	extends Checked<java.util.function.Function<T,R>, E>
+	{
+		R apply(T t) throws E;
+
+		@Override
+		default java.util.function.Function<T,R> ederWrap()
+		{
+			return (t) ->
+			{
+				try
+				{
+					return apply(t);
+				}
+				catch ( Throwable thw )
+				{
+					throw Checked.<RuntimeException>ederThrow(thw);
+				}
+			};
+		}
+
+		static <T, R, E extends Throwable>
+			Function<T,R,E> of(Function<T,R,E> f)
+		{
+			return f;
+		}
+	}
+
+	/*
+	 * Consumers that have checked-exception-less counterparts in the Java API.
+	 */
+
+	@FunctionalInterface
+	interface Consumer<T,E extends Throwable>
+	extends Checked<java.util.function.Consumer<T>, E>
+	{
+		void accept(T t) throws E;
+
+		@Override
+		default java.util.function.Consumer<T> ederWrap()
+		{
+			return (t) ->
+			{
+				try
+				{
+					accept(t);
+				}
+				catch ( Throwable thw )
+				{
+					throw Checked.<RuntimeException>ederThrow(thw);
+				}
+			};
+		}
+
+		static <T, E extends Throwable>
+			Consumer<T,E> of(Consumer<T,E> c)
+		{
+			return c;
+		}
+	}
+
+	@FunctionalInterface
+	interface DoubleConsumer<E extends Throwable>
+	extends Checked<java.util.function.DoubleConsumer, E>
+	{
+		void accept(double value) throws E;
+
+		@Override
+		default java.util.function.DoubleConsumer ederWrap()
+		{
+			return (t) ->
+			{
+				try
+				{
+					accept(t);
+				}
+				catch ( Throwable thw )
+				{
+					throw Checked.<RuntimeException>ederThrow(thw);
+				}
+			};
+		}
+
+		static <E extends Throwable>
+			DoubleConsumer<E> of(DoubleConsumer<E> c)
+		{
+			return c;
+		}
+	}
+
+	@FunctionalInterface
+	interface IntConsumer<E extends Throwable>
+	extends Checked<java.util.function.IntConsumer, E>
+	{
+		void accept(int value) throws E;
+
+		@Override
+		default java.util.function.IntConsumer ederWrap()
+		{
+			return (t) ->
+			{
+				try
+				{
+					accept(t);
+				}
+				catch ( Throwable thw )
+				{
+					throw Checked.<RuntimeException>ederThrow(thw);
+				}
+			};
+		}
+
+		static <E extends Throwable>
+			IntConsumer<E> of(IntConsumer<E> c)
+		{
+			return c;
+		}
+	}
+
+	@FunctionalInterface
+	interface LongConsumer<E extends Throwable>
+	extends Checked<java.util.function.LongConsumer, E>
+	{
+		void accept(long value) throws E;
+
+		@Override
+		default java.util.function.LongConsumer ederWrap()
+		{
+			return (t) ->
+			{
+				try
+				{
+					accept(t);
+				}
+				catch ( Throwable thw )
+				{
+					throw Checked.<RuntimeException>ederThrow(thw);
+				}
+			};
+		}
+
+		static <E extends Throwable>
+			LongConsumer<E> of(LongConsumer<E> c)
+		{
+			return c;
+		}
+	}
+
+	/*
+	 * Consumers without checked-exception-less counterparts in the Java API.
+	 */
+
+	@FunctionalInterface
+	interface BooleanConsumer<E extends Throwable>
+	{
+		void accept(boolean value) throws E;
+	}
+
+	@FunctionalInterface
+	interface ByteConsumer<E extends Throwable>
+	{
+		void accept(byte value) throws E;
+	}
+
+	@FunctionalInterface
+	interface ShortConsumer<E extends Throwable>
+	{
+		void accept(short value) throws E;
+	}
+
+	@FunctionalInterface
+	interface CharConsumer<E extends Throwable>
+	{
+		void accept(char value) throws E;
+	}
+
+	@FunctionalInterface
+	interface FloatConsumer<E extends Throwable>
+	{
+		void accept(float value) throws E;
+	}
+
+	/*
+	 * Optionals without checked-exception-less counterparts in the Java API.
+	 */
+
+	abstract class OptionalBase
+	{
+		public boolean isPresent()
+		{
+			return false;
+		}
+
+		@Override
+		public String toString()
+		{
+			return getClass().getSimpleName() + ".empty";
+		}
+	}
+
+	class OptionalBoolean extends OptionalBase
+	{
+		public static final OptionalBoolean EMPTY = new OptionalBoolean();
+		public static final OptionalBoolean FALSE = new False();
+		public static final OptionalBoolean TRUE  = new True();
+
+		private OptionalBoolean()
+		{
+		}
+
+		public static OptionalBoolean of(boolean value)
+		{
+			return value ? TRUE : FALSE;
+		}
+
+		public boolean getAsBoolean()
+		{
+			throw new NoSuchElementException("No value present");
+		}
+
+		public <E extends Throwable> void ifPresent(
+			BooleanConsumer<? extends E> action)
+		throws E
+		{
+		}
+
+		public <E extends Throwable> void ifPresentOrElse(
+			BooleanConsumer<? extends E> action,
+			Runnable<? extends E> emptyAction)
+		throws E
+		{
+			emptyAction.run();
+		}
+
+		public boolean orElse(boolean other)
+		{
+			return other;
+		}
+
+		public <E extends Throwable> boolean orElseGet(
+			BooleanSupplier<? extends E> supplier)
+		throws E
+		{
+			return supplier.getAsBoolean();
+		}
+
+		public <E extends Throwable> boolean orElseThrow(
+			Supplier<? extends E, ? extends E> exceptionSupplier)
+		throws E
+		{
+			throw exceptionSupplier.get();
+		}
+
+		private abstract static class Present extends OptionalBoolean
+		{
+			private Present()
+			{
+			}
+
+			@Override
+			public boolean isPresent()
+			{
+				return true;
+			}
+
+			@Override
+			public String toString()
+			{
+				return "OptionalBoolean[" + getAsBoolean() + ']';
+			}
+
+			@Override
+			public abstract boolean getAsBoolean();
+
+			@Override
+			public <E extends Throwable> void ifPresent(
+				BooleanConsumer<? extends E> action)
+			throws E
+			{
+				action.accept(getAsBoolean());
+			}
+
+			@Override
+			public <E extends Throwable> void ifPresentOrElse(
+				BooleanConsumer<? extends E> action,
+				Runnable<? extends E> emptyAction)
+			throws E
+			{
+				action.accept(getAsBoolean());
+			}
+
+			@Override
+			public boolean orElse(boolean other)
+			{
+				return getAsBoolean();
+			}
+
+			@Override
+			public <E extends Throwable> boolean orElseGet(
+				BooleanSupplier<? extends E> supplier)
+			throws E
+			{
+				return getAsBoolean();
+			}
+
+			@Override
+			public <E extends Throwable> boolean orElseThrow(
+				Supplier<? extends E, ? extends E> exceptionSupplier)
+			throws E
+			{
+				return getAsBoolean();
+			}
+		}
+
+		private static final class False extends Present
+		{
+			private False()
+			{
+			}
+
+			@Override
+			public boolean getAsBoolean()
+			{
+				return false;
+			}
+		}
+
+		private static final class True extends Present
+		{
+			private True()
+			{
+			}
+
+			@Override
+			public boolean getAsBoolean()
+			{
+				return true;
+			}
+		}
+	}
+
+	class OptionalByte extends OptionalBase
+	{
+		public static final OptionalByte EMPTY = new OptionalByte();
+
+		private OptionalByte()
+		{
+		}
+
+		public static OptionalByte of(byte value)
+		{
+			return new Present(value);
+		}
+
+		public byte getAsByte()
+		{
+			throw new NoSuchElementException("No value present");
+		}
+
+		public <E extends Throwable> void ifPresent(
+			ByteConsumer<? extends E> action)
+		throws E
+		{
+		}
+
+		public <E extends Throwable> void ifPresentOrElse(
+			ByteConsumer<? extends E> action, Runnable<? extends E> emptyAction)
+		throws E
+		{
+			emptyAction.run();
+		}
+
+		public byte orElse(byte other)
+		{
+			return other;
+		}
+
+		public <E extends Throwable> byte orElseGet(
+			ByteSupplier<? extends E> supplier)
+		throws E
+		{
+			return supplier.getAsByte();
+		}
+
+		public <E extends Throwable> byte orElseThrow(
+			Supplier<? extends E, ? extends E> exceptionSupplier)
+		throws E
+		{
+			throw exceptionSupplier.get();
+		}
+
+		private static final class Present extends OptionalByte
+		{
+			private final byte m_value;
+
+			private Present(byte value)
+			{
+				m_value = value;
+			}
+
+			@Override
+			public boolean isPresent()
+			{
+				return true;
+			}
+
+			@Override
+			public String toString()
+			{
+				return "OptionalByte[" + m_value + ']';
+			}
+
+			@Override
+			public byte getAsByte()
+			{
+				return m_value;
+			}
+
+			@Override
+			public <E extends Throwable> void ifPresent(
+				ByteConsumer<? extends E> action)
+			throws E
+			{
+				action.accept(m_value);
+			}
+
+			@Override
+			public <E extends Throwable> void ifPresentOrElse(
+				ByteConsumer<? extends E> action,
+				Runnable<? extends E> emptyAction)
+			throws E
+			{
+				action.accept(m_value);
+			}
+
+			@Override
+			public byte orElse(byte other)
+			{
+				return m_value;
+			}
+
+			@Override
+			public <E extends Throwable> byte orElseGet(
+				ByteSupplier<? extends E> supplier)
+			throws E
+			{
+				return m_value;
+			}
+
+			@Override
+			public <E extends Throwable> byte orElseThrow(
+				Supplier<? extends E, ? extends E> exceptionSupplier)
+			throws E
+			{
+				return m_value;
+			}
+		}
+	}
+
+	class OptionalShort extends OptionalBase
+	{
+		public static final OptionalShort EMPTY = new OptionalShort();
+
+		private OptionalShort()
+		{
+		}
+
+		public static OptionalShort of(short value)
+		{
+			return new Present(value);
+		}
+
+		public short getAsShort()
+		{
+			throw new NoSuchElementException("No value present");
+		}
+
+		public <E extends Throwable> void ifPresent(
+			ShortConsumer<? extends E> action)
+		throws E
+		{
+		}
+
+		public <E extends Throwable> void ifPresentOrElse(
+			ShortConsumer<? extends E> action,
+			Runnable<? extends E> emptyAction)
+		throws E
+		{
+			emptyAction.run();
+		}
+
+		public short orElse(short other)
+		{
+			return other;
+		}
+
+		public <E extends Throwable> short orElseGet(
+			ShortSupplier<? extends E> supplier)
+		throws E
+		{
+			return supplier.getAsShort();
+		}
+
+		public <E extends Throwable> short orElseThrow(
+			Supplier<? extends E, ? extends E> exceptionSupplier)
+		throws E
+		{
+			throw exceptionSupplier.get();
+		}
+
+		private static final class Present extends OptionalShort
+		{
+			private final short m_value;
+
+			private Present(short value)
+			{
+				m_value = value;
+			}
+
+			@Override
+			public boolean isPresent()
+			{
+				return true;
+			}
+
+			@Override
+			public String toString()
+			{
+				return "OptionalShort[" + m_value + ']';
+			}
+
+			@Override
+			public short getAsShort()
+			{
+				return m_value;
+			}
+
+			@Override
+			public <E extends Throwable> void ifPresent(
+				ShortConsumer<? extends E> action)
+			throws E
+			{
+				action.accept(m_value);
+			}
+
+			@Override
+			public <E extends Throwable> void ifPresentOrElse(
+				ShortConsumer<? extends E> action,
+				Runnable<? extends E> emptyAction)
+			throws E
+			{
+				action.accept(m_value);
+			}
+
+			@Override
+			public short orElse(short other)
+			{
+				return m_value;
+			}
+
+			@Override
+			public <E extends Throwable> short orElseGet(
+				ShortSupplier<? extends E> supplier)
+			throws E
+			{
+				return m_value;
+			}
+
+			@Override
+			public <E extends Throwable> short orElseThrow(
+				Supplier<? extends E, ? extends E> exceptionSupplier)
+			throws E
+			{
+				return m_value;
+			}
+		}
+	}
+
+	class OptionalChar extends OptionalBase
+	{
+		public static final OptionalChar EMPTY = new OptionalChar();
+
+		private OptionalChar()
+		{
+		}
+
+		public static OptionalChar of(char value)
+		{
+			return new Present(value);
+		}
+
+		public char getAsChar()
+		{
+			throw new NoSuchElementException("No value present");
+		}
+
+		public <E extends Throwable> void ifPresent(
+			CharConsumer<? extends E> action)
+		throws E
+		{
+		}
+
+		public <E extends Throwable> void ifPresentOrElse(
+			CharConsumer<? extends E> action, Runnable<? extends E> emptyAction)
+		throws E
+		{
+			emptyAction.run();
+		}
+
+		public char orElse(char other)
+		{
+			return other;
+		}
+
+		public <E extends Throwable> char orElseGet(
+			CharSupplier<? extends E> supplier)
+		throws E
+		{
+			return supplier.getAsChar();
+		}
+
+		public <E extends Throwable> char orElseThrow(
+			Supplier<? extends E, ? extends E> exceptionSupplier)
+		throws E
+		{
+			throw exceptionSupplier.get();
+		}
+
+		private static final class Present extends OptionalChar
+		{
+			private final char m_value;
+
+			private Present(char value)
+			{
+				m_value = value;
+			}
+
+			@Override
+			public boolean isPresent()
+			{
+				return true;
+			}
+
+			@Override
+			public String toString()
+			{
+				return "OptionalChar[" + (int)m_value + ']';
+			}
+
+			@Override
+			public char getAsChar()
+			{
+				return m_value;
+			}
+
+			@Override
+			public <E extends Throwable> void ifPresent(
+				CharConsumer<? extends E> action)
+			throws E
+			{
+				action.accept(m_value);
+			}
+
+			@Override
+			public <E extends Throwable> void ifPresentOrElse(
+				CharConsumer<? extends E> action,
+				Runnable<? extends E> emptyAction)
+			throws E
+			{
+				action.accept(m_value);
+			}
+
+			@Override
+			public char orElse(char other)
+			{
+				return m_value;
+			}
+
+			@Override
+			public <E extends Throwable> char orElseGet(
+				CharSupplier<? extends E> supplier)
+			throws E
+			{
+				return m_value;
+			}
+
+			@Override
+			public <E extends Throwable> char orElseThrow(
+				Supplier<? extends E, ? extends E> exceptionSupplier)
+			throws E
+			{
+				return m_value;
+			}
+		}
+	}
+
+	class OptionalFloat extends OptionalBase
+	{
+		public static final OptionalFloat EMPTY = new OptionalFloat();
+
+		private OptionalFloat()
+		{
+		}
+
+		public static OptionalFloat of(float value)
+		{
+			return new Present(value);
+		}
+
+		public float getAsFloat()
+		{
+			throw new NoSuchElementException("No value present");
+		}
+
+		public <E extends Throwable> void ifPresent(
+			FloatConsumer<? extends E> action)
+		throws E
+		{
+		}
+
+		public <E extends Throwable> void ifPresentOrElse(
+			FloatConsumer<? extends E> action, Runnable<? extends E> emptyAction)
+		throws E
+		{
+			emptyAction.run();
+		}
+
+		public float orElse(float other)
+		{
+			return other;
+		}
+
+		public <E extends Throwable> float orElseGet(
+			FloatSupplier<? extends E> supplier)
+		throws E
+		{
+			return supplier.getAsFloat();
+		}
+
+		public <E extends Throwable> float orElseThrow(
+			Supplier<? extends E, ? extends E> exceptionSupplier)
+		throws E
+		{
+			throw exceptionSupplier.get();
+		}
+
+		private static final class Present extends OptionalFloat
+		{
+			private final float m_value;
+
+			private Present(float value)
+			{
+				m_value = value;
+			}
+
+			@Override
+			public boolean isPresent()
+			{
+				return true;
+			}
+
+			@Override
+			public String toString()
+			{
+				return "OptionalFloat[" + m_value + ']';
+			}
+
+			@Override
+			public float getAsFloat()
+			{
+				return m_value;
+			}
+
+			@Override
+			public <E extends Throwable> void ifPresent(
+				FloatConsumer<? extends E> action)
+			throws E
+			{
+				action.accept(m_value);
+			}
+
+			@Override
+			public <E extends Throwable> void ifPresentOrElse(
+				FloatConsumer<? extends E> action,
+				Runnable<? extends E> emptyAction)
+			throws E
+			{
+				action.accept(m_value);
+			}
+
+			@Override
+			public float orElse(float other)
+			{
+				return m_value;
+			}
+
+			@Override
+			public <E extends Throwable> float orElseGet(
+				FloatSupplier<? extends E> supplier)
+			throws E
+			{
+				return m_value;
+			}
+
+			@Override
+			public <E extends Throwable> float orElseThrow(
+				Supplier<? extends E, ? extends E> exceptionSupplier)
+			throws E
+			{
+				return m_value;
+			}
+		}
+	}
+}

--- a/pljava/src/main/java/org/postgresql/pljava/internal/Checked.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/Checked.java
@@ -68,6 +68,10 @@ href='https://wiki.sei.cmu.edu/confluence/display/java/ERR06-J.+Do+not+throw+und
  * to challenge {@code javac}'s type inference when exception types are thrown
  * in. A static {@code composed} method can substitute for {@code compose} or
  * {@code andThen}, by ordering the parameters as desired.
+ *<p>
+ * Each functional interface declared here has a static {@code of(...)} method
+ * that can be used, as a concise alternative to casting, to constrain the type
+ * of a lambda expression when the compiler won't infer it.
  */
 public interface Checked<WT, EX extends Throwable>
 {
@@ -80,7 +84,7 @@ public interface Checked<WT, EX extends Throwable>
 	WT ederWrap();
 
 	/*
-	 * ederUnwrap() methods.
+	 * ederUnwrap() methods, overloaded for all the types that can be wrapped.
 	 */
 
 	default <RT> Supplier<RT,EX> ederUnwrap(java.util.function.Supplier<RT> s)
@@ -224,6 +228,11 @@ public interface Checked<WT, EX extends Throwable>
 				}
 			};
 		}
+
+		static <E extends Throwable> Runnable<E> of(Runnable<E> o)
+		{
+			return o;
+		}
 	}
 
 	/*
@@ -251,6 +260,11 @@ public interface Checked<WT, EX extends Throwable>
 				}
 			};
 		}
+
+		static <T, E extends Throwable> Supplier<T,E> of(Supplier<T,E> o)
+		{
+			return o;
+		}
 	}
 
 	@FunctionalInterface
@@ -273,6 +287,11 @@ public interface Checked<WT, EX extends Throwable>
 					throw Checked.<RuntimeException>ederThrow(t);
 				}
 			};
+		}
+
+		static <E extends Throwable> BooleanSupplier<E> of(BooleanSupplier<E> o)
+		{
+			return o;
 		}
 	}
 
@@ -297,6 +316,11 @@ public interface Checked<WT, EX extends Throwable>
 				}
 			};
 		}
+
+		static <E extends Throwable> DoubleSupplier<E> of(DoubleSupplier<E> o)
+		{
+			return o;
+		}
 	}
 
 	@FunctionalInterface
@@ -319,6 +343,11 @@ public interface Checked<WT, EX extends Throwable>
 					throw Checked.<RuntimeException>ederThrow(t);
 				}
 			};
+		}
+
+		static <E extends Throwable> IntSupplier<E> of(IntSupplier<E> o)
+		{
+			return o;
 		}
 	}
 
@@ -343,6 +372,11 @@ public interface Checked<WT, EX extends Throwable>
 				}
 			};
 		}
+
+		static <E extends Throwable> LongSupplier<E> of(LongSupplier<E> o)
+		{
+			return o;
+		}
 	}
 
 	/*
@@ -353,24 +387,44 @@ public interface Checked<WT, EX extends Throwable>
 	interface ByteSupplier<E extends Throwable>
 	{
 		byte getAsByte() throws E;
+
+		static <E extends Throwable> ByteSupplier<E> of(ByteSupplier<E> o)
+		{
+			return o;
+		}
 	}
 
 	@FunctionalInterface
 	interface ShortSupplier<E extends Throwable>
 	{
 		short getAsShort() throws E;
+
+		static <E extends Throwable> ShortSupplier<E> of(ShortSupplier<E> o)
+		{
+			return o;
+		}
 	}
 
 	@FunctionalInterface
 	interface CharSupplier<E extends Throwable>
 	{
 		char getAsChar() throws E;
+
+		static <E extends Throwable> CharSupplier<E> of(CharSupplier<E> o)
+		{
+			return o;
+		}
 	}
 
 	@FunctionalInterface
 	interface FloatSupplier<E extends Throwable>
 	{
 		float getAsFloat() throws E;
+
+		static <E extends Throwable> FloatSupplier<E> of(FloatSupplier<E> o)
+		{
+			return o;
+		}
 	}
 
 	/*
@@ -399,10 +453,9 @@ public interface Checked<WT, EX extends Throwable>
 			};
 		}
 
-		static <T, R, E extends Throwable>
-			Function<T,R,E> of(Function<T,R,E> f)
+		static <T, R, E extends Throwable> Function<T,R,E> of(Function<T,R,E> o)
 		{
-			return f;
+			return o;
 		}
 	}
 
@@ -432,10 +485,9 @@ public interface Checked<WT, EX extends Throwable>
 			};
 		}
 
-		static <T, E extends Throwable>
-			Consumer<T,E> of(Consumer<T,E> c)
+		static <T, E extends Throwable> Consumer<T,E> of(Consumer<T,E> o)
 		{
-			return c;
+			return o;
 		}
 	}
 
@@ -461,10 +513,9 @@ public interface Checked<WT, EX extends Throwable>
 			};
 		}
 
-		static <E extends Throwable>
-			DoubleConsumer<E> of(DoubleConsumer<E> c)
+		static <E extends Throwable> DoubleConsumer<E> of(DoubleConsumer<E> o)
 		{
-			return c;
+			return o;
 		}
 	}
 
@@ -490,10 +541,9 @@ public interface Checked<WT, EX extends Throwable>
 			};
 		}
 
-		static <E extends Throwable>
-			IntConsumer<E> of(IntConsumer<E> c)
+		static <E extends Throwable> IntConsumer<E> of(IntConsumer<E> o)
 		{
-			return c;
+			return o;
 		}
 	}
 
@@ -519,10 +569,9 @@ public interface Checked<WT, EX extends Throwable>
 			};
 		}
 
-		static <E extends Throwable>
-			LongConsumer<E> of(LongConsumer<E> c)
+		static <E extends Throwable> LongConsumer<E> of(LongConsumer<E> o)
 		{
-			return c;
+			return o;
 		}
 	}
 
@@ -534,30 +583,55 @@ public interface Checked<WT, EX extends Throwable>
 	interface BooleanConsumer<E extends Throwable>
 	{
 		void accept(boolean value) throws E;
+
+		static <E extends Throwable> BooleanConsumer<E> of(BooleanConsumer<E> o)
+		{
+			return o;
+		}
 	}
 
 	@FunctionalInterface
 	interface ByteConsumer<E extends Throwable>
 	{
 		void accept(byte value) throws E;
+
+		static <E extends Throwable> ByteConsumer<E> of(ByteConsumer<E> o)
+		{
+			return o;
+		}
 	}
 
 	@FunctionalInterface
 	interface ShortConsumer<E extends Throwable>
 	{
 		void accept(short value) throws E;
+
+		static <E extends Throwable> ShortConsumer<E> of(ShortConsumer<E> o)
+		{
+			return o;
+		}
 	}
 
 	@FunctionalInterface
 	interface CharConsumer<E extends Throwable>
 	{
 		void accept(char value) throws E;
+
+		static <E extends Throwable> CharConsumer<E> of(CharConsumer<E> o)
+		{
+			return o;
+		}
 	}
 
 	@FunctionalInterface
 	interface FloatConsumer<E extends Throwable>
 	{
 		void accept(float value) throws E;
+
+		static <E extends Throwable> FloatConsumer<E> of(FloatConsumer<E> o)
+		{
+			return o;
+		}
 	}
 
 	/*

--- a/pljava/src/main/java/org/postgresql/pljava/internal/ErrorData.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/ErrorData.java
@@ -12,6 +12,8 @@
  */
 package org.postgresql.pljava.internal;
 
+import static org.postgresql.pljava.internal.Backend.doInPG;
+
 import java.lang.reflect.UndeclaredThrowableException;
 import java.sql.SQLException;
 
@@ -89,10 +91,7 @@ public class ErrorData
 	 */
 	public int getErrorLevel()
 	{
-		synchronized(Backend.THREADLOCK)
-		{
-			return _getErrorLevel(this.getNativePointer());
-		}
+		return doInPG(() -> _getErrorLevel(this.getNativePointer()));
 	}
 
 	/**
@@ -100,10 +99,7 @@ public class ErrorData
 	 */
 	public boolean isOutputToServer()
 	{
-		synchronized(Backend.THREADLOCK)
-		{
-			return _isOutputToServer(this.getNativePointer());
-		}
+		return doInPG(() -> _isOutputToServer(this.getNativePointer()));
 	}
 
 	/**
@@ -111,10 +107,7 @@ public class ErrorData
 	 */
 	public boolean isOutputToClient()
 	{
-		synchronized(Backend.THREADLOCK)
-		{
-			return _isOutputToClient(this.getNativePointer());
-		}
+		return doInPG(() -> _isOutputToClient(this.getNativePointer()));
 	}
 
 	/**
@@ -122,10 +115,7 @@ public class ErrorData
 	 */
 	public boolean isShowFuncname()
 	{
-		synchronized(Backend.THREADLOCK)
-		{
-			return _isShowFuncname(this.getNativePointer());
-		}
+		return doInPG(() -> _isShowFuncname(this.getNativePointer()));
 	}
 
 	/**
@@ -133,10 +123,7 @@ public class ErrorData
 	 */
 	public String getFilename()
 	{
-		synchronized(Backend.THREADLOCK)
-		{
-			return _getFilename(this.getNativePointer());
-		}
+		return doInPG(() -> _getFilename(this.getNativePointer()));
 	}
 
 	/**
@@ -144,10 +131,7 @@ public class ErrorData
 	 */
 	public int getLineno()
 	{
-		synchronized(Backend.THREADLOCK)
-		{
-			return _getLineno(this.getNativePointer());
-		}
+		return doInPG(() -> _getLineno(this.getNativePointer()));
 	}
 
 	/**
@@ -155,10 +139,7 @@ public class ErrorData
 	 */
 	public String getFuncname()
 	{
-		synchronized(Backend.THREADLOCK)
-		{
-			return _getFuncname(this.getNativePointer());
-		}
+		return doInPG(() -> _getFuncname(this.getNativePointer()));
 	}
 
 	/**
@@ -166,10 +147,7 @@ public class ErrorData
 	 */
 	public String getSqlState()
 	{
-		synchronized(Backend.THREADLOCK)
-		{
-			return _getSqlState(this.getNativePointer());
-		}
+		return doInPG(() -> _getSqlState(this.getNativePointer()));
 	}
 
 	/**
@@ -177,10 +155,7 @@ public class ErrorData
 	 */
 	public String getMessage()
 	{
-		synchronized(Backend.THREADLOCK)
-		{
-			return _getMessage(this.getNativePointer());
-		}
+		return doInPG(() -> _getMessage(this.getNativePointer()));
 	}
 	
 	/**
@@ -188,10 +163,7 @@ public class ErrorData
 	 */
 	public String getDetail()
 	{
-		synchronized(Backend.THREADLOCK)
-		{
-			return _getDetail(this.getNativePointer());
-		}
+		return doInPG(() -> _getDetail(this.getNativePointer()));
 	}
 	
 	/**
@@ -199,10 +171,7 @@ public class ErrorData
 	 */
 	public String getHint()
 	{
-		synchronized(Backend.THREADLOCK)
-		{
-			return _getHint(this.getNativePointer());
-		}
+		return doInPG(() -> _getHint(this.getNativePointer()));
 	}
 	
 	/**
@@ -210,10 +179,7 @@ public class ErrorData
 	 */
 	public String getContextMessage()
 	{
-		synchronized(Backend.THREADLOCK)
-		{
-			return _getContextMessage(this.getNativePointer());
-		}
+		return doInPG(() -> _getContextMessage(this.getNativePointer()));
 	}
 	
 	/**
@@ -221,10 +187,7 @@ public class ErrorData
 	 */
 	public int getCursorPos()
 	{
-		synchronized(Backend.THREADLOCK)
-		{
-			return _getCursorPos(this.getNativePointer());
-		}
+		return doInPG(() -> _getCursorPos(this.getNativePointer()));
 	}
 	
 	/**
@@ -232,10 +195,7 @@ public class ErrorData
 	 */
 	public int getInternalPos()
 	{
-		synchronized(Backend.THREADLOCK)
-		{
-			return _getInternalPos(this.getNativePointer());
-		}
+		return doInPG(() -> _getInternalPos(this.getNativePointer()));
 	}
 	
 	/**
@@ -243,10 +203,7 @@ public class ErrorData
 	 */
 	public String getInternalQuery()
 	{
-		synchronized(Backend.THREADLOCK)
-		{
-			return _getInternalQuery(this.getNativePointer());
-		}
+		return doInPG(() -> _getInternalQuery(this.getNativePointer()));
 	}
 	
 	/**
@@ -254,10 +211,7 @@ public class ErrorData
 	 */
 	public int getSavedErrno()
 	{
-		synchronized(Backend.THREADLOCK)
-		{
-			return _getSavedErrno(this.getNativePointer());
-		}
+		return doInPG(() -> _getSavedErrno(this.getNativePointer()));
 	}
 
 	private static native int _getErrorLevel(long pointer);

--- a/pljava/src/main/java/org/postgresql/pljava/internal/ExecutionPlan.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/ExecutionPlan.java
@@ -12,6 +12,8 @@
  */
 package org.postgresql.pljava.internal;
 
+import static org.postgresql.pljava.internal.Backend.doInPG;
+
 import java.sql.SQLException;
 import java.util.Collections;
 import java.util.Map;
@@ -240,11 +242,9 @@ public class ExecutionPlan
 		String cursorName, Object[] parameters, short read_only)
 	throws SQLException
 	{
-		synchronized(Backend.THREADLOCK)
-		{
-			return _cursorOpen(m_state.getExecutionPlanPtr(),
-				cursorName, parameters, read_only);
-		}
+		return doInPG(() ->
+			_cursorOpen(m_state.getExecutionPlanPtr(),
+				cursorName, parameters, read_only));
 	}
 
 	/**
@@ -258,10 +258,7 @@ public class ExecutionPlan
 	 */
 	public boolean isCursorPlan() throws SQLException
 	{
-		synchronized(Backend.THREADLOCK)
-		{
-			return _isCursorPlan(m_state.getExecutionPlanPtr());
-		}
+		return doInPG(() -> _isCursorPlan(m_state.getExecutionPlanPtr()));
 	}
 
 	/**
@@ -281,11 +278,9 @@ public class ExecutionPlan
 	public int execute(Object[] parameters, short read_only, int rowCount)
 	throws SQLException
 	{
-		synchronized(Backend.THREADLOCK)
-		{
-			return _execute(m_state.getExecutionPlanPtr(),
-				parameters, read_only, rowCount);
-		}
+		return doInPG(() ->
+			_execute(m_state.getExecutionPlanPtr(),
+				parameters, read_only, rowCount));
 	}
 
 	/**
@@ -307,12 +302,7 @@ public class ExecutionPlan
 
 		ExecutionPlan plan = s_planCache.remove(key);
 		if(plan == null)
-		{
-			synchronized(Backend.THREADLOCK)
-			{
-				plan = _prepare(key, statement, argTypes);
-			}
-		}
+			plan = doInPG(() -> _prepare(key, statement, argTypes));
 		return plan;
 	}
 

--- a/pljava/src/main/java/org/postgresql/pljava/internal/Privilege.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/Privilege.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright (c) 2020 Tada AB and other contributors, as listed below.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Chapman Flack
+ */
+package org.postgresql.pljava.internal;
+
+import java.security.AccessControlContext;
+import java.security.AccessController;
+import java.security.Permission;
+import java.security.PrivilegedActionException;
+import java.security.PrivilegedExceptionAction;
+
+/**
+ * Clean interface to the {@code doPrivileged...} methods on
+ * {@link AccessController AccessController}.
+ *<p>
+ * <strong>This interface must remain non-exported
+ * from {@code org.postgresql.pljava.internal}.</strong>
+ *<p>
+ * The reason, of course, is that the real methods on {@code AccessController}
+ * end up getting called from these wrappers, and will therefore apply the
+ * permissions granted to this module. As long as these methods are only
+ * accessible within this module, that isn't a problem.
+ *<p>
+ * It would be great to develop this into an exportable API so user code
+ * could benefit, but that would be a much trickier undertaking, with editing of
+ * {@code AccessControlContext}s to snag the correct caller's context, and
+ * not for the faint of heart.
+ *<p>
+ * Each method here comes in a flavor accepting a
+ * {@link Checked.Supplier Checked.Supplier}, matching any lambda that returns a
+ * reference type, and a flavor accepting a
+ * {@link Checked.Runnable Checked.Runnable} for {@code void} lambdas, because
+ * the compiler will not match those up with {@code Supplier<Void>}.
+ *<p>
+ * Fuss no more with {@code PrivilegedExceptionAction} and catching
+ * {@code PrivilegedActionException}: just pass any of these methods a lambda.
+ * If the lambda throws a checked exception, so does the method. If the lambda
+ * throws some checked exceptions, the method throws their least common
+ * supertype, which is not as nice as throwing their union, and climbs all the
+ * way up to {@code Exception} if they are unrelated. But even so, you can now
+ * simply catch it, rather than catching a {@code PrivilegedActionException} and
+ * having to unwrap it first.
+ */
+public interface Privilege
+{
+	public static <T, E extends Exception>T doPrivileged(
+		Checked.Supplier<T,E> op)
+	throws E
+	{
+		try
+		{
+			return (T)AccessController.doPrivileged(
+				(PrivilegedExceptionAction)op::get);
+		}
+		catch ( PrivilegedActionException pae )
+		{
+			throw Checked.<E>ederThrow(pae.getException());
+		}
+	}
+
+	public static <T, E extends Exception> T doPrivileged(
+		Checked.Supplier<T,E> op, AccessControlContext acc)
+	throws E
+	{
+		try
+		{
+			return (T)AccessController.doPrivileged(
+				(PrivilegedExceptionAction)op::get, acc);
+		}
+		catch ( PrivilegedActionException pae )
+		{
+			throw Checked.<E>ederThrow(pae.getException());
+		}
+	}
+
+	public static <T, E extends Exception> T doPrivileged(
+		Checked.Supplier<T,E> op, AccessControlContext acc, Permission... perms)
+	throws E
+	{
+		try
+		{
+			return (T)AccessController.doPrivileged(
+				(PrivilegedExceptionAction)op::get, acc, perms);
+		}
+		catch ( PrivilegedActionException pae )
+		{
+			throw Checked.<E>ederThrow(pae.getException());
+		}
+	}
+
+	public static <T, E extends Exception>T doPrivilegedWithCombiner(
+		Checked.Supplier<T,E> op)
+	throws E
+	{
+		try
+		{
+			return (T)AccessController.doPrivilegedWithCombiner(
+				(PrivilegedExceptionAction)op::get);
+		}
+		catch ( PrivilegedActionException pae )
+		{
+			throw Checked.<E>ederThrow(pae.getException());
+		}
+	}
+
+	public static <T, E extends Exception> T doPrivilegedWithCombiner(
+		Checked.Supplier<T,E> op, AccessControlContext acc, Permission... perms)
+	throws E
+	{
+		try
+		{
+			return (T)AccessController.doPrivilegedWithCombiner(
+				(PrivilegedExceptionAction)op::get, acc, perms);
+		}
+		catch ( PrivilegedActionException pae )
+		{
+			throw Checked.<E>ederThrow(pae.getException());
+		}
+	}
+
+	public static <E extends Exception> void doPrivileged(
+		Checked.Runnable<E> op)
+	throws E
+	{
+		try
+		{
+			AccessController.doPrivileged((PrivilegedExceptionAction)() ->
+			{
+				op.run();
+				return null;
+			});
+		}
+		catch ( PrivilegedActionException pae )
+		{
+			throw Checked.<E>ederThrow(pae.getException());
+		}
+	}
+
+	public static <E extends Exception> void doPrivileged(
+		Checked.Runnable<E> op, AccessControlContext acc)
+	throws E
+	{
+		try
+		{
+			AccessController.doPrivileged((PrivilegedExceptionAction)() ->
+			{
+				op.run();
+				return null;
+			}, acc);
+		}
+		catch ( PrivilegedActionException pae )
+		{
+			throw Checked.<E>ederThrow(pae.getException());
+		}
+	}
+
+	public static <E extends Exception> void doPrivileged(
+		Checked.Runnable<E> op, AccessControlContext acc, Permission... perms)
+	throws E
+	{
+		try
+		{
+			AccessController.doPrivileged((PrivilegedExceptionAction)() ->
+			{
+				op.run();
+				return null;
+			}, acc, perms);
+		}
+		catch ( PrivilegedActionException pae )
+		{
+			throw Checked.<E>ederThrow(pae.getException());
+		}
+	}
+
+	public static <E extends Exception> void doPrivilegedWithCombiner(
+		Checked.Runnable<E> op)
+	throws E
+	{
+		try
+		{
+			AccessController
+			.doPrivilegedWithCombiner((PrivilegedExceptionAction)() ->
+			{
+				op.run();
+				return null;
+			});
+		}
+		catch ( PrivilegedActionException pae )
+		{
+			throw Checked.<E>ederThrow(pae.getException());
+		}
+	}
+
+	public static <E extends Exception> void doPrivilegedWithCombiner(
+		Checked.Runnable<E> op, AccessControlContext acc, Permission... perms)
+	throws E
+	{
+		try
+		{
+			AccessController
+			.doPrivilegedWithCombiner((PrivilegedExceptionAction)() ->
+			{
+				op.run();
+				return null;
+			}, acc, perms);
+		}
+		catch ( PrivilegedActionException pae )
+		{
+			throw Checked.<E>ederThrow(pae.getException());
+		}
+	}
+}

--- a/pljava/src/main/java/org/postgresql/pljava/internal/Relation.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/Relation.java
@@ -1,10 +1,18 @@
 /*
- * Copyright (c) 2004, 2005, 2006 TADA AB - Taby Sweden
- * Distributed under the terms shown in the file COPYRIGHT
- * found in the root folder of this project or at
- * http://eng.tada.se/osprojects/COPYRIGHT.html
+ * Copyright (c) 2004-2019 Tada AB and other contributors, as listed below.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Tada AB
+ *   Chapman Flack
  */
 package org.postgresql.pljava.internal;
+
+import static org.postgresql.pljava.internal.Backend.doInPG;
 
 import java.sql.SQLException;
 
@@ -69,10 +77,7 @@ public class Relation
 	public String getName()
 	throws SQLException
 	{
-		synchronized(Backend.THREADLOCK)
-		{
-			return _getName(m_state.getRelationPtr());
-		}
+		return doInPG(() -> _getName(m_state.getRelationPtr()));
 	}
 
 	/**
@@ -82,10 +87,7 @@ public class Relation
 	public String getSchema()
 	throws SQLException
 	{
-		synchronized(Backend.THREADLOCK)
-		{
-			return _getSchema(m_state.getRelationPtr());
-		}
+		return doInPG(() -> _getSchema(m_state.getRelationPtr()));
 	}
 
 	/**
@@ -97,10 +99,7 @@ public class Relation
 	{
 		if(m_tupleDesc == null)
 		{
-			synchronized(Backend.THREADLOCK)
-			{
-				m_tupleDesc = _getTupleDesc(m_state.getRelationPtr());
-			}
+			m_tupleDesc = doInPG(() -> _getTupleDesc(m_state.getRelationPtr()));
 		}
 		return m_tupleDesc;
 	}
@@ -127,10 +126,9 @@ public class Relation
 	public Tuple modifyTuple(Tuple original, int[] fieldNumbers, Object[] values)
 	throws SQLException
 	{
-		synchronized(Backend.THREADLOCK)
-		{
-			return _modifyTuple(m_state.getRelationPtr(), original.getNativePointer(), fieldNumbers, values);
-		}
+		return doInPG(() ->
+			_modifyTuple(m_state.getRelationPtr(),
+				original.getNativePointer(), fieldNumbers, values));
 	}
 
 	private static native String _getName(long pointer)

--- a/pljava/src/main/java/org/postgresql/pljava/internal/SPI.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/SPI.java
@@ -12,6 +12,8 @@
  */
 package org.postgresql.pljava.internal;
 
+import static org.postgresql.pljava.internal.Backend.doInPG;
+
 /**
  * The <code>SPI</code> class provides access to some global
  * variables used by SPI.
@@ -64,18 +66,12 @@ public class SPI
 	@Deprecated
 	private static int exec(String command, int rowCount)
 	{
-		synchronized(Backend.THREADLOCK)
-		{
-			return _exec(command, rowCount);
-		}
+		return doInPG(() -> _exec(command, rowCount));
 	}
 
 	public static void freeTupTable()
 	{
-		synchronized(Backend.THREADLOCK)
-		{
-			_freeTupTable();
-		}
+		doInPG(SPI::_freeTupTable);
 	}
 
 	/**
@@ -83,14 +79,11 @@ public class SPI
 	 */
 	public static long getProcessed()
 	{
-		synchronized(Backend.THREADLOCK)
-		{
-			long count = _getProcessed();
-			if ( count < 0 )
-				throw new ArithmeticException(
-					"too many rows processed to count in a Java signed long");
-			return count;
-		}
+		long count = doInPG(SPI::_getProcessed);
+		if ( count < 0 )
+			throw new ArithmeticException(
+				"too many rows processed to count in a Java signed long");
+		return count;
 	}
 
 	/**
@@ -98,10 +91,7 @@ public class SPI
 	 */
 	public static int getResult()
 	{
-		synchronized(Backend.THREADLOCK)
-		{
-			return _getResult();
-		}
+		return doInPG(SPI::_getResult);
 	}
 
 	/**
@@ -109,10 +99,7 @@ public class SPI
 	 */
 	public static TupleTable getTupTable(TupleDesc known)
 	{
-		synchronized(Backend.THREADLOCK)
-		{
-			return _getTupTable(known);
-		}
+		return doInPG(() -> _getTupTable(known));
 	}
 
 	/**

--- a/pljava/src/main/java/org/postgresql/pljava/internal/Session.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/Session.java
@@ -26,6 +26,7 @@ import org.postgresql.pljava.SavepointListener;
 import org.postgresql.pljava.TransactionListener;
 import org.postgresql.pljava.jdbc.SQLUtils;
 
+import static org.postgresql.pljava.internal.Backend.doInPG;
 
 /**
  * An instance of this interface reflects the current session. The attribute
@@ -183,7 +184,7 @@ public class Session implements org.postgresql.pljava.Session
 	throws SQLException
 	{
 		Statement stmt = conn.createStatement();
-		synchronized(Backend.THREADLOCK)
+		doInPG(() ->
 		{
 			ResultSet rs = null;
 			AclId outerUser = AclId.getOuterUser();
@@ -207,7 +208,7 @@ public class Session implements org.postgresql.pljava.Session
 				if ( changeSucceeded )
 					_setUser(effectiveUser, wasLocalChange);
 			}
-		}
+		});
 	}
 
 	/**
@@ -219,7 +220,7 @@ public class Session implements org.postgresql.pljava.Session
 	throws SQLException
 	{
 		Statement stmt = SQLUtils.getDefaultConnection().createStatement();
-		synchronized(Backend.THREADLOCK)
+		return doInPG(() ->
 		{
 			ResultSet rs = null;
 			AclId sessionUser = AclId.getSessionUser();
@@ -242,7 +243,7 @@ public class Session implements org.postgresql.pljava.Session
 				if ( changeSucceeded )
 					_setUser(effectiveUser, wasLocalChange);
 			}
-		}
+		});
 	}
 
 	/**

--- a/pljava/src/main/java/org/postgresql/pljava/internal/SubXactListener.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/SubXactListener.java
@@ -12,6 +12,8 @@
  */
 package org.postgresql.pljava.internal;
 
+import static org.postgresql.pljava.internal.Backend.doInPG;
+
 import java.sql.SQLException;
 import java.util.ArrayDeque;
 import java.util.Deque;
@@ -57,25 +59,25 @@ class SubXactListener
 
 	static void addListener(SavepointListener listener)
 	{
-		synchronized(Backend.THREADLOCK)
+		doInPG(() ->
 		{
 			if ( s_listeners.contains(listener) )
 				return;
 			s_listeners.push(listener);
 			if( 1 == s_listeners.size() )
 				_register();
-		}
+		});
 	}
 
 	static void removeListener(SavepointListener listener)
 	{
-		synchronized(Backend.THREADLOCK)
+		doInPG(() ->
 		{
 			if ( ! s_listeners.remove(listener) )
 				return;
 			if ( 0 == s_listeners.size() )
 				_unregister();
-		}
+		});
 	}
 
 	private static native void _register();

--- a/pljava/src/main/java/org/postgresql/pljava/internal/TriggerData.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/TriggerData.java
@@ -15,6 +15,8 @@ package org.postgresql.pljava.internal;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
+import static org.postgresql.pljava.internal.Backend.doInPG;
+
 import org.postgresql.pljava.TriggerException;
 import org.postgresql.pljava.jdbc.TriggerResultSet;
 
@@ -212,10 +214,7 @@ public class TriggerData implements org.postgresql.pljava.TriggerData
 	{
 		if(m_relation == null)
 		{
-			synchronized(Backend.THREADLOCK)
-			{
-				m_relation = _getRelation(this.getNativePointer());
-			}
+			m_relation = doInPG(() -> _getRelation(this.getNativePointer()));
 		}
 		return m_relation;
 	}
@@ -238,10 +237,8 @@ public class TriggerData implements org.postgresql.pljava.TriggerData
 	{
 		if(m_triggerTuple == null)
 		{
-			synchronized(Backend.THREADLOCK)
-			{
-				m_triggerTuple = _getTriggerTuple(this.getNativePointer());
-			}
+			m_triggerTuple =
+				doInPG(() -> _getTriggerTuple(this.getNativePointer()));
 		}
 		return m_triggerTuple;
 	}
@@ -262,10 +259,7 @@ public class TriggerData implements org.postgresql.pljava.TriggerData
 	{
 		if(m_newTuple == null)
 		{
-			synchronized(Backend.THREADLOCK)
-			{
-				m_newTuple = _getNewTuple(this.getNativePointer());
-			}
+			m_newTuple = doInPG(() -> _getNewTuple(this.getNativePointer()));
 		}
 		return m_newTuple;
 	}
@@ -281,10 +275,7 @@ public class TriggerData implements org.postgresql.pljava.TriggerData
 	public String[] getArguments()
 	throws SQLException
 	{
-		synchronized(Backend.THREADLOCK)
-		{
-			return _getArguments(this.getNativePointer());
-		}
+		return doInPG(() -> _getArguments(this.getNativePointer()));
 	}
 
 	/**
@@ -297,10 +288,7 @@ public class TriggerData implements org.postgresql.pljava.TriggerData
 	public String getName()
 	throws SQLException
 	{
-		synchronized(Backend.THREADLOCK)
-		{
-			return _getName(this.getNativePointer());
-		}
+		return doInPG(() -> _getName(this.getNativePointer()));
 	}
 
 	/**
@@ -313,10 +301,7 @@ public class TriggerData implements org.postgresql.pljava.TriggerData
 	public boolean isFiredAfter()
 	throws SQLException
 	{
-		synchronized(Backend.THREADLOCK)
-		{
-			return _isFiredAfter(this.getNativePointer());
-		}
+		return doInPG(() -> _isFiredAfter(this.getNativePointer()));
 	}
 
 	/**
@@ -329,10 +314,7 @@ public class TriggerData implements org.postgresql.pljava.TriggerData
 	public boolean isFiredBefore()
 	throws SQLException
 	{
-		synchronized(Backend.THREADLOCK)
-		{
-			return _isFiredBefore(this.getNativePointer());
-		}
+		return doInPG(() -> _isFiredBefore(this.getNativePointer()));
 	}
 
 	/**
@@ -345,10 +327,7 @@ public class TriggerData implements org.postgresql.pljava.TriggerData
 	public boolean isFiredForEachRow()
 	throws SQLException
 	{
-		synchronized(Backend.THREADLOCK)
-		{
-			return _isFiredForEachRow(this.getNativePointer());
-		}
+		return doInPG(() -> _isFiredForEachRow(this.getNativePointer()));
 	}
 
 	/**
@@ -361,10 +340,7 @@ public class TriggerData implements org.postgresql.pljava.TriggerData
 	public boolean isFiredForStatement()
 	throws SQLException
 	{
-		synchronized(Backend.THREADLOCK)
-		{
-			return _isFiredForStatement(this.getNativePointer());
-		}
+		return doInPG(() -> _isFiredForStatement(this.getNativePointer()));
 	}
 
 	/**
@@ -376,10 +352,7 @@ public class TriggerData implements org.postgresql.pljava.TriggerData
 	public boolean isFiredByDelete()
 	throws SQLException
 	{
-		synchronized(Backend.THREADLOCK)
-		{
-			return _isFiredByDelete(this.getNativePointer());
-		}
+		return doInPG(() -> _isFiredByDelete(this.getNativePointer()));
 	}
 
 	/**
@@ -391,10 +364,7 @@ public class TriggerData implements org.postgresql.pljava.TriggerData
 	public boolean isFiredByInsert()
 	throws SQLException
 	{
-		synchronized(Backend.THREADLOCK)
-		{
-			return _isFiredByInsert(this.getNativePointer());
-		}
+		return doInPG(() -> _isFiredByInsert(this.getNativePointer()));
 	}
 
 	/**
@@ -406,10 +376,7 @@ public class TriggerData implements org.postgresql.pljava.TriggerData
 	public boolean isFiredByUpdate()
 	throws SQLException
 	{
-		synchronized(Backend.THREADLOCK)
-		{
-			return _isFiredByUpdate(this.getNativePointer());
-		}
+		return doInPG(() -> _isFiredByUpdate(this.getNativePointer()));
 	}
 
 	private static native Relation _getRelation(long pointer) throws SQLException;

--- a/pljava/src/main/java/org/postgresql/pljava/internal/Tuple.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/Tuple.java
@@ -12,6 +12,8 @@
  */
 package org.postgresql.pljava.internal;
 
+import static org.postgresql.pljava.internal.Backend.doInPG;
+
 import java.sql.SQLException;
 
 /**
@@ -93,11 +95,9 @@ public class Tuple
 	public Object getObject(TupleDesc tupleDesc, int index, Class<?> type)
 	throws SQLException
 	{
-		synchronized(Backend.THREADLOCK)
-		{
-			return _getObject(this.getNativePointer(),
-				tupleDesc.getNativePointer(), index, type);
-		}
+		return doInPG(() ->
+			_getObject(this.getNativePointer(),
+				tupleDesc.getNativePointer(), index, type));
 	}
 
 	private static native Object _getObject(

--- a/pljava/src/main/java/org/postgresql/pljava/internal/TupleDesc.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/TupleDesc.java
@@ -12,6 +12,8 @@
  */
 package org.postgresql.pljava.internal;
 
+import static org.postgresql.pljava.internal.Backend.doInPG;
+
 import java.sql.SQLException;
 
 /**
@@ -90,10 +92,7 @@ public class TupleDesc
 	public String getColumnName(int index)
 	throws SQLException
 	{
-		synchronized(Backend.THREADLOCK)
-		{
-			return _getColumnName(this.getNativePointer(), index);
-		}
+		return doInPG(() -> _getColumnName(this.getNativePointer(), index));
 	}
 
 	/**
@@ -106,10 +105,8 @@ public class TupleDesc
 	public int getColumnIndex(String colName)
 	throws SQLException
 	{
-		synchronized(Backend.THREADLOCK)
-		{
-			return _getColumnIndex(this.getNativePointer(), colName.toLowerCase());
-		}
+		return doInPG(() ->
+			_getColumnIndex(this.getNativePointer(), colName.toLowerCase()));
 	}
 
 	/**
@@ -123,10 +120,7 @@ public class TupleDesc
 	public Tuple formTuple(Object[] values)
 	throws SQLException
 	{
-		synchronized(Backend.THREADLOCK)
-		{
-			return _formTuple(this.getNativePointer(), values);
-		}
+		return doInPG(() -> _formTuple(this.getNativePointer(), values));
 	}
 
 	/**
@@ -146,12 +140,12 @@ public class TupleDesc
 		if(m_columnClasses == null)
 		{
 			m_columnClasses = new Class[m_size];
-			synchronized(Backend.THREADLOCK)
+			doInPG(() ->
 			{				
 				long _this = this.getNativePointer();
 				for(int idx = 0; idx < m_size; ++idx)
 					m_columnClasses[idx] = _getOid(_this, idx+1).getJavaClass();
-			}
+			});
 		}
 		return m_columnClasses[index-1];
 	}
@@ -162,10 +156,7 @@ public class TupleDesc
 	public Oid getOid(int index)
 	throws SQLException
 	{
-		synchronized(Backend.THREADLOCK)
-		{
-			return _getOid(this.getNativePointer(), index);
-		}
+		return doInPG(() -> _getOid(this.getNativePointer(), index));
 	}
 
 	private static native String _getColumnName(long _this, int index) throws SQLException;

--- a/pljava/src/main/java/org/postgresql/pljava/internal/XactListener.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/XactListener.java
@@ -12,6 +12,8 @@
  */
 package org.postgresql.pljava.internal;
 
+import static org.postgresql.pljava.internal.Backend.doInPG;
+
 import java.sql.SQLException;
 import java.util.ArrayDeque;
 import java.util.Deque;
@@ -59,25 +61,25 @@ class XactListener
 	
 	static void addListener(TransactionListener listener)
 	{
-		synchronized(Backend.THREADLOCK)
+		doInPG(() ->
 		{
 			if ( s_listeners.contains(listener) )
 				return;
 			s_listeners.push(listener);
 			if( 1 == s_listeners.size() )
 				_register();
-		}
+		});
 	}
 	
 	static void removeListener(TransactionListener listener)
 	{
-		synchronized(Backend.THREADLOCK)
+		doInPG(() ->
 		{
 			if ( ! s_listeners.remove(listener) )
 				return;
 			if ( 0 == s_listeners.size() )
 				_unregister();
-		}
+		});
 	}
 
 	private static native void _register();

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/Invocation.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/Invocation.java
@@ -18,6 +18,7 @@ import java.util.ArrayList;
 import java.util.logging.Logger;
 
 import org.postgresql.pljava.internal.Backend;
+import static org.postgresql.pljava.internal.Backend.doInPG;
 import org.postgresql.pljava.internal.PgSavepoint;
 
 /**
@@ -106,7 +107,7 @@ public class Invocation
 	 */
 	public static Invocation current()
 	{
-		synchronized(Backend.THREADLOCK)
+		return doInPG(() ->
 		{
 			Invocation curr = _getCurrent();
 			if(curr != null)
@@ -135,15 +136,12 @@ public class Invocation
 			s_levels[level] = curr;
 			curr._register();
 			return curr;
-		}
+		});
 	}
 
 	static void clearErrorCondition()
 	{
-		synchronized(Backend.THREADLOCK)
-		{
-			_clearErrorCondition();
-		}
+		doInPG(Invocation::_clearErrorCondition);
 	}
 
 	/**

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/SPIConnection.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/SPIConnection.java
@@ -1035,29 +1035,6 @@ public class SPIConnection implements Connection
 
 	static
 	{
-		/*
-		 * Try to get the JDBC 4.2 / Java 8 TIME*ZONE types reflectively.
-		 * Once the Java back horizon advances to 8, just do this the easy way.
-		 */
-		int sqx  = Types.OTHER;      // don't just start saying SQLXML in 1.5.1
-		int ttz  = Types.TIME;       // Use these values
-		int tstz = Types.TIMESTAMP;  //         pre-Java 8
-//		try    COMMENTED OUT FOR BACK-COMPATIBILITY REASONS IN PL/JAVA 1.5.x
-//		{
-//			ttz =
-//				Types.class.getField("TIME_WITH_TIMEZONE")
-//					.getInt(Types.class);
-//			tstz =
-//				Types.class.getField("TIMESTAMP_WITH_TIMEZONE")
-//					.getInt(Types.class);
-//		}
-//		catch ( NoSuchFieldException nsfe ) { } // ok, not running in Java 8
-//		catch ( IllegalAccessException iae )
-//		{
-//			throw new ExceptionInInitializerError(iae);
-//		}
-//		sqx = Types.SQLXML;
-
 		JDBC_TYPE_NUMBERS = new int[]
 		{
 			Types.SMALLINT,
@@ -1073,9 +1050,9 @@ public class SPIConnection implements Connection
 			Types.BOOLEAN,
 			Types.BIT,
 			Types.DATE,
-			Types.TIME, ttz,
-			Types.TIMESTAMP, Types.TIMESTAMP, tstz,
-			sqx,
+			Types.TIME, Types.TIME_WITH_TIMEZONE,
+			Types.TIMESTAMP, Types.TIMESTAMP, Types.TIMESTAMP_WITH_TIMEZONE,
+			Types.SQLXML,
 			Types.ARRAY, Types.ARRAY, Types.ARRAY, Types.ARRAY, Types.ARRAY,
 			Types.ARRAY, Types.ARRAY, Types.ARRAY, Types.ARRAY, Types.ARRAY,
 			Types.ARRAY, Types.ARRAY, Types.ARRAY, Types.ARRAY, Types.ARRAY,

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/SQLInputFromTuple.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/SQLInputFromTuple.java
@@ -328,9 +328,9 @@ public class SQLInputFromTuple extends SingleRowReader implements SQLInput
 
 	// ************************************************************
 	// Implementation of JDBC 4.2 method.
-	// Add @Override here once Java back horizon advances to 8.
 	// ************************************************************
 
+	@Override
 	public <T> T readObject(Class<T> type) throws SQLException
 	{
 		return getObject(nextIndex(), type);

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/SQLOutputToChunk.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/SQLOutputToChunk.java
@@ -46,7 +46,7 @@ import java.sql.Struct;
 import java.sql.Time;
 import java.sql.Timestamp;
 
-import org.postgresql.pljava.internal.Backend;
+import static org.postgresql.pljava.internal.Backend.doInPG;
 
 /**
  * The SQLOutputToChunk uses JNI to build a PostgreSQL StringInfo buffer in
@@ -486,7 +486,7 @@ public class SQLOutputToChunk implements SQLOutput
 
 	private void ensureCapacity(int c) throws SQLException
 	{
-		synchronized(Backend.THREADLOCK)
+		doInPG(() ->
 		{
 			if(m_handle == 0)
 				throw new SQLException("Stream is closed");
@@ -494,7 +494,7 @@ public class SQLOutputToChunk implements SQLOutput
 			m_bb = _ensureCapacity(m_handle, m_bb, m_bb.position(), c);
 			if ( m_bb != oldbb )
 				m_bb.order(oldbb.order());
-		}
+		});
 	}
 
 	private static native ByteBuffer _ensureCapacity(long handle,

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/SQLXMLImpl.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/SQLXMLImpl.java
@@ -311,9 +311,10 @@ public abstract class SQLXMLImpl<V extends VarlenaWrapper> implements SQLXML
 		if ( sx instanceof Readable.PgXML || sx instanceof Writable )
 			return ((SQLXMLImpl)sx).adopt(oid);
 
+		Source src = sx.getSource(null);
 		SQLXML rx =
 			newWritable().setResult(Adjusting.XML.SourceResult.class)
-			.set(sx.getSource(null)).getSQLXML();
+			.set(src).getSQLXML();
 
 		sx.free();
 		return ((SQLXMLImpl)rx).adopt(oid);

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/SQLXMLImpl.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/SQLXMLImpl.java
@@ -35,6 +35,7 @@ import java.nio.charset.Charset;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.postgresql.pljava.internal.Backend;
+import static org.postgresql.pljava.internal.Backend.doInPG;
 import org.postgresql.pljava.internal.MarkableSequenceInputStream;
 
 import java.sql.SQLNonTransientException;
@@ -285,10 +286,7 @@ public abstract class SQLXMLImpl<V extends VarlenaWrapper> implements SQLXML
 	 */
 	static SQLXML newWritable()
 	{
-		synchronized ( Backend.THREADLOCK )
-		{
-			return _newWritable();
-		}
+		return doInPG(() -> _newWritable());
 	}
 
 	/**

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/SingleRowReader.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/SingleRowReader.java
@@ -16,7 +16,7 @@ package org.postgresql.pljava.jdbc;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
-import org.postgresql.pljava.internal.Backend;
+import static org.postgresql.pljava.internal.Backend.doInPG;
 import org.postgresql.pljava.internal.DualState;
 import org.postgresql.pljava.internal.TupleDesc;
 
@@ -97,12 +97,9 @@ public class SingleRowReader extends SingleRowResultSet
 	protected Object getObjectValue(int columnIndex, Class<?> type)
 	throws SQLException
 	{
-		synchronized(Backend.THREADLOCK)
-		{
-			return _getObject(
+		return doInPG(() -> _getObject(
 				m_state.getHeapTupleHeaderPtr(), m_tupleDesc.getNativePointer(),
-				columnIndex, type);
-		}
+				columnIndex, type));
 	}
 
 	/**

--- a/pom.xml
+++ b/pom.xml
@@ -67,9 +67,9 @@
 
 	<profiles>
 		<profile>
-			<id>srctgt7</id>
+			<id>srctgt8</id>
 			<activation>
-				<jdk>[1.7,9)</jdk>
+				<jdk>[1.8,9)</jdk>
 			</activation>
 			<build>
 				<plugins>
@@ -78,15 +78,15 @@
 						<artifactId>maven-compiler-plugin</artifactId>
 						<version>2.5.1</version>
 						<configuration>
-							<source>1.7</source>
-							<target>1.7</target>
+							<source>1.8</source>
+							<target>1.8</target>
 						</configuration>
 					</plugin>
 				</plugins>
 			</build>
 		</profile>
 		<profile>
-			<id>release7</id>
+			<id>release8</id>
 			<activation>
 				<jdk>[9,)</jdk>
 			</activation>
@@ -97,7 +97,7 @@
 						<artifactId>maven-compiler-plugin</artifactId>
 						<version>3.8.1</version>
 						<configuration>
-							<release>7</release>
+							<release>8</release>
 						</configuration>
 					</plugin>
 				</plugins>

--- a/src/site/markdown/build/versions.md
+++ b/src/site/markdown/build/versions.md
@@ -1,11 +1,11 @@
 # Versions of external packages needed to build and use PL/Java
 
-As of June 2019, the following version constraints are known.
+As of January 2020, the following version constraints are known.
 
 ## Java
 
-No version of Java before 1.7 ("Java 7") is supported. The PL/Java code
-makes use of Java features first appearing in Java 7.
+No version of Java before 1.8 ("Java 8") is supported. The PL/Java code
+makes use of Java features first appearing in Java 8.
 
 As for later versions of Java, backward compatibility in the language is
 generally good. Before Java 8, most likely problem areas with a new Java
@@ -14,10 +14,8 @@ implemented. Since Java 8, even JDBC additions have not caused problems for
 existing PL/Java code, as they have taken advantage of the default-methods
 feature introduced in that release.
 
-In the PL/Java 1.6.x series, the build can be done with Java 7 or newer (but
-builds with 7
-[may be difficult](#Maven_failures_when_downloading_dependencies)).
-Once built, PL/Java is able to use another Java 7 or later JVM at run time,
+In the PL/Java 1.6.x series, the build can be done with Java 8 or newer.
+Once built, PL/Java is able to use another Java 8 or later JVM at run time,
 simply by setting
 [the `pljava.libjvm_location` variable][jvml] to the desired version's library.
 
@@ -30,15 +28,6 @@ PL/Java has been successfully used with [Oracle Java][orj] and with
 [either the Hotspot or the OpenJ9 JVM][hsj9]. It can also be built and used
 with [GraalVM][].
 
-### Maven failures when downloading dependencies
-
-As of late 2017, important Maven remote repository servers no longer accept
-connections using the encryption protocols available in Java 7. Although
-PL/Java can still, in principle, be built using that Java version (if all
-dependencies are already in the build host's local repository), Maven may fail
-to download necessary dependencies unless run with Java 8, which supports the
-newer protocol versions needed to reach the servers.
-
 [jvml]: ../use/variables.html
 [cds]:  ../install/vmoptions.html#Class_data_sharing
 [orj]: https://www.oracle.com/technetwork/java/javase/downloads/index.html
@@ -48,10 +37,8 @@ newer protocol versions needed to reach the servers.
 
 ## Maven
 
-PL/Java can be built with Maven versions at least as far back as 3.0.4.
-As shown in the [Maven release history][mvnhist], **Maven releases after
-3.2.5 require Java 7 or later**. If you wish to *build* PL/Java using a
-Java 6 development kit, you must use a Maven version not newer than 3.2.5.
+PL/Java can be built with Maven versions at least as far back as 3.3.
+Maven's requirements can be seen in the [Maven release history][mvnhist].
 
 [mvnhist]: https://maven.apache.org/docs/history.html
 

--- a/src/site/markdown/use/variables.md
+++ b/src/site/markdown/use/variables.md
@@ -53,7 +53,7 @@ These PostgreSQL configuration variables can influence PL/Java's operation:
     a (single-quoted) string explicitly containing the double quotes._
 
 `pljava.java_thread_pg_entry`
-: A choice of `allow`, `error`, or `block` controlling PL/Java's thread
+: A choice of `allow`, `error`, `block`, or `throw` controlling PL/Java's thread
     management. Java makes heavy use of threading, while PostgreSQL may not be
     accessed by multiple threads concurrently. PL/Java's historical behavior is
     `allow`, which serializes access by Java threads into PostgreSQL, allowing
@@ -64,7 +64,8 @@ These PostgreSQL configuration variables can influence PL/Java's operation:
     PL/Java itself no longer requires the ability for any thread to access
     PostgreSQL other than the original main thread. User code developed for
     PL/Java, however, may still rely on that ability. To test whether it does,
-    the `error` setting can be used here, and any attempt by a Java thread other
+    the `error` or `throw` setting can be used here, and any attempt by a Java
+    thread other
     than the main one to enter PostgreSQL will incur an exception (and stack
     trace, written to the server's standard error channel). When confident that
     there is no code that will need to enter PostgreSQL except on the main
@@ -75,6 +76,12 @@ These PostgreSQL configuration variables can influence PL/Java's operation:
     can lead to blocked threads or a deadlocked backend if used with code that
     does attempt to access PG from more than one thread. (A JMX client, like
     JConsole, can identify the blocked threads, should that occur.)
+
+    The `throw` setting is like `error` but more efficient: under the `error`
+    setting, attempted entry by the wrong thread is detected in the native C
+    code, only after a lock operation and call through JNI. Under the `throw`
+    setting, the lock operations are elided and an entry attempt by the wrong
+    thread results in no JNI call and an exception thrown directly in Java.
 
 `pljava.libjvm_location`
 : Used by PL/Java to load the Java runtime. The full path to a `libjvm` shared


### PR DESCRIPTION
Highlights: Java 8 lambdas allow a much more concise idiom for PL/Java's many downcalls into C/PostgreSQL, which in turn makes possible more approaches to the thread-exclusion problem.