### PR TITLE
Add validator function

### DIFF
--- a/pljava-so/src/main/c/Function.c
+++ b/pljava-so/src/main/c/Function.c
@@ -1132,9 +1132,6 @@ JNIEXPORT void JNICALL
 			}
 		}
 
-		javaNameString =
-			String_createJavaStringFromNTS(Type_getJavaTypeName(replType));
-
 		JNI_setObjectArrayElement(resolvedTypes, index, javaNameString);
 	}
 	PG_CATCH();

--- a/pljava-so/src/main/c/Function.c
+++ b/pljava-so/src/main/c/Function.c
@@ -258,7 +258,7 @@ void Function_initialize(void)
 	s_Function_class = JNI_newGlobalRef(PgObject_getJavaClass(
 		"org/postgresql/pljava/internal/Function"));
 	s_Function_create = PgObject_getStaticJavaMethod(s_Function_class, "create",
-		"(JLjava/sql/ResultSet;Ljava/lang/String;Ljava/lang/String;Z)"
+		"(JLjava/sql/ResultSet;Ljava/lang/String;Ljava/lang/String;ZZZ)"
 		"Ljava/lang/invoke/MethodHandle;");
 	s_Function_getClassIfUDT = PgObject_getStaticJavaMethod(s_Function_class,
 		"getClassIfUDT",
@@ -454,12 +454,13 @@ Type Function_checkTypeUDT(Oid typeId, Form_pg_type typeStruct)
 	return t;
 }
 
-static Function Function_create(PG_FUNCTION_ARGS)
+static Function Function_create(
+	Oid funcOid, bool forTrigger, bool forValidator, bool checkBody)
 {
-	Function self =
+	Function self = /* will rely on the fact that allocInstance zeroes memory */
 		(Function)PgObjectClass_allocInstance(s_FunctionClass,TopMemoryContext);
 	HeapTuple procTup =
-		PgObject_getValidTuple(PROCOID, fcinfo->flinfo->fn_oid, "function");
+		PgObject_getValidTuple(PROCOID, funcOid, "function");
 	Form_pg_proc procStruct = (Form_pg_proc)GETSTRUCT(procTup);
 	HeapTuple lngTup =
 		PgObject_getValidTuple(LANGOID, procStruct->prolang, "language");
@@ -479,16 +480,51 @@ static Function Function_create(PG_FUNCTION_ARGS)
 	handle = JNI_callStaticObjectMethod(s_Function_class, s_Function_create,
 		p2l.longVal, Type_coerceDatum(s_pgproc_Type, d), lname,
 		schemaName,
-		CALLED_AS_TRIGGER(fcinfo)? JNI_TRUE : JNI_FALSE);
+		forTrigger ? JNI_TRUE : JNI_FALSE,
+		forValidator ? JNI_TRUE : JNI_FALSE,
+		checkBody ? JNI_TRUE : JNI_FALSE);
 	pfree((void *)d);
 	JNI_deleteLocalRef(schemaName);
 	ReleaseSysCache(lngTup);
 	ReleaseSysCache(procTup);
 
+	/*
+	 * One of four things has happened, the product of two binary choices:
+	 * - This Function turns out to be either a UDT function, or a nonUDT one.
+	 * - it is now fully initialized and should be returned, or it isn't, and
+	 *   should be pfree()d. (Validator calls don't have to do the whole job.)
+	 *
+	 * If Function.create returned a non-NULL result, this is a fully
+	 * initialized, non-UDT function, ready to save and use. (That can happen
+	 * even during validation; if checkBody is true, enough work is done to get
+	 * a complete result, so we might as well save it.)
+	 *
+	 * If it returned NULL, this is either an incompletely-initialized non-UDT
+	 * function, or it is a UDT function (whether fully initialized or not; it
+	 * is always NULL for a UDT function). If it is a UDT function and not
+	 * complete, it should be pfree()d. If complete, it has already been
+	 * registered with the UDT machinery and should be saved. We can arrange
+	 * (see _storeToUDT below) for the isUDT flag to be left false if the UDT
+	 * initialization isn't complete; that collapses the need-to-pfree cases
+	 * into one case here (Function.create returned NULL && ! isUDT).
+	 *
+	 * Because allocInstance zeroes memory, isUDT is reliably false even if
+	 * the Java code bailed early.
+	 */
+
 	if ( NULL != handle )
 	{
 		self->func.nonudt.methodHandle = JNI_newGlobalRef(handle);
 		JNI_deleteLocalRef(handle);
+	}
+	else if ( ! self->isUDT )
+	{
+		pfree(self);
+		if ( forValidator )
+			return NULL;
+		elog(ERROR,
+			"failed to create a PL/Java function (oid %u) and not validating",
+			funcOid);
 	}
 
 	return self;
@@ -496,17 +532,24 @@ static Function Function_create(PG_FUNCTION_ARGS)
 
 /*
  * In all cases, this Function has been stored in currentInvocation->function
- * upon succesful return from here.
+ * upon successful return from here.
+ *
+ * If called with forValidator true, may return NULL. The validator doesn't
+ * use the result.
  */
-Function Function_getFunction(PG_FUNCTION_ARGS)
+Function Function_getFunction(
+	Oid funcOid, bool forTrigger, bool forValidator, bool checkBody)
 {
-	Oid funcOid = fcinfo->flinfo->fn_oid;
-	Function func = (Function)HashMap_getByOid(s_funcMap, funcOid);
-	if(func == 0)
+	Function func =
+		forValidator ? NULL : (Function)HashMap_getByOid(s_funcMap, funcOid);
+
+	if ( NULL == func )
 	{
-		func = Function_create(fcinfo);
-		HashMap_putByOid(s_funcMap, funcOid, func);
+		func = Function_create(funcOid, forTrigger, forValidator, checkBody);
+		if ( NULL != func )
+			HashMap_putByOid(s_funcMap, funcOid, func);
 	}
+
 	currentInvocation->function = func;
 	return func;
 }
@@ -957,28 +1000,41 @@ JNIEXPORT void JNICALL
 	BEGIN_NATIVE_NO_ERRCHECK
 	PG_TRY();
 	{
-		self->isUDT = true;
-		self->readOnly = (JNI_TRUE == readOnly);
-		self->schemaLoader = JNI_newWeakGlobalRef(schemaLoader);
-		self->clazz = JNI_newGlobalRef(clazz);
-
 		typeTup = PgObject_getValidTuple(TYPEOID, udtId, "type");
 		pgType = (Form_pg_type)GETSTRUCT(typeTup);
-		self->func.udt.udt =
-			UDT_registerUDT(
-				self->clazz, udtId, pgType, 0, true, parseMH, readMH);
-		ReleaseSysCache(typeTup);
 
-		switch ( funcInitial )
+		/*
+		 * Check typisdefined first. During validation, it will probably be
+		 * false, as the functions are created while the type is just a shell.
+		 * In that case, leave isUDT false, which will trigger Function_create
+		 * to pfree the unusable proto-Function.
+		 *
+		 * In that case, don't store anything needing special deallocation
+		 * such as JNI references; Function_create will do a blind pfree only.
+		 */
+		if ( pgType->typisdefined )
 		{
-		case 'i': self->func.udt.udtFunction = UDT_input; break;
-		case 'o': self->func.udt.udtFunction = UDT_output; break;
-		case 'r': self->func.udt.udtFunction = UDT_receive; break;
-		case 's': self->func.udt.udtFunction = UDT_send; break;
-		default:
-			elog(ERROR,
-				"PL/Java jar/native code mismatch: unexpected UDT func ID");
+			self->isUDT = true;
+			self->readOnly = (JNI_TRUE == readOnly);
+			self->schemaLoader = JNI_newWeakGlobalRef(schemaLoader);
+			self->clazz = JNI_newGlobalRef(clazz);
+
+			self->func.udt.udt =
+				UDT_registerUDT(
+					self->clazz, udtId, pgType, 0, true, parseMH, readMH);
+
+			switch ( funcInitial )
+			{
+			case 'i': self->func.udt.udtFunction = UDT_input; break;
+			case 'o': self->func.udt.udtFunction = UDT_output; break;
+			case 'r': self->func.udt.udtFunction = UDT_receive; break;
+			case 's': self->func.udt.udtFunction = UDT_send; break;
+			default:
+				elog(ERROR,
+					"PL/Java jar/native code mismatch: unexpected UDT func ID");
+			}
 		}
+		ReleaseSysCache(typeTup);
 	}
 	PG_CATCH();
 	{

--- a/pljava-so/src/main/c/TypeOid.c
+++ b/pljava-so/src/main/c/TypeOid.c
@@ -54,4 +54,6 @@ JNIEXPORT void JNICALL Java_org_postgresql_pljava_jdbc_TypeOid__1dummy(JNIEnv * 
 #if PG_VERSION_NUM >= 90100
 	CONFIRMCONST(PGNODETREEOID);
 #endif
+
+	CONFIRMCONST(TRIGGEROID);
 }

--- a/pljava-so/src/main/include/pljava/Function.h
+++ b/pljava-so/src/main/include/pljava/Function.h
@@ -46,12 +46,16 @@ extern void Function_clearFunctionCache(void);
  * Get a Function using a function Oid. If the function is not found, one
  * will be created based on the class and method name denoted in the "AS"
  * clause, the parameter types, and the return value of the function
- * description. If "isTrigger" is set to true, the parameter type and
+ * description. If "forTrigger" is true, the parameter type and
  * return value of the function will be fixed to:
- * 
- * org.postgresql.pljava.Tuple <method name>(org.postgresql.pljava.TriggerData td)
+ * void <method name>(org.postgresql.pljava.TriggerData td)
+ *
+ * If forValidator is true, forTrigger is disregarded, and will be determined
+ * from the function's pg_proc entry. If forValidator is false, checkBody has no
+ * meaning.
  */
-extern Function Function_getFunction(PG_FUNCTION_ARGS);
+extern Function Function_getFunction(
+	Oid funcOid, bool forTrigger, bool forValidator, bool checkBody);
 
 extern Type Function_checkTypeUDT(Oid typeId, Form_pg_type typeStruct);
 

--- a/pljava/src/main/java/org/postgresql/pljava/internal/InstallHelper.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/InstallHelper.java
@@ -306,6 +306,7 @@ public class InstallHelper
 	private static void languages( Connection c, Statement s)
 	throws SQLException
 	{
+		boolean created = false;
 		Savepoint p = null;
 		try
 		{
@@ -313,6 +314,7 @@ public class InstallHelper
 			s.execute(
 				"CREATE TRUSTED LANGUAGE java HANDLER sqlj.java_call_handler " +
 				"VALIDATOR sqlj.java_validator");
+			created = true;
 			s.execute(
 				"COMMENT ON LANGUAGE java IS '" +
 				"Trusted/sandboxed language for routines and types in " +
@@ -327,12 +329,20 @@ public class InstallHelper
 				throw sqle;
 		}
 
+		if ( ! created ) /* existed already but may need validator added */
+			s.execute(
+				"CREATE OR REPLACE " +
+				"TRUSTED LANGUAGE java HANDLER sqlj.java_call_handler " +
+				"VALIDATOR sqlj.java_validator");
+
+		created = false;
 		try
 		{
 			p = c.setSavepoint();
 			s.execute(
 				"CREATE LANGUAGE javaU HANDLER sqlj.javau_call_handler " +
 				"VALIDATOR sqlj.javau_validator");
+			created = true;
 			s.execute(
 				"COMMENT ON LANGUAGE javau IS '" +
 				"Untrusted/unsandboxed language for routines and types in " +
@@ -345,6 +355,12 @@ public class InstallHelper
 			if ( ! "42710".equals(sqle.getSQLState()) )
 				throw sqle;
 		}
+
+		if ( ! created ) /* existed already but may need validator added */
+			s.execute(
+				"CREATE OR REPLACE " +
+				"LANGUAGE javaU HANDLER sqlj.javau_call_handler " +
+				"VALIDATOR sqlj.javau_validator");
 	}
 
 	/**

--- a/pljava/src/main/java/org/postgresql/pljava/internal/InstallHelper.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/InstallHelper.java
@@ -255,6 +255,52 @@ public class InstallHelper
 				"COMMENT ON FUNCTION sqlj.javau_call_handler() IS '" +
 				"Function-call handler for PL/Java''s untrusted/unsandboxed " +
 				"language.'");
+
+		s.execute(
+			"CREATE OR REPLACE FUNCTION sqlj.javau_validator(pg_catalog.oid)" +
+			" RETURNS pg_catalog.void" +
+			" AS " + eQuote(module_path) +
+			" LANGUAGE C");
+		s.execute("REVOKE ALL PRIVILEGES" +
+			" ON FUNCTION sqlj.javau_validator(pg_catalog.oid) FROM public");
+		rs = s.executeQuery(
+			"SELECT pg_catalog.obj_description(CAST(" +
+			"'sqlj.javau_validator(pg_catalog.oid)' " +
+			"AS pg_catalog.regprocedure), " +
+			"'pg_proc')");
+		rs.next();
+		rs.getString(1);
+		noComment = rs.wasNull();
+		rs.close();
+		if ( noComment )
+			s.execute(
+				"COMMENT ON FUNCTION " +
+				"sqlj.javau_validator(pg_catalog.oid) IS '" +
+				"Function declaration validator for PL/Java''s " +
+				"untrusted/unsandboxed language.'");
+
+		s.execute(
+			"CREATE OR REPLACE FUNCTION sqlj.java_validator(pg_catalog.oid)" +
+			" RETURNS pg_catalog.void" +
+			" AS " + eQuote(module_path) +
+			" LANGUAGE C");
+		s.execute("REVOKE ALL PRIVILEGES" +
+			" ON FUNCTION sqlj.java_validator(pg_catalog.oid) FROM public");
+		rs = s.executeQuery(
+			"SELECT pg_catalog.obj_description(CAST(" +
+			"'sqlj.java_validator(pg_catalog.oid)' " +
+			"AS pg_catalog.regprocedure), " +
+			"'pg_proc')");
+		rs.next();
+		rs.getString(1);
+		noComment = rs.wasNull();
+		rs.close();
+		if ( noComment )
+			s.execute(
+				"COMMENT ON FUNCTION " +
+				"sqlj.java_validator(pg_catalog.oid) IS '" +
+				"Function declaration validator for PL/Java''s " +
+				"trusted/sandboxed language.'");
 	}
 
 	private static void languages( Connection c, Statement s)
@@ -265,7 +311,8 @@ public class InstallHelper
 		{
 			p = c.setSavepoint();
 			s.execute(
-				"CREATE TRUSTED LANGUAGE java HANDLER sqlj.java_call_handler");
+				"CREATE TRUSTED LANGUAGE java HANDLER sqlj.java_call_handler " +
+				"VALIDATOR sqlj.java_validator");
 			s.execute(
 				"COMMENT ON LANGUAGE java IS '" +
 				"Trusted/sandboxed language for routines and types in " +
@@ -284,7 +331,8 @@ public class InstallHelper
 		{
 			p = c.setSavepoint();
 			s.execute(
-				"CREATE LANGUAGE javaU HANDLER sqlj.javau_call_handler");
+				"CREATE LANGUAGE javaU HANDLER sqlj.javau_call_handler " +
+				"VALIDATOR sqlj.javau_validator");
 			s.execute(
 				"COMMENT ON LANGUAGE javau IS '" +
 				"Untrusted/unsandboxed language for routines and types in " +

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/TypeOid.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/TypeOid.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2019 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2020 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -66,6 +66,10 @@ public class TypeOid
 	 * for an Oid-reference constant.
 	 */
 	public static final int PGNODETREEOID = 194;
+	/*
+	 * Likewise in 2020.
+	 */
+	public static final int TRIGGEROID = 2279;
 
 	/*
 	 * Before Java 8 with the @Native annotation, a class needs at least one

--- a/pljava/src/main/java/org/postgresql/pljava/management/Commands.java
+++ b/pljava/src/main/java/org/postgresql/pljava/management/Commands.java
@@ -263,7 +263,7 @@ import static org.postgresql.pljava.annotation.Function.Security.DEFINER;
  * many are unchanged). It is used that way in the cache-token construction in
  * o.p.p.sqlj.Loader, which could need to be revisited if this behavior changes.
  */
-@SQLAction(install={
+@SQLAction(provides="sqlj.tables", install={
 "	CREATE TABLE sqlj.jar_repository(" +
 "		jarId       SERIAL PRIMARY KEY," +
 "		jarName     CHARACTER VARYING(100) UNIQUE NOT NULL," +
@@ -525,7 +525,8 @@ public class Commands
 	 * @throws SQLException if the type or class cannot be found, or if the
 	 *            invoking user does not own the type.
 	 */
-	@Function(schema="sqlj", name="add_type_mapping", security=DEFINER)
+	@Function(schema="sqlj", name="add_type_mapping", security=DEFINER,
+		requires="sqlj.tables")
 	public static void addTypeMapping(String sqlTypeName, String javaClassName)
 	throws SQLException
 	{
@@ -563,7 +564,8 @@ public class Commands
 	 * @throws SQLException if the type cannot be found, or if the
 	 *            invoking user does not own the type.
 	 */
-	@Function(schema="sqlj", name="drop_type_mapping", security=DEFINER)
+	@Function(schema="sqlj", name="drop_type_mapping", security=DEFINER,
+		requires="sqlj.tables")
 	public static void dropTypeMapping(String sqlTypeName) throws SQLException
 	{
 		try(PreparedStatement stmt = SQLUtils.getDefaultConnection()
@@ -588,7 +590,8 @@ public class Commands
 	 *         no classpath.
 	 * @throws SQLException
 	 */
-	@Function(schema="sqlj", name="get_classpath", security=DEFINER)
+	@Function(schema="sqlj", name="get_classpath", security=DEFINER,
+		requires="sqlj.tables")
 	public static String getClassPath(String schemaName) throws SQLException
 	{
 		try(PreparedStatement stmt = SQLUtils.getDefaultConnection()
@@ -644,7 +647,8 @@ public class Commands
 	 *             system.
 	 * @see #setClassPath
 	 */
-	@Function(schema="sqlj", name="install_jar", security=DEFINER)
+	@Function(schema="sqlj", name="install_jar", security=DEFINER,
+		requires="sqlj.tables")
 	public static void installJar(byte[] image, String jarName, boolean deploy)
 	throws SQLException
 	{
@@ -666,7 +670,8 @@ public class Commands
 	 *             system.
 	 * @see #setClassPath
 	 */
-	@Function(schema="sqlj", name="install_jar", security=DEFINER)
+	@Function(schema="sqlj", name="install_jar", security=DEFINER,
+		requires="sqlj.tables")
 	public static void installJar(String urlString, String jarName,
 		boolean deploy) throws SQLException
 	{
@@ -684,7 +689,8 @@ public class Commands
 	 *            descriptor of the jar.
 	 * @throws SQLException if the named jar cannot be found in the repository.
 	 */
-	@Function(schema="sqlj", name="remove_jar", security=DEFINER)
+	@Function(schema="sqlj", name="remove_jar", security=DEFINER,
+		requires="sqlj.tables")
 	public static void removeJar(String jarName, boolean undeploy)
 	throws SQLException
 	{
@@ -735,7 +741,8 @@ public class Commands
 	 *            deployment descriptor of the new jar.
 	 * @throws SQLException if the named jar cannot be found in the repository.
 	 */
-	@Function(schema="sqlj", name="replace_jar", security=DEFINER)
+	@Function(schema="sqlj", name="replace_jar", security=DEFINER,
+		requires="sqlj.tables")
 	public static void replaceJar(byte[] jarImage, String jarName,
 		boolean redeploy) throws SQLException
 	{
@@ -754,7 +761,8 @@ public class Commands
 	 *            deployment descriptor of the new jar.
 	 * @throws SQLException if the named jar cannot be found in the repository.
 	 */
-	@Function(schema="sqlj", name="replace_jar", security=DEFINER)
+	@Function(schema="sqlj", name="replace_jar", security=DEFINER,
+		requires="sqlj.tables")
 	public static void replaceJar(String urlString, String jarName,
 		boolean redeploy) throws SQLException
 	{
@@ -774,7 +782,8 @@ public class Commands
 	 *             if one or several names of the path denotes a nonexistant jar
 	 *             file.
 	 */
-	@Function(schema="sqlj", name="set_classpath", security=DEFINER)
+	@Function(schema="sqlj", name="set_classpath", security=DEFINER,
+		requires="sqlj.tables")
 	public static void setClassPath(String schemaName, String path)
 	throws SQLException
 	{

--- a/src/site/markdown/examples/examples.md.vm
+++ b/src/site/markdown/examples/examples.md.vm
@@ -60,6 +60,9 @@ test-related output. (To see _successful_ test-related output, be sure to
 set `client_min_messages` to a level at least as detailed as `INFO` before
 the session's first use of PL/Java.)
 
+**See the end of this page if your attempt to install the examples jar
+fails with "unable to find static method" or "no such class" messages.**
+
 $h2 Trying the examples
 
 While the deployment descriptor itself runs some of the examples, once the
@@ -122,3 +125,33 @@ command line.
 The Saxon example [documentation is here](../examples/saxon.html).
 
 [Saxon-HE]: http://www.saxonica.com/html/products/products.html
+
+$h2 Unable to find class or method (message when installing examples)
+
+As described above, there are some optionally-built examples included
+in the source. For example, there are XML Query examples that are not built
+by default because they depend on the Saxon jar.
+
+If your examples jar was built with the optional examples enabled, then
+PL/Java will normally validate that all of the functions it creates can be used.
+That validation will fail if a needed dependency, such as the Saxon jar, is
+not already installed and on the classpath. The error message can be puzzling,
+as it won't say the Saxon jar is missing, it will say it can't find a method
+that is clearly present in the examples jar. The explanation is that Java does
+not resolve the method, because a dependency is missing.
+
+There are two ways to proceed:
+
+* Install the required dependency first. Use `sqlj.install_jar` to install
+    the Saxon jar (as described [here](../examples/saxon.html)), and
+    `sqlj.set_classpath` to make it accessible, and *then* use
+    `sqlj.install_jar` to install the examples jar itself. The dependency will
+    be satisfied and all of the example functions will work.
+
+* Use `SET check_function_bodies TO off` before installing the examples jar.
+    That will simply relax the strict checking at `CREATE FUNCTION` time, so
+    that all of the example functions will be created. The ones that require
+    Saxon, of course, won't work; `SET check_function_bodies TO off` simply
+    means you get the errors later, when trying to use the functions, instead
+    of when creating them. If you install the dependency jar later and
+    add it to the class path, those functions will then work.

--- a/src/site/markdown/examples/saxon.md
+++ b/src/site/markdown/examples/saxon.md
@@ -16,14 +16,12 @@ trivial and does not require an XQuery library at all, but is missing from
 core PostgreSQL and easy to implement here.
 
 This code is not built by default, because it pulls in the sizeable [Saxon-HE][]
-library from Saxonica, and because (unlike the rest of PL/Java) it requires
-Java 8.
+library from Saxonica.
 
-To include these optional functions when building the examples, be sure to use
-a Java 8 or later build environment, and add `-Psaxon-examples` to the `mvn`
-command line.
+To include these optional functions when building the examples,
+add `-Psaxon-examples` to the `mvn` command line.
 
-The functions are presented as examples, not as fully supported for production;
+The functions are presented as examples, not as a full implementation;
 for one thing, there is no test suite included to verify their conformance.
 Nevertheless, they are intended to be substantially usable subject to the limits
 described here, and testing and reports of shortcomings are welcome.
@@ -46,14 +44,39 @@ porting queries from Oracle, which permits the same extension.
 ### Using the Saxon examples
 
 The simplest installation method is to use `sqlj.install_jar` twice, once to
-install the PL/Java examples jar in the usual way (perhaps with the name `ex`
-and with `deploy => true`), and once to install (perhaps with the name `saxon`)
-the Saxon-HE jar that Maven will have downloaded during the build. That jar
-will be found in your Maven repository (likely `~/.m2/repository/` unless you
-have directed it elsewhere) below the path `net/sf/saxon`.
+install (perhaps with the name `saxon`) the Saxon-HE jar that Maven will have
+downloaded during the build, and once to install the PL/Java examples jar in the
+usual way (perhaps with the name `examples` and with `deploy => true`). The
+Saxon jar will be found in your Maven repository (likely `~/.m2/repository/`
+unless you have directed it elsewhere) below the path `net/sf/saxon`.
 
-Then use `sqlj.set_classpath` to set a path including both jars (`'ex:saxon'` if
-you used the names suggested above).
+The function `sqlj.set_classpath` is used to make installed jars available.
+After installing the Saxon jar, if you installed it with the name `saxon`,
+add it to the class path:
+
+```
+SELECT sqlj.set_classpath('public', 'saxon');
+```
+
+This must be done before installing the `examples` jar, so that its dependencies
+on Saxon can be resolved.
+
+After both jars are installed, make sure they are both on the classpath. If
+the examples jar was installed with the name `examples`:
+
+```
+SELECT sqlj.set_classpath('public', 'examples:saxon');
+```
+
+*Note: an alternative, shorter procedure is to use
+`SET check_function_bodies TO off;` before loading the examples jar.
+With the checking turned off, the jar can be installed even if the Saxon jar
+has not been installed yet, or has not been added to the class path, so the
+order of steps is less critical. Naturally, the example functions that use Saxon
+will not work until it has been installed and added to the class path.
+`SET check_function_bodies TO off;` simply arranges that missing dependency
+errors will be reported later when the functions are used, rather than when
+they are created.*
 
 ### Calling XML functions without SQL syntactic sugar
 

--- a/src/site/markdown/use/use.md
+++ b/src/site/markdown/use/use.md
@@ -28,6 +28,12 @@ If not using Maven, you can simply add the `pljava-api` jar file to the
 class path for your Java compiler. Installation normally places the file
 in `SHAREDIR/pljava` where `SHAREDIR` is as reported by `pg_config`.
 
+## PL/Java configuration variables
+
+Several [configuration variables](variables.html) can affect PL/Java's
+operation, including some common PostgreSQL variables as well as
+PL/Java's own.
+
 ## Special topics
 
 ### Choices when mapping data types

--- a/src/site/markdown/use/variables.md
+++ b/src/site/markdown/use/variables.md
@@ -2,8 +2,22 @@
 
 These PostgreSQL configuration variables can influence PL/Java's operation:
 
+`check_function_bodies`
+: Although not technically a PL/Java variable, `check_function_bodies` affects
+    how strictly PL/Java validates a new function at the time of a
+    `CREATE FUNCTION` (or when installing a jar file with `CREATE FUNCTION`
+    among its deployment actions). With `check_function_bodies` set to `on`,
+    PL/Java will make sure that the referenced class and method can be loaded
+    and resolved. If the referenced class depends on classes in other jars,
+    those other jars must be already installed and on the class path, so
+    loading jars with dependencies in the wrong order can incur validation
+    errors. With `check_function_bodies` set to `off`, only basic syntax is
+    checked at `CREATE FUNCTION` time, so it is possible to declare functions
+    or install jars in any order, postponing any errors about unresolved
+    dependencies until later when the functions are used.
+
 `dynamic_library_path`
-: Although strictly not a PL/Java variable, `dynamic_library_path` influences
+: Another non-PL/Java variable, `dynamic_library_path` influences
     where the PL/Java native code object (`.so`, `.dll`, `.bundle`, etc.) can
     be found, if the full path is not given to the `LOAD` command.
 
@@ -18,17 +32,6 @@ These PostgreSQL configuration variables can influence PL/Java's operation:
     non-ASCII characters. (PL/Java can still be used in such a database, but
     the application code needs to know what it's doing and use the right
     conversion functions where needed.)
-
-`pljava.module_path`
-: The module path to be passed to the Java application class loader. The default
-    is computed from the PostgreSQL configuration and is usually correct, unless
-    PL/Java's files have been installed in unusual locations. If it must be set
-    explicitly, there must be at least two (and usually only two) entries, the
-    PL/Java API jar file and the PL/Java internals jar file. To determine the
-    proper setting, see
-    [finding the files produced by a PL/Java build](../install/locate.html).
-    For more on PL/Java's "module path" and "class path", see
-    [PL/Java and the Java Platform Module System](jpms.html).
 
 `pljava.debug`
 : A boolean variable that, if set `on`, stops the process on first entry to
@@ -92,6 +95,17 @@ These PostgreSQL configuration variables can influence PL/Java's operation:
 : Used by PL/Java to load the Java runtime. The full path to a `libjvm` shared
     object (filename typically ending with `.so`, `.dll`, or `.dylib`).
     To determine the proper setting, see [finding the `libjvm` library][fljvm].
+
+`pljava.module_path`
+: The module path to be passed to the Java application class loader. The default
+    is computed from the PostgreSQL configuration and is usually correct, unless
+    PL/Java's files have been installed in unusual locations. If it must be set
+    explicitly, there must be at least two (and usually only two) entries, the
+    PL/Java API jar file and the PL/Java internals jar file. To determine the
+    proper setting, see
+    [finding the files produced by a PL/Java build](../install/locate.html).
+    For more on PL/Java's "module path" and "class path", see
+    [PL/Java and the Java Platform Module System](jpms.html).
 
 `pljava.release_lingering_savepoints`
 : How the return from a PL/Java function will treat any savepoints created


### PR DESCRIPTION
PL/Java has been without one long enough. This start does not include much of an effort to improve or beautify the existing error messages for unsuccessful function definitions, but only to make the same old ugly ones happen at a more useful time, that of `CREATE FUNCTION` instead of only later with attempts to use the function.

Requires reworking some documentation, which formerly suggested installing example jars in an order that won't work if dependencies are being checked. Can either do things in the other order, or `SET check_function_bodies TO off` and go ahead without concern for ordering.