### PR TITLE
Add more constructs to the Lexicals class

### DIFF
--- a/pljava-api/src/main/java/org/postgresql/pljava/sqlgen/Lexicals.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/sqlgen/Lexicals.java
@@ -794,10 +794,29 @@ public abstract class Lexicals
 				if ( null == local )
 					throw new NullPointerException(
 					"local part of an Identifier.Qualified may not be null");
-				Simple localId = Simple.fromCatalog(local);
+				Simple localId = ( null == local ) ?
+					null : Simple.fromCatalog(local);
 				Simple qualId = ( null == qualifier ) ?
 					null : Simple.fromCatalog(qualifier);
-				return new Qualified(qualId, localId);
+				return fromSimplePair(qualId, localId);
+			}
+
+
+			/**
+			 * Create an {@code Identifier.Qualified} from a pair of
+			 * {@code Identifier.Simple}.
+			 * @param Simple identifier representing the schema name.
+			 * @param Simple identifier naming an object in that schema.
+			 * @return an Identifier.Qualified
+			 * @throws NullPointerException if the local name is null.
+			 */
+			public static Qualified fromSimplePair(
+				Simple qualifier, Simple local)
+			{
+				if ( null == local )
+					throw new NullPointerException(
+					"local part of an Identifier.Qualified may not be null");
+				return new Qualified(qualifier, local);
 			}
 
 			private Qualified(Simple qualifier, Simple local)

--- a/pljava-api/src/main/java/org/postgresql/pljava/sqlgen/Lexicals.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/sqlgen/Lexicals.java
@@ -492,6 +492,37 @@ public abstract class Lexicals
 				return new Simple(s);
 			}
 
+			/**
+			 * Create an {@code Identifier.Simple} from a name string supplied
+			 * in Java source, such as an annotation value.
+			 *<p>
+			 * Historically, PL/Java has treated these identifiers as regular
+			 * ones, requiring delimited ones to be represented by adding quotes
+			 * explicitly at start and end, and doubling internal quotes, all
+			 * escaped for Java, naturally. This method accepts either of those
+			 * forms, and will also accept a string that neither qualifies as a
+			 * regular identifier nor starts and ends with quotes. Such a string
+			 * will be treated as if it were a delimited identifier with the
+			 * start/end quotes already stripped and internal ones already
+			 * undoubled.
+			 *<p>
+			 * The SQL Unicode escape syntax is not accepted here. Java already
+			 * has its own Unicode escape syntax, which is what should be used.
+			 * @param s name of the simple identifier, as found in Java source.
+			 * @return an Identifier.Simple or subclass appropriate to the form
+			 * of the name.
+			 */
+			public static Simple fromJava(String s)
+			{
+				boolean quoted = true;
+				Matcher m = ISO_DELIMITED_IDENTIFIER_CAPTURING.matcher(s);
+				if ( m.matches() )
+					s = m.group("xd").replace("\"\"", "\"");
+				else if ( m.usePattern(PG_REGULAR_IDENTIFIER).matches() )
+					return new Folding(s);
+				return Identifier.from(s, true);
+			}
+
 			@Override
 			public String deparse()
 			{

--- a/pljava-api/src/test/java/LexicalsTest.java
+++ b/pljava-api/src/test/java/LexicalsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2019 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2016-2020 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -221,13 +221,13 @@ public class LexicalsTest extends TestCase
 
 		assertThat("ne1", s2, not(equalTo(s6)));
 
-		assertEquals("deparse1", s1.deparse(), "aB");
-		assertEquals("deparse2", s2.deparse(), "\"ab\"");
-		assertEquals("deparse3", s3.deparse(), "\"A\"\"b\"");
-		assertEquals("deparse4", s4.deparse(), "\"A\"\"b\"");
-		assertEquals("deparse5", s5.deparse(), "ab");
-		assertEquals("deparse6", s6.deparse(), "\"AB\"");
-		assertEquals("deparse7", s7.deparse(), "\"A\"\"b\"");
+		assertEquals("deparse1", s1.toString(), "aB");
+		assertEquals("deparse2", s2.toString(), "\"ab\"");
+		assertEquals("deparse3", s3.toString(), "\"A\"\"b\"");
+		assertEquals("deparse4", s4.toString(), "\"A\"\"b\"");
+		assertEquals("deparse5", s5.toString(), "ab");
+		assertEquals("deparse6", s6.toString(), "\"AB\"");
+		assertEquals("deparse7", s7.toString(), "\"A\"\"b\"");
 	}
 
 	public void testOperatorPattern() throws Exception
@@ -262,14 +262,14 @@ public class LexicalsTest extends TestCase
 		Operator o1 = Operator.from("!@#%*");
 		Operator o2 = Operator.from("!@#%*");
 		assertEquals("eq1", o1, o2);
-		assertEquals("eq2", o1.deparse(), "!@#%*");
+		assertEquals("eq2", o1.toString(), "!@#%*");
 		Simple s1 = Simple.from("foo", false);
 		Qualified q1 = o1.withQualifier(null);
-		assertEquals("eq3", q1.deparse(), o1.deparse());
+		assertEquals("eq3", q1.toString(), o1.toString());
 		Qualified q2 = o1.withQualifier(s1);
-		assertEquals("eq4", q2.deparse(), "OPERATOR(foo.!@#%*)");
+		assertEquals("eq4", q2.toString(), "OPERATOR(foo.!@#%*)");
 		Simple s2 = Simple.from("foo", true);
 		Qualified q3 = o1.withQualifier(s2);
-		assertEquals("eq5", q3.deparse(), "OPERATOR(\"foo\".!@#%*)");
+		assertEquals("eq5", q3.toString(), "OPERATOR(\"foo\".!@#%*)");
 	}
 }

--- a/pljava-api/src/test/java/LexicalsTest.java
+++ b/pljava-api/src/test/java/LexicalsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2016-2019 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -193,5 +193,35 @@ public class LexicalsTest extends TestCase
 		assertThat("ne2", Baß, not(equalTo(qbass)));
 
 		assertThat("ne3", sab, not(equalTo(SAB)));
+	}
+
+	public void testIdentifierSimpleFrom() throws Exception
+	{
+		Identifier.Simple s1 = Identifier.Simple.fromJava("aB");
+		Identifier.Simple s2 = Identifier.Simple.fromJava("\"ab\"");
+		Identifier.Simple s3 = Identifier.Simple.fromJava("\"A\"\"b\"");
+		Identifier.Simple s4 = Identifier.Simple.fromJava("A\"b");
+
+		Identifier.Simple s5 = Identifier.Simple.fromCatalog("ab");
+		Identifier.Simple s6 = Identifier.Simple.fromCatalog("AB");
+		Identifier.Simple s7 = Identifier.Simple.fromCatalog("A\"b");
+
+		assertEquals("eq1", s1, s2);
+		assertEquals("eq2", s3, s4);
+		assertEquals("eq3", s1, s5);
+		assertEquals("eq4", s2, s5);
+		assertEquals("eq5", s1, s6);
+		assertEquals("eq6", s5, s6);
+		assertEquals("eq7", s3, s7);
+
+		assertThat("ne1", s2, not(equalTo(s6)));
+
+		assertEquals("deparse1", s1.deparse(), "aB");
+		assertEquals("deparse2", s2.deparse(), "\"ab\"");
+		assertEquals("deparse3", s3.deparse(), "\"A\"\"b\"");
+		assertEquals("deparse4", s4.deparse(), "\"A\"\"b\"");
+		assertEquals("deparse5", s5.deparse(), "ab");
+		assertEquals("deparse6", s6.deparse(), "\"AB\"");
+		assertEquals("deparse7", s7.deparse(), "\"A\"\"b\"");
 	}
 }


### PR DESCRIPTION
Flesh out support for identifiers, unqualified and schema-qualified, for normal names and operator names. Also some support for recognizing SQL newlines and comments.

The obvious remaining omissions are character string and binary string literals. Those are important, but there are lots of uses for identifiers throughout PL/Java, so it seems worth pulling what is here now, and returning to the string literals another time.