### PR TITLE
Stop Maven's suppression of javac warnings

### DIFF
--- a/pljava-api/src/main/java/module-info.java
+++ b/pljava-api/src/main/java/module-info.java
@@ -13,6 +13,7 @@
 /**
  * Defines the API for PL/Java.
  */
+@SuppressWarnings("module") // don't warn that o.p.p.internal's not visible yet
 module org.postgresql.pljava
 {
 	requires java.base;

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/MetaDataInts.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/MetaDataInts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2013 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2020 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -9,6 +9,7 @@
  * Contributors:
  *   Tada AB
  *   Filip Hrbek
+ *   Chapman Flack
  */
 package org.postgresql.pljava.example;
 
@@ -82,10 +83,10 @@ public class MetaDataInts implements ResultSetProvider {
 			} catch (InvocationTargetException e) {
 				log.info("Method: " + m[i].getName() + " => "
 						+ e.getTargetException().getMessage());
-				result = new Integer(-1);
+				result = -1;
 			} catch (Exception e) {
 				log.info("Method: " + m[i].getName() + " => " + e.getMessage());
-				result = new Integer(-1);
+				result = -1;
 			}
 
 			mn.add(m[i].getName());

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/MetaDataTest.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/MetaDataTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2013 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2020 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -9,6 +9,7 @@
  * Contributors:
  *   Tada AB
  *   Filip Hrbek
+ *   Chapman Flack
  */
 package org.postgresql.pljava.example;
 
@@ -201,7 +202,7 @@ public class MetaDataTest {
 																				// a
 																				// boolean
 					{
-						objects.add(new Boolean(param));
+						objects.add(Boolean.valueOf(param));
 						types.add(Boolean.TYPE);
 					} else if (param.startsWith("(")) // it is String, String[]
 														// or int[] null
@@ -247,14 +248,14 @@ public class MetaDataTest {
 										+ param);
 							}
 
-							intList.add(new Integer(marr.group(1)));
+							intList.add(Integer.valueOf(marr.group(1)));
 							auxParamArr = marr.group(2).trim();
 						}
 						objects.add(intList.toArray(new Integer[0]));
 						types.add(int[].class);
 					} else // it is an int
 					{
-						objects.add(new Integer(param));
+						objects.add(Integer.valueOf(param));
 						types.add(Integer.TYPE);
 					}
 

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/UsingProperties.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/UsingProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2013 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2020 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -8,6 +8,7 @@
  *
  * Contributors:
  *   Tada AB
+ *   Chapman Flack
  */
 package org.postgresql.pljava.example;
 
@@ -34,18 +35,19 @@ public class UsingProperties implements ResultSetProvider, PooledObject {
 	private static Logger s_logger = Logger.getAnonymousLogger();
 
 	public static ResultSetProvider getProperties() throws SQLException {
-		ObjectPool pool = SessionManager.current().getObjectPool(
-				UsingProperties.class);
+		ObjectPool<UsingProperties> pool =
+			SessionManager.current().getObjectPool(UsingProperties.class);
 		return (ResultSetProvider) pool.activateInstance();
 	}
 
 	private final Properties m_properties;
 
-	private final ObjectPool m_pool;
+	private final ObjectPool<UsingProperties> m_pool;
 
 	private Enumeration<?> m_propertyIterator;
 
-	public UsingProperties(ObjectPool pool) throws IOException {
+	public UsingProperties(ObjectPool<UsingProperties> pool) throws IOException
+	{
 		m_pool = pool;
 		m_properties = new Properties();
 

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/Parameters.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/Parameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2018 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2020 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -111,7 +111,7 @@ public class Parameters {
 
 	@Function(schema = "javatest", effects = IMMUTABLE)
 	public static Integer nullOnEven(int value) {
-		return (value % 2) == 0 ? null : new Integer(value);
+		return (value % 2) == 0 ? null : value;
 	}
 
 	/*

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/PassXML.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/PassXML.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2019 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2018-2020 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -70,8 +70,9 @@ import org.postgresql.pljava.annotation.SQLType;
 import static org.postgresql.pljava.example.LoggerTest.logMessage;
 
 /* Imports needed just for the SAX flavor of "low-level XML echo" below */
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.parsers.SAXParserFactory;
 import org.xml.sax.XMLReader;
-import org.xml.sax.helpers.XMLReaderFactory;
 import org.xml.sax.ContentHandler;
 import org.xml.sax.DTDHandler;
 import org.xml.sax.ext.LexicalHandler;
@@ -581,9 +582,9 @@ public class PassXML implements SQLData
 				XMLReader xr  = sxs.getXMLReader();
 				if ( null == xr )
 				{
-					xr = XMLReaderFactory.createXMLReader();
-					xr.setFeature("http://xml.org/sax/features/namespaces",
-									true);
+					SAXParserFactory spf = SAXParserFactory.newInstance();
+					spf.setNamespaceAware(true);
+					xr = spf.newSAXParser().getXMLReader();
 					/*
 					 * Important: before copying this example code for another
 					 * use, consider whether the input XML might be untrusted.
@@ -671,15 +672,11 @@ public class PassXML implements SQLData
 			throw new SQLException(
 				"IOException in lowLevelXMLEcho", "58030", e);
 		}
-		catch ( SAXException e )
+		catch (
+			ParserConfigurationException | SAXException | XMLStreamException e )
 		{
 			throw new SQLException(
-				"SAXException in lowLevelXMLEcho", "22000", e);
-		}
-		catch ( XMLStreamException e )
-		{
-			throw new SQLException(
-				"XMLStreamException in lowLevelXMLEcho", "22000", e);
+				"XML exception in lowLevelXMLEcho", "22000", e);
 		}
 		return rx;
 	}
@@ -1200,6 +1197,7 @@ public class PassXML implements SQLData
 		}
 
 		@Override
+		@SuppressWarnings("unchecked") // all the fun's when sourceClass is null
 		public <T extends Source> T getSource(Class<T> sourceClass)
 		throws SQLException
 		{
@@ -1312,6 +1310,7 @@ public class PassXML implements SQLData
 		}
 
 		@Override
+		@SuppressWarnings("unchecked") // sourceClass==StreamSource is verified
 		public <T extends Source> T getSource(Class<T> sourceClass)
 		throws SQLException
 		{

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/SPIActions.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/SPIActions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2019 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2020 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -220,6 +220,7 @@ public class SPIActions {
 		connection.close();
 	}
 
+	@SuppressWarnings("removal") // getAttribute / setAttribute
 	private static void nextState(Session session, int expected, int next)
 			throws SQLException {
 		Integer state = (Integer) session.getAttribute(SP_CHECKSTATE);
@@ -230,6 +231,7 @@ public class SPIActions {
 	}
 
 	@Function(schema="javatest", effects=IMMUTABLE)
+	@SuppressWarnings("removal") // setAttribute
 	public static int testSavepointSanity() throws SQLException {
 		Connection conn = DriverManager
 				.getConnection("jdbc:default:connection");
@@ -322,6 +324,7 @@ public class SPIActions {
 	}
 
 	@Function(schema="javatest", effects=IMMUTABLE)
+	@SuppressWarnings("removal") // setAttribute
 	public static int testTransactionRecovery() throws SQLException {
 		Connection conn = DriverManager
 				.getConnection("jdbc:default:connection");

--- a/pljava/src/main/java/org/postgresql/pljava/elog/ELogHandler.java
+++ b/pljava/src/main/java/org/postgresql/pljava/elog/ELogHandler.java
@@ -205,7 +205,11 @@ public class ELogHandler extends Handler
 		{	
 			try
 			{	
-				this.setFilter((Filter)Class.forName(val.trim()).newInstance());
+				this.setFilter((Filter)
+					Class.forName(val.trim())
+						.getDeclaredConstructor()
+						.newInstance()
+				);
 			}
 			catch (Exception e)
 			{
@@ -220,7 +224,11 @@ public class ELogHandler extends Handler
 		{	
 			try
 			{
-				this.setFormatter((Formatter)Class.forName(val.trim()).newInstance());
+				this.setFormatter((Formatter)
+					Class.forName(val.trim())
+						.getDeclaredConstructor()
+						.newInstance()
+				);
 			}
 			catch (Exception e)
 			{

--- a/pljava/src/main/java/org/postgresql/pljava/internal/Function.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/Function.java
@@ -1300,7 +1300,7 @@ public class Function
 
 		if ( null == actualArgs )
 		{
-			List<Type> pending = new LinkedList();
+			List<Type> pending = new LinkedList<>();
 			pending.add(c.getGenericSuperclass());
 			addAll(pending, c.getGenericInterfaces());
 

--- a/pljava/src/main/java/org/postgresql/pljava/internal/ObjectPoolImpl.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/ObjectPoolImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2019 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2020 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -66,6 +66,7 @@ class ObjectPoolImpl<T extends PooledObject> implements ObjectPool<T>
 	 * @return
 	 * @throws SQLException
 	 */
+	@SuppressWarnings("unchecked")
 	public static <T extends PooledObject> ObjectPoolImpl<T>
 	getObjectPool(Class<T> cls)
 	{
@@ -78,6 +79,7 @@ class ObjectPoolImpl<T extends PooledObject> implements ObjectPool<T>
 		return pool;
 	}
 
+	@SuppressWarnings("unchecked")
 	public T activateInstance()
 	throws SQLException
 	{
@@ -149,6 +151,7 @@ class ObjectPoolImpl<T extends PooledObject> implements ObjectPool<T>
 		// Obtain a handle from the pool of handles so that
 		// we have something to wrap the instance in.
 		//
+		@SuppressWarnings("unchecked")
 		PooledObjectHandle<T> handle = (PooledObjectHandle<T>)s_handlePool;
 		if(handle != null)
 			s_handlePool = handle.m_next;
@@ -160,6 +163,7 @@ class ObjectPoolImpl<T extends PooledObject> implements ObjectPool<T>
 		m_providerPool = handle;
 	}
 
+	@SuppressWarnings("unchecked")
 	public void removeInstance(T instance) throws SQLException
 	{
 		PooledObjectHandle prev = null;

--- a/pljava/src/main/java/org/postgresql/pljava/internal/Privilege.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/Privilege.java
@@ -51,14 +51,14 @@ import java.security.PrivilegedExceptionAction;
  */
 public interface Privilege
 {
-	public static <T, E extends Exception>T doPrivileged(
+	public static <T, E extends Exception> T doPrivileged(
 		Checked.Supplier<T,E> op)
 	throws E
 	{
 		try
 		{
 			return (T)AccessController.doPrivileged(
-				(PrivilegedExceptionAction)op::get);
+				(PrivilegedExceptionAction<T>)op::get);
 		}
 		catch ( PrivilegedActionException pae )
 		{
@@ -73,7 +73,7 @@ public interface Privilege
 		try
 		{
 			return (T)AccessController.doPrivileged(
-				(PrivilegedExceptionAction)op::get, acc);
+				(PrivilegedExceptionAction<T>)op::get, acc);
 		}
 		catch ( PrivilegedActionException pae )
 		{
@@ -88,7 +88,7 @@ public interface Privilege
 		try
 		{
 			return (T)AccessController.doPrivileged(
-				(PrivilegedExceptionAction)op::get, acc, perms);
+				(PrivilegedExceptionAction<T>)op::get, acc, perms);
 		}
 		catch ( PrivilegedActionException pae )
 		{
@@ -103,7 +103,7 @@ public interface Privilege
 		try
 		{
 			return (T)AccessController.doPrivilegedWithCombiner(
-				(PrivilegedExceptionAction)op::get);
+				(PrivilegedExceptionAction<T>)op::get);
 		}
 		catch ( PrivilegedActionException pae )
 		{
@@ -118,7 +118,7 @@ public interface Privilege
 		try
 		{
 			return (T)AccessController.doPrivilegedWithCombiner(
-				(PrivilegedExceptionAction)op::get, acc, perms);
+				(PrivilegedExceptionAction<T>)op::get, acc, perms);
 		}
 		catch ( PrivilegedActionException pae )
 		{
@@ -132,7 +132,7 @@ public interface Privilege
 	{
 		try
 		{
-			AccessController.doPrivileged((PrivilegedExceptionAction)() ->
+			AccessController.doPrivileged((PrivilegedExceptionAction<Void>)() ->
 			{
 				op.run();
 				return null;
@@ -150,7 +150,7 @@ public interface Privilege
 	{
 		try
 		{
-			AccessController.doPrivileged((PrivilegedExceptionAction)() ->
+			AccessController.doPrivileged((PrivilegedExceptionAction<Void>)() ->
 			{
 				op.run();
 				return null;
@@ -168,7 +168,7 @@ public interface Privilege
 	{
 		try
 		{
-			AccessController.doPrivileged((PrivilegedExceptionAction)() ->
+			AccessController.doPrivileged((PrivilegedExceptionAction<Void>)() ->
 			{
 				op.run();
 				return null;
@@ -187,7 +187,7 @@ public interface Privilege
 		try
 		{
 			AccessController
-			.doPrivilegedWithCombiner((PrivilegedExceptionAction)() ->
+			.doPrivilegedWithCombiner((PrivilegedExceptionAction<Void>)() ->
 			{
 				op.run();
 				return null;
@@ -206,7 +206,7 @@ public interface Privilege
 		try
 		{
 			AccessController
-			.doPrivilegedWithCombiner((PrivilegedExceptionAction)() ->
+			.doPrivilegedWithCombiner((PrivilegedExceptionAction<Void>)() ->
 			{
 				op.run();
 				return null;

--- a/pljava/src/main/java/org/postgresql/pljava/internal/Session.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/Session.java
@@ -236,13 +236,13 @@ public class Session implements org.postgresql.pljava.Session
 		return doInPG(() ->
 		{
 			ResultSet rs = null;
-			AclId sessionUser = AclId.getSessionUser();
+			AclId outerUser = AclId.getOuterUser();
 			AclId effectiveUser = AclId.getUser();
 			boolean wasLocalChange = false;
 			boolean changeSucceeded = false;
 			try
 			{
-				wasLocalChange = _setUser(sessionUser, true);
+				wasLocalChange = _setUser(outerUser, true);
 				changeSucceeded = true;
 				rs = stmt.executeQuery("SELECT current_schema()");
 				if ( rs.next() )

--- a/pljava/src/main/java/org/postgresql/pljava/internal/TransactionalMap.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/TransactionalMap.java
@@ -45,6 +45,7 @@ import org.postgresql.pljava.TransactionListener;
  * @author Thomas Hallgren
  */
 @Deprecated(since="1.5.3", forRemoval=true)
+@SuppressWarnings("unchecked") // fix warnings in a deprecated class? no thanks.
 public class TransactionalMap extends HashMap
 {
 	private static final long serialVersionUID = 5337569423915578121L;

--- a/pljava/src/main/java/org/postgresql/pljava/internal/UncheckedException.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/UncheckedException.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2020 Tada AB and other contributors, as listed below.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Chapman Flack
+ */
+package org.postgresql.pljava.internal;
+
+import java.io.PrintStream;
+import java.io.PrintWriter;
+
+/**
+ * An unchecked exception to efficiently wrap checked Throwables.
+ *<p>
+ * This exception does not carry a message or stack trace of its own; most of
+ * its methods proxy through to those of its 'cause', so that it does not appear
+ * as an extra layer of indirection in a typical stack trace. It has one
+ * specific new method, {@link #unwrap unwrap}, to obtain the actual wrapped
+ * throwable (as {@code getCause} is proxied to return the wrapped throwable's
+ * cause).
+ */
+public final class UncheckedException extends RuntimeException
+{
+	/**
+	 * Return the exception <em>e</em> as a {@code RuntimeException}.
+	 *<p>
+	 * Intended for use in a {@code throw unchecked(e);} construct.
+	 * If <em>e</em> is already an unchecked exception, it is simply returned;
+	 * otherwise, it is returned wrapped.
+	 * @return the supplied exception, possibly wrapped
+	 */
+	public static RuntimeException unchecked(Exception e)
+	{
+		if ( e instanceof RuntimeException )
+			return (RuntimeException)e;
+		return new UncheckedException(e);
+	}
+
+	/**
+	 * Return the throwable <em>t</em> as a {@code RuntimeException}.
+	 *<p>
+	 * Intended for use in a {@code throw unchecked(t);} construct.
+	 * If <em>t</em> is already a {@code RuntimeException}, it is simply
+	 * returned; if it is an {@code Error}, it is thrown from this method;
+	 * otherwise, it is returned wrapped.
+	 * @return the supplied exception, possibly wrapped
+	 * @throws Error or a subclass, if that's what t is
+	 */
+	public static RuntimeException unchecked(Throwable t)
+	{
+		if ( t instanceof Error )
+			throw (Error)t;
+		if ( t instanceof RuntimeException )
+			return (RuntimeException)t;
+		return new UncheckedException(t);
+	}
+
+	private UncheckedException(Throwable t)
+	{
+		super(null, null != t ? t : new NullPointerException(
+				"null 'cause' passed to UncheckedException constructor"),
+				true, false);
+	}
+
+	/**
+	 * Return the {@code Throwable} that this {@code UncheckedException} wraps.
+	 *<p>
+	 * The familiar inherited methods proxy through to the wrapped throwable
+	 * (so {@code getCause} will return <em>its</em> cause, and so on); this
+	 * distinct method is provided to undo the wrapping.
+	 * @return the wrapped Throwable
+	 */
+	public Throwable unwrap()
+	{
+		return super.getCause();
+	}
+
+	@Override
+	public Throwable fillInStackTrace()
+	{
+		super.getCause().fillInStackTrace();
+		return this;
+	}
+
+	@Override
+	public Throwable getCause()
+	{
+		return super.getCause().getCause();
+	}
+
+	@Override
+	public String getLocalizedMessage()
+	{
+		return super.getCause().getLocalizedMessage();
+	}
+
+	@Override
+	public String getMessage()
+	{
+		return super.getCause().getMessage();
+	}
+
+	@Override
+	public StackTraceElement[] getStackTrace()
+	{
+		return super.getCause().getStackTrace();
+	}
+
+	@Override
+	public Throwable initCause(Throwable cause)
+	{
+		super.getCause().initCause(cause);
+		return this;
+	}
+
+	@Override
+	public void printStackTrace()
+	{
+		super.getCause().printStackTrace();
+	}
+
+	@Override
+	public void printStackTrace(PrintStream s)
+	{
+		super.getCause().printStackTrace(s);
+	}
+
+	@Override
+	public void printStackTrace(PrintWriter s)
+	{
+		super.getCause().printStackTrace(s);
+	}
+
+	@Override
+	public void setStackTrace(StackTraceElement[] stackTrace)
+	{
+		super.getCause().setStackTrace(stackTrace);
+	}
+
+	@Override
+	public String toString()
+	{
+		return "unchecked:" + super.getCause().toString();
+	}
+}

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/AbstractResultSet.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/AbstractResultSet.java
@@ -71,7 +71,7 @@ public abstract class AbstractResultSet implements ResultSet
 		return this.getBigDecimal(this.findColumn(columnName));
 	}
 
-	@Override
+	@SuppressWarnings("deprecation") @Override
 	public BigDecimal getBigDecimal(String columnName, int scale)
 	throws SQLException
 	{
@@ -177,7 +177,7 @@ public abstract class AbstractResultSet implements ResultSet
 	}
 
 	@Override
-	public Object getObject(String columnName, Map map)
+	public Object getObject(String columnName, Map<String,Class<?>> map)
 	throws SQLException
 	{
 		return this.getObject(this.findColumn(columnName), map);
@@ -232,7 +232,7 @@ public abstract class AbstractResultSet implements ResultSet
 		return this.getTimestamp(this.findColumn(columnName), cal);
 	}
 
-	@Override
+	@SuppressWarnings("deprecation") @Override
 	public InputStream getUnicodeStream(String columnName)
 	throws SQLException
 	{

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/ObjectResultSet.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/ObjectResultSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2019 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2020 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -125,7 +125,7 @@ public abstract class ObjectResultSet extends AbstractResultSet
 	/**
 	 * Throws "unsupported" exception.
 	 */
-	@Override
+	@SuppressWarnings("deprecation") @Override
 	public BigDecimal getBigDecimal(int columnIndex, int scale)
 	throws SQLException
 	{
@@ -372,6 +372,7 @@ public abstract class ObjectResultSet extends AbstractResultSet
 	/**
 	 * Throws "unsupported" exception.
 	 */
+	@SuppressWarnings("deprecation") @Override
 	public InputStream getUnicodeStream(int columnIndex)
 	throws SQLException
 	{

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/ResultSetField.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/ResultSetField.java
@@ -1,8 +1,14 @@
 /*
- * Copyright (c) 2004, 2005, 2006 TADA AB - Taby Sweden
- * Distributed under the terms shown in the file COPYRIGHT
- * found in the root folder of this project or at
- * http://eng.tada.se/osprojects/COPYRIGHT.html
+ * Copyright (c) 2004-2020 Tada AB and other contributors, as listed below.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Thomas Hallgren
+ *   Chapman Flack
  */
 package org.postgresql.pljava.jdbc;
 
@@ -71,6 +77,7 @@ public class ResultSetField
     /*
      * @return true if the field can contain a value of specified class
      */
+    @SuppressWarnings("unchecked")
     public final boolean canContain(Class cls)
 	throws SQLException
     {

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/SPIConnection.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/SPIConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2019 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2020 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -828,6 +828,7 @@ public class SPIConnection implements Connection
 	 * in {@code ResultSet}s seems a bit suspect, as does its use in UDT input
 	 * but not output with composites.
 	 */
+	@SuppressWarnings("unchecked")
 	static <T> T basicCoercion(Class<T> cls, Object value)
 	throws SQLException
 	{
@@ -888,7 +889,7 @@ public class SPIConnection implements Connection
 				return Long.valueOf((String)value);
 
 			if(value instanceof Boolean)
-				return new Long(((Boolean)value).booleanValue() ? 1 : 0);
+				return ((Boolean)value) ? 1 : 0;
 		}
 		else if(cls == BigDecimal.class)
 		{
@@ -904,7 +905,7 @@ public class SPIConnection implements Connection
 				return Double.valueOf((String)value);
 
 			if(value instanceof Boolean)
-				return new Double(((Boolean)value).booleanValue() ? 1 : 0);
+				return ((Boolean)value) ? 1 : 0;
 		}
 		throw new SQLException("Cannot derive a Number from an object of class " + value.getClass().getName());
 	}
@@ -922,6 +923,7 @@ public class SPIConnection implements Connection
 	 * the use of the same coercion in both the retrieval and storage direction
 	 * in {@code ResultSet}s seems a bit suspect.
 	 */
+	@SuppressWarnings("unchecked")
 	static <T> T basicCalendricalCoercion(
 		Class<T> cls, Object value, Calendar cal)
 	throws SQLException

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/SPIDatabaseMetaData.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/SPIDatabaseMetaData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005-2019 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2005-2020 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -1469,7 +1469,7 @@ public class SPIDatabaseMetaData implements DatabaseMetaData
 		String columnNamePattern) throws SQLException
 	{
 		ResultSetField f[] = new ResultSetField[13];
-		ArrayList v = new ArrayList(); // The new ResultSet tuple stuff
+		ArrayList<Object[]> v = new ArrayList<>(); // New ResultSet tuple stuff
 
 		f[0] = new ResultSetField("PROCEDURE_CAT", TypeOid.VARCHAR,
 			getMaxNameLength());
@@ -1534,14 +1534,16 @@ public class SPIDatabaseMetaData implements DatabaseMetaData
 				tuple[1] = schema;
 				tuple[2] = procedureName;
 				tuple[3] = "returnValue";
-				tuple[4] = new Short((short)java.sql.DatabaseMetaData.procedureColumnReturn);
-				tuple[5] = new Short((short)m_connection.getSQLType(returnType));
+				tuple[4] = (short)
+					java.sql.DatabaseMetaData.procedureColumnReturn;
+				tuple[5] = (short)m_connection.getSQLType(returnType);
 				tuple[6] = m_connection.getPGType(returnType);
 				tuple[7] = null;
 				tuple[8] = null;
 				tuple[9] = null;
 				tuple[10] = null;
-				tuple[11] = new Short((short)java.sql.DatabaseMetaData.procedureNullableUnknown);
+				tuple[11] = (short)
+					java.sql.DatabaseMetaData.procedureNullableUnknown;
 				tuple[12] = null;
 				v.add(tuple);
 			}
@@ -1555,14 +1557,15 @@ public class SPIDatabaseMetaData implements DatabaseMetaData
 				tuple[1] = schema;
 				tuple[2] = procedureName;
 				tuple[3] = "$" + (i + 1);
-				tuple[4] = new Short((short)java.sql.DatabaseMetaData.procedureColumnIn);
-				tuple[5] = new Short((short)m_connection.getSQLType(argOid));
+				tuple[4] = (short)java.sql.DatabaseMetaData.procedureColumnIn;
+				tuple[5] = (short)m_connection.getSQLType(argOid);
 				tuple[6] = m_connection.getPGType(argOid);
 				tuple[7] = null;
 				tuple[8] = null;
 				tuple[9] = null;
 				tuple[10] = null;
-				tuple[11] = new Short((short)java.sql.DatabaseMetaData.procedureNullableUnknown);
+				tuple[11] = (short)
+					java.sql.DatabaseMetaData.procedureNullableUnknown;
 				tuple[12] = null;
 				v.add(tuple);
 			}
@@ -1583,14 +1586,16 @@ public class SPIDatabaseMetaData implements DatabaseMetaData
 					tuple[1] = schema;
 					tuple[2] = procedureName;
 					tuple[3] = columnrs.getString("attname");
-					tuple[4] = new Short((short)java.sql.DatabaseMetaData.procedureColumnResult);
-					tuple[5] = new Short((short)m_connection.getSQLType(columnTypeOid));
+					tuple[4] = (short)
+						java.sql.DatabaseMetaData.procedureColumnResult;
+					tuple[5] = (short)m_connection.getSQLType(columnTypeOid);
 					tuple[6] = m_connection.getPGType(columnTypeOid);
 					tuple[7] = null;
 					tuple[8] = null;
 					tuple[9] = null;
 					tuple[10] = null;
-					tuple[11] = new Short((short)java.sql.DatabaseMetaData.procedureNullableUnknown);
+					tuple[11] = (short)
+						java.sql.DatabaseMetaData.procedureNullableUnknown;
 					tuple[12] = null;
 					v.add(tuple);
 				}
@@ -1796,7 +1801,7 @@ public class SPIDatabaseMetaData implements DatabaseMetaData
 		sort(types);
 
 		ResultSetField f[] = new ResultSetField[1];
-		ArrayList v = new ArrayList();
+		ArrayList<Object[]> v = new ArrayList<>();
 		f[0] = new ResultSetField(new String("TABLE_TYPE"), TypeOid.VARCHAR,
 			getMaxNameLength());
 		for(int i = 0; i < types.length; i++)
@@ -1844,7 +1849,7 @@ public class SPIDatabaseMetaData implements DatabaseMetaData
 	public java.sql.ResultSet getColumns(String catalog, String schemaPattern,
 		String tableNamePattern, String columnNamePattern) throws SQLException
 	{
-		ArrayList v = new ArrayList(); // The new ResultSet tuple stuff
+		ArrayList<Object[]> v = new ArrayList<>(); // New ResultSet tuple stuff
 		ResultSetField f[] = new ResultSetField[18]; // The field descriptors
 														// for the new ResultSet
 
@@ -1925,7 +1930,7 @@ public class SPIDatabaseMetaData implements DatabaseMetaData
 			tuple[1] = rs.getString("nspname"); // Schema
 			tuple[2] = rs.getString("relname"); // Table name
 			tuple[3] = rs.getString("attname"); // Column name
-			tuple[4] = new Short((short)m_connection.getSQLType(typeOid));
+			tuple[4] = (short)m_connection.getSQLType(typeOid);
 			String pgType = m_connection.getPGType(typeOid);
 			tuple[5] = m_connection.getPGType(typeOid); // Type name
 
@@ -1950,45 +1955,44 @@ public class SPIDatabaseMetaData implements DatabaseMetaData
 			// by default no decimal_digits
 			// if the type is numeric or decimal we will
 			// overwrite later.
-			tuple[8] = new Integer(0);
+			tuple[8] = 0;
 
 			if(pgType.equals("bpchar") || pgType.equals("varchar"))
 			{
 				int atttypmod = rs.getInt("atttypmod");
-				tuple[6] = new Integer(atttypmod != -1
-										? atttypmod - VARHDRSZ
-										: 0);
+				tuple[6] = atttypmod != -1
+								? atttypmod - VARHDRSZ
+								: 0;
 			}
 			else if(pgType.equals("numeric") || pgType.equals("decimal"))
 			{
 				int attypmod = rs.getInt("atttypmod") - VARHDRSZ;
-				tuple[6] = new Integer ((attypmod >> 16) & 0xffff);
-				tuple[8] = new Integer (attypmod & 0xffff);
-				tuple[9] = new Integer(10);
+				tuple[6] = (attypmod >> 16) & 0xffff;
+				tuple[8] = attypmod & 0xffff;
+				tuple[9] = 10;
 			}
 			else if(pgType.equals("bit") || pgType.equals("varbit"))
 			{
 				tuple[6] = rs.getObject("atttypmod");
-				tuple[9] = new Integer(2);
+				tuple[9] = 2;
 			}
 			else
 			{
 				tuple[6] = rs.getObject("attlen");
-				tuple[9] = new Integer(10);
+				tuple[9] = 10;
 			}
 
 			tuple[7] = null; // Buffer length
 
-			tuple[10] = new Integer(rs
-							.getBoolean("attnotnull")
+			tuple[10] = rs.getBoolean("attnotnull") // Nullable
 							? java.sql.DatabaseMetaData.columnNoNulls
-							: java.sql.DatabaseMetaData.columnNullable); // Nullable
+							: java.sql.DatabaseMetaData.columnNullable;
 			tuple[11] = rs.getString("description"); // Description (if any)
 			tuple[12] = rs.getString("adsrc"); // Column default
 			tuple[13] = null; // sql data type (unused)
 			tuple[14] = null; // sql datetime sub (unused)
 			tuple[15] = tuple[6]; // char octet length
-			tuple[16] = new Integer(rs.getInt("attnum")); // ordinal position
+			tuple[16] = rs.getInt("attnum"); // ordinal position
 			tuple[17] = rs.getBoolean("attnotnull") ? "NO" : "YES"; // Is
 																	// nullable
 			v.add(tuple);
@@ -2021,7 +2025,7 @@ public class SPIDatabaseMetaData implements DatabaseMetaData
 	throws SQLException
 	{
 		ResultSetField f[] = new ResultSetField[8];
-		ArrayList v = new ArrayList();
+		ArrayList<Object[]> v = new ArrayList<>();
 
 		if(table == null)
 			table = "%";
@@ -2072,7 +2076,7 @@ public class SPIDatabaseMetaData implements DatabaseMetaData
 		String column = null;
 		String owner = null;
 		String[] acls = null;
-		HashMap permissions = null;
+		HashMap<String,ArrayList<String>> permissions = null;
 		String permNames[] = null;
 
 		while(rs.next())
@@ -2083,7 +2087,8 @@ public class SPIDatabaseMetaData implements DatabaseMetaData
 			owner = rs.getString("usename");
 			acls = (String[])rs.getObject("relacl");
 			permissions = parseACL(acls, owner);
-			permNames = (String[])permissions.keySet().toArray(new String[permissions.size()]);
+			permNames =
+				permissions.keySet().toArray(new String[permissions.size()]);
 			sort(permNames);
 			for(int i = 0; i < permNames.length; i++)
 			{
@@ -2133,7 +2138,7 @@ public class SPIDatabaseMetaData implements DatabaseMetaData
 		String schemaPattern, String tableNamePattern) throws SQLException
 	{
 		ResultSetField f[] = new ResultSetField[7];
-		ArrayList v = new ArrayList();
+		ArrayList<Object[]> v = new ArrayList<>();
 
 		f[0] = new ResultSetField("TABLE_CAT", TypeOid.VARCHAR,
 			getMaxNameLength());
@@ -2170,7 +2175,7 @@ public class SPIDatabaseMetaData implements DatabaseMetaData
 		String table = null;
 		String owner = null;
 		String[] acls = null;
-		HashMap permissions = null;
+		HashMap<String,ArrayList<String>> permissions = null;
 		String permNames[] = null;
 
 		while(rs.next())
@@ -2180,11 +2185,12 @@ public class SPIDatabaseMetaData implements DatabaseMetaData
 			owner = rs.getString("usename");
 			acls = (String[])rs.getObject("relacl");
 			permissions = parseACL(acls, owner);
-			permNames = (String[])permissions.keySet().toArray(new String[permissions.size()]);
+			permNames =
+				permissions.keySet().toArray(new String[permissions.size()]);
 			sort(permNames);
 			for(int i = 0; i < permNames.length; i++)
 			{
-				ArrayList grantees = (ArrayList)permissions.get(permNames[i]);
+				ArrayList<String> grantees = permissions.get(permNames[i]);
 				for(int j = 0; j < grantees.size(); j++)
 				{
 					String grantee = (String)grantees.get(j);
@@ -2210,7 +2216,8 @@ public class SPIDatabaseMetaData implements DatabaseMetaData
 	 * Add the user described by the given acl to the ArrayLists of users with the
 	 * privileges described by the acl.
 	 */
-	private void addACLPrivileges(String acl, HashMap privileges)
+	private void addACLPrivileges(
+		String acl, HashMap<String,ArrayList<String>> privileges)
 	{
 		int equalIndex = acl.lastIndexOf("=");
 		String name = acl.substring(0, equalIndex);
@@ -2263,13 +2270,9 @@ public class SPIDatabaseMetaData implements DatabaseMetaData
 				default:
 					sqlpriv = "UNKNOWN";
 			}
-			ArrayList usersWithPermission = (ArrayList)privileges.get(sqlpriv);
-			if(usersWithPermission == null)
-			{
-				usersWithPermission = new ArrayList();
-				privileges.put(sqlpriv, usersWithPermission);
-			}
-			usersWithPermission.add(name);
+			privileges
+				.computeIfAbsent(sqlpriv, k -> new ArrayList<>())
+				.add(name);
 		}
 	}
 
@@ -2278,14 +2281,16 @@ public class SPIDatabaseMetaData implements DatabaseMetaData
 	 * mapping the SQL permission name to a ArrayList of usernames who have that
 	 * permission.
 	 */
-	protected HashMap parseACL(String[] aclArray, String owner)
+	protected HashMap<String,ArrayList<String>> parseACL(
+		String[] aclArray, String owner)
 	{
 		if(aclArray == null || aclArray.length == 0)
 		{
 			// null acl is a shortcut for owner having full privs
+			// XXX (2020) the implied default depends on type of catalog object
 			aclArray = new String[] { owner + "=arwdRxt" };
 		}
-		HashMap privileges = new HashMap();
+		HashMap<String,ArrayList<String>> privileges = new HashMap<>();
 		for(int i = 0; i < aclArray.length; i++)
 		{
 			String acl = aclArray[i];
@@ -2320,7 +2325,7 @@ public class SPIDatabaseMetaData implements DatabaseMetaData
 	throws SQLException
 	{
 		ResultSetField f[] = new ResultSetField[8];
-		ArrayList v = new ArrayList(); // The new ResultSet tuple stuff
+		ArrayList<Object[]> v = new ArrayList<>(); // New ResultSet tuple stuff
 
 		f[0] = new ResultSetField("SCOPE", TypeOid.INT2, 2);
 		f[1] = new ResultSetField("COLUMN_NAME", TypeOid.VARCHAR,
@@ -2359,14 +2364,14 @@ public class SPIDatabaseMetaData implements DatabaseMetaData
 		{
 			Object[] tuple = new Object[8];
 			Oid columnTypeOid = (Oid)rs.getObject("atttypid");
-			tuple[0] = new Short((short)scope);
+			tuple[0] = (short)scope;
 			tuple[1] = rs.getString("attname");
-			tuple[2] = new Short((short)m_connection.getSQLType(columnTypeOid));
+			tuple[2] = (short)m_connection.getSQLType(columnTypeOid);
 			tuple[3] = m_connection.getPGType(columnTypeOid);
 			tuple[4] = null;
 			tuple[5] = null;
 			tuple[6] = null;
-			tuple[7] = new Short((short)java.sql.DatabaseMetaData.bestRowNotPseudo);
+			tuple[7] = (short)java.sql.DatabaseMetaData.bestRowNotPseudo;
 			v.add(tuple);
 		}
 
@@ -2393,7 +2398,7 @@ public class SPIDatabaseMetaData implements DatabaseMetaData
 		String table) throws SQLException
 	{
 		ResultSetField f[] = new ResultSetField[8];
-		ArrayList v = new ArrayList(); // The new ResultSet tuple stuff
+		ArrayList<Object[]> v = new ArrayList<>(); // New ResultSet tuple stuff
 
 		f[0] = new ResultSetField("SCOPE", TypeOid.INT2, 2);
 		f[1] = new ResultSetField("COLUMN_NAME", TypeOid.VARCHAR,
@@ -2420,12 +2425,12 @@ public class SPIDatabaseMetaData implements DatabaseMetaData
 
 		tuple[0] = null;
 		tuple[1] = "ctid";
-		tuple[2] = new Short((short)m_connection.getSQLType("tid"));
+		tuple[2] = (short)m_connection.getSQLType("tid");
 		tuple[3] = "tid";
 		tuple[4] = null;
 		tuple[5] = null;
 		tuple[6] = null;
-		tuple[7] = new Short((short)java.sql.DatabaseMetaData.versionColumnPseudo);
+		tuple[7] = (short)java.sql.DatabaseMetaData.versionColumnPseudo;
 		v.add(tuple);
 
 		/*
@@ -2768,7 +2773,7 @@ public class SPIDatabaseMetaData implements DatabaseMetaData
 	{
 
 		ResultSetField f[] = new ResultSetField[18];
-		ArrayList v = new ArrayList(); // The new ResultSet tuple stuff
+		ArrayList<Object[]> v = new ArrayList<>(); // New ResultSet tuple stuff
 
 		f[0] = new ResultSetField("TYPE_NAME", TypeOid.VARCHAR,
 			getMaxNameLength());
@@ -2801,10 +2806,10 @@ public class SPIDatabaseMetaData implements DatabaseMetaData
 		ResultSet rs = m_connection.createStatement().executeQuery(sql);
 		// cache some results, this will keep memory useage down, and speed
 		// things up a little.
-		Integer i9 = new Integer(9);
-		Integer i10 = new Integer(10);
-		Short nn = new Short((short)java.sql.DatabaseMetaData.typeNoNulls);
-		Short ts = new Short((short)java.sql.DatabaseMetaData.typeSearchable);
+		Integer i9 = 9;
+		Integer i10 = 10;
+		Short nn = (short)java.sql.DatabaseMetaData.typeNoNulls;
+		Short ts = (short)java.sql.DatabaseMetaData.typeSearchable;
 
 		String typname = null;
 
@@ -2813,7 +2818,7 @@ public class SPIDatabaseMetaData implements DatabaseMetaData
 			Object[] tuple = new Object[18];
 			typname = rs.getString(1);
 			tuple[0] = typname;
-			tuple[1] = new Short((short)m_connection.getSQLType(typname));
+			tuple[1] = (short)m_connection.getSQLType(typname);
 			tuple[2] = i9; // for now
 			tuple[6] = nn; // for now
 			tuple[7] = Boolean.FALSE; // false for now - not case sensitive
@@ -3517,7 +3522,8 @@ public class SPIDatabaseMetaData implements DatabaseMetaData
 	 * This method creates a ResultSet which is not associated with any
 	 * statement.
 	 */
-	private ResultSet createSyntheticResultSet(ResultSetField[] f, ArrayList tuples)
+	private ResultSet createSyntheticResultSet(
+		ResultSetField[] f, ArrayList<Object[]> tuples)
 	throws SQLException
 	{
 		return new SyntheticResultSet(f, tuples);

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/SPIPreparedStatement.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/SPIPreparedStatement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2019 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2020 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -186,7 +186,7 @@ public class SPIPreparedStatement extends SPIStatement implements PreparedStatem
 			Types.CLOB);
 	}
 
-	@Override
+	@SuppressWarnings("deprecation") @Override
 	public void setUnicodeStream(int columnIndex, InputStream value, int arg2) throws SQLException
 	{
 		throw new UnsupportedFeatureException("PreparedStatement.setUnicodeStream");

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/SPIStatement.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/SPIStatement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2018 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2020 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -41,7 +41,7 @@ public class SPIStatement implements Statement, SPIReadOnlyControl
 	private int       m_maxRows        = 0;
 	private ResultSet m_resultSet      = null;
 	private long      m_updateCount    = 0;
-	private ArrayList m_batch          = null;
+	private ArrayList<Object> m_batch  = null;
 	private boolean   m_closed         = false;
 	private short     m_readonly_spec  = ExecutionPlan.SPI_READONLY_DEFAULT;
 
@@ -408,11 +408,17 @@ public class SPIStatement implements Statement, SPIReadOnlyControl
 		throw new UnsupportedFeatureException("Statement.setQueryTimeout");
 	}
 
+	/**
+	 * The argument is either a {@code String} containing SQL (if from a
+	 * {@code Statement}, or an {@code Object} array of length three (if from
+	 * a {@code PreparedStatement}) holding parameter values, SQL types, and
+	 * PG type Oids.
+	 */
 	protected void internalAddBatch(Object batch)
 	throws SQLException
 	{
 		if(m_batch == null)
-			m_batch = new ArrayList();
+			m_batch = new ArrayList<Object>();
 		m_batch.add(batch);
 	}
 

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/SingleRowWriter.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/SingleRowWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2018 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2020 Tada AB and other contributors, as listed below.
  * Copyright (c) 2010, 2011 PostgreSQL Global Development Group
  *
  * All rights reserved. This program and the accompanying materials
@@ -89,7 +89,7 @@ public class SingleRowWriter extends SingleRowResultSet
 		if(x == null)
 			m_values[columnIndex-1] = x;
 
-		Class c = m_tupleDesc.getColumnClass(columnIndex);
+		Class<?> c = m_tupleDesc.getColumnClass(columnIndex);
 		TypeBridge<?>.Holder xAlt = TypeBridge.wrap(x);
 		if(null == xAlt  &&  !c.isInstance(x)
 		&& !(c == byte[].class && (x instanceof BlobValue)))

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/SyntheticResultSet.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/SyntheticResultSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2019 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2020 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -47,7 +47,7 @@ public class SyntheticResultSet extends ResultSetBase
 		super(tuples.size());
 		m_fields = fields;
 		m_tuples = tuples;
-        m_fieldIndexes = new HashMap();
+        m_fieldIndexes = new HashMap<>();
         int i = m_fields.length;
         while(--i >= 0)
             m_fieldIndexes.put(m_fields[i].getColumnLabel(), i+1);

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/TriggerResultSet.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/TriggerResultSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2019 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2020 Tada AB and other contributors, as listed below.
  * Copyright (c) 2010, 2011 PostgreSQL Global Development Group
  *
  * All rights reserved. This program and the accompanying materials
@@ -28,7 +28,7 @@ import org.postgresql.pljava.internal.TupleDesc;
  */
 public class TriggerResultSet extends SingleRowResultSet
 {
-	private ArrayList m_tupleChanges;
+	private ArrayList<Object> m_tupleChanges;
 	private final TupleDesc m_tupleDesc;
 	private final Tuple     m_tuple;
 	private final boolean   m_readOnly;
@@ -92,7 +92,7 @@ public class TriggerResultSet extends SingleRowResultSet
 			throw new UnsupportedFeatureException("ResultSet is read-only");
 
 		if(m_tupleChanges == null)
-			m_tupleChanges = new ArrayList();
+			m_tupleChanges = new ArrayList<>();
 
 		m_tupleChanges.add(columnIndex);
 		m_tupleChanges.add(x);
@@ -111,7 +111,7 @@ public class TriggerResultSet extends SingleRowResultSet
 	 */
 	public Object[] getChangeIndexesAndValues()
 	{
-		ArrayList changes = m_tupleChanges;
+		ArrayList<Object> changes = m_tupleChanges;
 		if(changes == null)
 			return null;
 

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/TypeBridge.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/TypeBridge.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018- Tada AB and other contributors, as listed below.
+ * Copyright (c) 2018-2020 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -64,6 +64,12 @@ public abstract class TypeBridge<S>
 	 */
 	protected Class<S> m_cachedClass;
 
+	@SuppressWarnings("unchecked")
+	protected void setCachedClass(Class<?> cls)
+	{
+		m_cachedClass = (Class<S>)cls;
+	}
+
 	/**
 	 * List of TypeBridges to check, in order, for one that 'captures' a given
 	 * class.
@@ -90,9 +96,13 @@ public abstract class TypeBridge<S>
 		if ( null == o )
 			return null;
 		Class<?> c = o.getClass();
-		for ( TypeBridge tb : m_candidates )
+		for ( TypeBridge<?> tb : m_candidates )
 			if ( tb.captures(c) )
-				return ((TypeBridge<T>)tb).new Holder(o);
+			{
+				@SuppressWarnings("unchecked")
+				TypeBridge<T> tbt = (TypeBridge<T>)tb;
+				return tbt.new Holder(o);
+			}
 		if ( o instanceof TypeBridge<?>.Holder )
 			throw new IllegalArgumentException("Not valid as argument: " +
 				o.toString());
@@ -137,7 +147,7 @@ public abstract class TypeBridge<S>
 	private static <T> TypeBridge<T> of(Class<T> c, int dOid)
 	{
 		String cn = c.getCanonicalName();
-		TypeBridge tb =
+		TypeBridge<T> tb =
 			c.isInterface() ? ofInterface(cn, dOid) : ofClass(cn, dOid);
 		tb.m_cachedClass = c;
 		return tb;
@@ -182,7 +192,7 @@ public abstract class TypeBridge<S>
 			{
 				if ( ! m_canonName.equals(c.getCanonicalName()) )
 					continue;
-				m_cachedClass = (Class<S>)c;
+				setCachedClass(c);
 				return true;
 			}
 			return false;
@@ -220,7 +230,7 @@ public abstract class TypeBridge<S>
 
 				if ( m_canonName.equals(c.getCanonicalName()) )
 				{
-					m_cachedClass = (Class<S>)c;
+					setCachedClass(c);
 					return true;
 				}
 				addAll(q, c.getInterfaces());

--- a/pljava/src/main/java/org/postgresql/pljava/sqlj/Loader.java
+++ b/pljava/src/main/java/org/postgresql/pljava/sqlj/Loader.java
@@ -283,7 +283,7 @@ public class Loader extends ClassLoader
 				{
 					String javaClassName = rs.getString(1);
 					String sqlName = rs.getString(2);
-					Class cls = loader.loadClass(javaClassName);
+					Class<?> cls = loader.loadClass(javaClassName);
 					if(!SQLData.class.isAssignableFrom(cls))
 						throw new SQLException("Class " + javaClassName +
 							" does not implement java.sql.SQLData");
@@ -299,7 +299,7 @@ public class Loader extends ClassLoader
 				}
 			}
 			if(typesForSchema.isEmpty())
-				typesForSchema = Collections.EMPTY_MAP;
+				typesForSchema = Map.of();
 			s_typeMap.put(schema, typesForSchema);
 			return typesForSchema;
 		}

--- a/pljava/src/main/java/org/postgresql/pljava/sqlj/Loader.java
+++ b/pljava/src/main/java/org/postgresql/pljava/sqlj/Loader.java
@@ -13,30 +13,37 @@
 package org.postgresql.pljava.sqlj;
 
 import java.io.IOException;
+
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 import static java.lang.invoke.MethodType.methodType;
-import java.lang.reflect.UndeclaredThrowableException;
+
 import java.net.MalformedURLException;
 import java.net.URL;
+
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLData;
 import java.sql.SQLException;
 import java.sql.Statement;
+
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.NoSuchElementException;
+
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.postgresql.pljava.internal.Backend;
+import org.postgresql.pljava.internal.Checked;
 import org.postgresql.pljava.internal.Oid;
-import org.postgresql.pljava.jdbc.SQLUtils;
+import static org.postgresql.pljava.internal.UncheckedException.unchecked;
+
+import static org.postgresql.pljava.jdbc.SQLUtils.getDefaultConnection;
 
 /*
  * Import an interface (internal-only, at least for now) that allows overriding
@@ -72,7 +79,15 @@ public class Loader extends ClassLoader
 {
 	private final static Logger s_logger = Logger.getLogger(Loader.class.getName());
 
-	static class EntryEnumeration implements Enumeration
+	/**
+	 * The enumeration of URLs returned by {@code findResources}.
+	 *<p>
+	 * The returned URLs have a "dbf:" scheme and expose the integer surrogate
+	 * keys of jar entries, not a very stable way to refer to an entry in a jar,
+	 * but perhaps adequate for now, as no one will be constructing such URLs
+	 * or obtaining them except from {@code findResources} here.
+	 */
+	static class EntryEnumeration implements Enumeration<URL>
 	{
 		private final int[] m_entryIds;
 		private int m_top = 0;
@@ -87,7 +102,7 @@ public class Loader extends ClassLoader
 			return (m_top < m_entryIds.length);
 		}
 		
-		public Object nextElement()
+		public URL nextElement()
 		throws NoSuchElementException
 		{
 			if (m_top >= m_entryIds.length)
@@ -126,19 +141,15 @@ public class Loader extends ClassLoader
 	throws SQLException
 	{
 		String schema;
-		Statement stmt = SQLUtils.getDefaultConnection().createStatement();
-		ResultSet rs = null;
-		try
+		try (
+			Statement stmt = getDefaultConnection().createStatement();
+			ResultSet rs =
+				stmt.executeQuery("SELECT pg_catalog.current_schema()");
+		)
 		{
-			rs = stmt.executeQuery("SELECT pg_catalog.current_schema()");
 			if(!rs.next())
 				throw new SQLException("Unable to determine current schema");
 			schema = rs.getString(1);
-		}
-		finally
-		{
-			SQLUtils.close(rs);
-			SQLUtils.close(stmt);
 		}
 		return getSchemaLoader(schema);
 	}
@@ -162,15 +173,12 @@ public class Loader extends ClassLoader
 		if(loader != null)
 			return loader;
 
-		Map classImages = new HashMap();
-		Connection conn = SQLUtils.getDefaultConnection();
-		PreparedStatement outer = null;
-		PreparedStatement inner = null;
-		try
-		{
+		Map<String,int[]> classImages = new HashMap<>();
+		Connection conn = getDefaultConnection();
+		try (
 			// Read the entries so that the one with highest prio is read last.
 			//
-			outer = conn.prepareStatement(
+			PreparedStatement outer = conn.prepareStatement(
 				"SELECT r.jarId" +
 				" FROM" +
 				"  sqlj.jar_repository r" +
@@ -178,28 +186,26 @@ public class Loader extends ClassLoader
 				"  ON r.jarId OPERATOR(pg_catalog.=) c.jarId" +
 				" WHERE c.schemaName OPERATOR(pg_catalog.=) ?" +
 				" ORDER BY c.ordinal DESC");
-
-			inner = conn.prepareStatement(
+			PreparedStatement inner = conn.prepareStatement(
 				"SELECT entryId, entryName FROM sqlj.jar_entry " +
 				"WHERE jarId OPERATOR(pg_catalog.=) ?");
-
+		)
+		{
 			outer.unwrap(SPIReadOnlyControl.class).clearReadOnly();
 			inner.unwrap(SPIReadOnlyControl.class).clearReadOnly();
 			outer.setString(1, schemaName);
-			ResultSet rs = outer.executeQuery();
-			try
+			try ( ResultSet rs = outer.executeQuery() )
 			{
 				while(rs.next())
 				{
 					inner.setInt(1, rs.getInt(1));
-					ResultSet rs2 = inner.executeQuery();
-					try
+					try ( ResultSet rs2 = inner.executeQuery() )
 					{
 						while(rs2.next())
 						{
 							int entryId = rs2.getInt(1);
 							String entryName = rs2.getString(2);
-							int[] oldEntry = (int[])classImages.get(entryName);
+							int[] oldEntry = classImages.get(entryName);
 							if(oldEntry == null)
 								classImages.put(entryName, new int[] { entryId });
 							else
@@ -212,21 +218,8 @@ public class Loader extends ClassLoader
 							}
 						}
 					}
-					finally
-					{
-						SQLUtils.close(rs2);
-					}
 				}
 			}
-			finally
-			{
-				SQLUtils.close(rs);
-			}
-		}
-		finally
-		{
-			SQLUtils.close(outer);
-			SQLUtils.close(inner);
 		}
 
 		ClassLoader parent = ClassLoader.getSystemClassLoader();
@@ -236,7 +229,8 @@ public class Loader extends ClassLoader
 			// classpath of public schema or to the system classloader if the
 			// request already is for the public schema.
 			//
-			loader = schemaName.equals(PUBLIC_SCHEMA) ? parent : getSchemaLoader(PUBLIC_SCHEMA);
+			loader = schemaName.equals(PUBLIC_SCHEMA)
+				? parent : getSchemaLoader(PUBLIC_SCHEMA);
 		else
 			loader = new Loader(classImages, parent);
 
@@ -263,21 +257,26 @@ public class Loader extends ClassLoader
 			return typesForSchema;
 
 		s_logger.finer("Creating typeMappings for schema " + schema);
-		typesForSchema = new HashMap()
+		typesForSchema = new HashMap<Oid,Class<? extends SQLData>>()
 		{
-			public Object get(Object key)
+			public Class<? extends SQLData> get(Oid key)
 			{
 				s_logger.finer("Obtaining type mapping for OID " + key + " for schema " + schema);
 				return super.get(key);
 			}
 		};
 		ClassLoader loader = Loader.getSchemaLoader(schema);
-		Statement stmt = SQLUtils.getDefaultConnection().createStatement();
-		stmt.unwrap(SPIReadOnlyControl.class).clearReadOnly();
-		ResultSet rs = null;
-		try
+		try (
+			Statement stmt = Checked.Supplier.of((() ->
+			{
+				Statement s = getDefaultConnection().createStatement();
+				s.unwrap(SPIReadOnlyControl.class).clearReadOnly();
+				return s;
+			})).get();
+			ResultSet rs = stmt.executeQuery(
+				"SELECT javaName, sqlName FROM sqlj.typemap_entry");
+		)
 		{
-			rs = stmt.executeQuery("SELECT javaName, sqlName FROM sqlj.typemap_entry");
 			while(rs.next())
 			{
 				try
@@ -286,11 +285,13 @@ public class Loader extends ClassLoader
 					String sqlName = rs.getString(2);
 					Class cls = loader.loadClass(javaClassName);
 					if(!SQLData.class.isAssignableFrom(cls))
-						throw new SQLException("Class " + javaClassName + " does not implement java.sql.SQLData");
+						throw new SQLException("Class " + javaClassName +
+							" does not implement java.sql.SQLData");
 					
 					Oid typeOid = Oid.forTypeName(sqlName);
 					typesForSchema.put(typeOid, cls.asSubclass(SQLData.class));
-					s_logger.finer("Adding type mapping for OID " + typeOid + " -> class " + cls.getName() + " for schema " + schema);
+					s_logger.finer("Adding type mapping for OID " + typeOid +
+						" -> class " + cls.getName() + " for schema " + schema);
 				}
 				catch(ClassNotFoundException e)
 				{
@@ -301,11 +302,6 @@ public class Loader extends ClassLoader
 				typesForSchema = Collections.EMPTY_MAP;
 			s_typeMap.put(schema, typesForSchema);
 			return typesForSchema;
-		}
-		finally
-		{
-			SQLUtils.close(rs);
-			SQLUtils.close(stmt);
 		}
 	}
 
@@ -322,29 +318,35 @@ public class Loader extends ClassLoader
 		}
 		catch(MalformedURLException e)
 		{
-			throw new RuntimeException(e);
+			throw unchecked(e);
 		}
 	}
 
-	private final Map m_entries;
+	/**
+	 * Map from name of entry (resource or expanded class name) to an array of
+	 * the integer surrogate keys for jar entries, in the order of jars on this
+	 * loader's jar path that contain entries matching the name.
+	 */
+	private final Map<String,int[]> m_entries;
 
 	/**
 	 * Create a new Loader.
 	 * @param entries
 	 * @param parent
 	 */
-	Loader(Map entries, ClassLoader parent)
+	Loader(Map<String,int[]> entries, ClassLoader parent)
 	{
 		super(parent);
 		m_entries = entries;
 		m_j9Helper = ifJ9getHelper(); // null if not under OpenJ9 with sharing
 	}
 
+	@Override
 	protected Class<?> findClass(final String name)
 	throws ClassNotFoundException
 	{
 		String path = name.replace('.', '/').concat(".class");
-		int[] entryId = (int[])m_entries.get(path);
+		int[] entryId = m_entries.get(path);
 		if(entryId != null)
 		{
 			/*
@@ -365,26 +367,32 @@ public class Loader extends ClassLoader
 			}
 			String ifJ9token = (String) o; // used below when storing class
 
-			PreparedStatement stmt = null;
-			ResultSet rs = null;
-			try
-			{
+			try (
 				// This code relies heavily on the fact that the connection
 				// is a singleton and that the prepared statement will live
-				// for the duration of the loader.
+				// for the duration of the loader. (This comment has said so
+				// since January 2004; the prepared statement has been getting
+				// closed in a finally block since November 2004, and that
+				// hasn't broken anything, and it is currently true that
+				// prepared statements are backed by ExecutionPlans that stick
+				// around in an MRU cache after being closed.)
 				//
-				stmt = SQLUtils.getDefaultConnection().prepareStatement(
-					"SELECT entryImage FROM sqlj.jar_entry " +
-					"WHERE entryId OPERATOR(pg_catalog.=) ?");
-
-				stmt.setInt(1, entryId[0]);
-				stmt.unwrap(SPIReadOnlyControl.class).clearReadOnly();
-				rs = stmt.executeQuery();
+				PreparedStatement stmt = Checked.Supplier.of((() ->
+					{
+						PreparedStatement s = getDefaultConnection()
+							.prepareStatement(
+								"SELECT entryImage FROM sqlj.jar_entry " +
+								"WHERE entryId OPERATOR(pg_catalog.=) ?");
+						s.unwrap(SPIReadOnlyControl.class).clearReadOnly();
+						s.setInt(1, entryId[0]);
+						return s;
+					})).get();
+				ResultSet rs = stmt.executeQuery();
+			)
+			{
 				if(rs.next())
 				{
 					byte[] img = rs.getBytes(1);
-					rs.close();
-					rs = null;
 
 					Class<?> cls = this.defineClass(name, img, 0, img.length);
 
@@ -394,31 +402,30 @@ public class Loader extends ClassLoader
 			}
 			catch(SQLException e)
 			{
-				Logger.getAnonymousLogger().log(Level.INFO, "Failed to load class", e);
-				throw new ClassNotFoundException(name + " due to: " + e.getMessage());
-			}
-			finally
-			{
-				SQLUtils.close(rs);
-				SQLUtils.close(stmt);
+				Logger.getAnonymousLogger().log(Level.INFO,
+					"Failed to load class", e);
+				throw new ClassNotFoundException(name + " due to: " +
+					e.getMessage(), e);
 			}
 		}
-	throw new ClassNotFoundException(name);
+		throw new ClassNotFoundException(name);
 	}
 
+	@Override
 	protected URL findResource(String name)
 	{
-		int[] entryIds = (int[])m_entries.get(name);
+		int[] entryIds = m_entries.get(name);
 		if(entryIds == null)
 			return null;
 		
 		return entryURL(entryIds[0]);
 	}
 
-	protected Enumeration findResources(String name)
+	@Override
+	protected Enumeration<URL> findResources(String name)
     throws IOException
 	{
-		int[] entryIds = (int[])m_entries.get(name);
+		int[] entryIds = m_entries.get(name);
 		if(entryIds == null)
 			entryIds = new int[0];
 		return new EntryEnumeration(entryIds);
@@ -450,11 +457,7 @@ public class Loader extends ClassLoader
 		}
 		catch ( Throwable t )
 		{
-			if ( t instanceof Error )
-				throw (Error)t;
-			if ( t instanceof RuntimeException )
-				throw (RuntimeException)t;
-			throw new UndeclaredThrowableException(t, t.getMessage());
+			throw unchecked(t);
 		}
 	}
 
@@ -489,11 +492,7 @@ public class Loader extends ClassLoader
 		}
 		catch ( Throwable t )
 		{
-			if ( t instanceof Error )
-				throw (Error)t;
-			if ( t instanceof RuntimeException )
-				throw (RuntimeException)t;
-			throw new UndeclaredThrowableException(t, t.getMessage());
+			throw unchecked(t);
 		}
 	}
 
@@ -518,11 +517,7 @@ public class Loader extends ClassLoader
 		}
 		catch ( Throwable t )
 		{
-			if ( t instanceof Error )
-				throw (Error)t;
-			if ( t instanceof RuntimeException )
-				throw (RuntimeException)t;
-			throw new UndeclaredThrowableException(t, t.getMessage());
+			throw unchecked(t);
 		}
 	}
 

--- a/pom.xml
+++ b/pom.xml
@@ -139,6 +139,7 @@
 				<configuration>
 					<encoding>${project.build.sourceEncoding}</encoding>
 					<release>9</release>
+					<showWarnings>true</showWarnings>
 				</configuration>
 			</plugin>
 			<plugin>


### PR DESCRIPTION
What a riot: the `nar-maven-plugin` goads `gcc` into flooding the output with every least interesting warning it's got, while at the same time the `maven-compiler-plugin` has been telling `javac` all along, by default, to report _no warnings at all_.
    
Override that default, and chase down a bunch of warnings thoughout the code that have not been visible in normal builds.