### PR TITLE
Improve DDR generator by recognizing implicit dependencies (types and functions that use them, etc.)

### DIFF
--- a/pljava-api/src/main/java/org/postgresql/pljava/annotation/processing/DDRProcessor.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/annotation/processing/DDRProcessor.java
@@ -901,9 +901,14 @@ hunt:	for ( ExecutableElement ee : ees )
 		{
 			Object v = getValue( av);
 			if ( isEnum )
-				v = Enum.valueOf( k.asSubclass( Enum.class),
+			{
+				@SuppressWarnings({"unchecked"})
+				T t = (T)Enum.valueOf( k.asSubclass( Enum.class),
 					((VariableElement)v).getSimpleName().toString());
-			a[i++] = k.cast( v);
+				a[i++] = t;
+			}
+			else
+				a[i++] = k.cast( v);
 		}
 		return a;
 	}
@@ -1075,8 +1080,12 @@ hunt:	for ( ExecutableElement ee : ees )
 						}
 					}
 					else if ( fkl.isEnum() )
-						f.set( inst, Enum.valueOf( fkl.asSubclass( Enum.class),
-							((VariableElement)v).getSimpleName().toString()));
+					{
+						@SuppressWarnings("unchecked")
+						Object t = Enum.valueOf( fkl.asSubclass( Enum.class),
+							((VariableElement)v).getSimpleName().toString());
+						f.set( inst, t);
+					}
 					else
 						f.set( inst, v);
 					nsme = null;
@@ -2633,10 +2642,7 @@ hunt:	for ( ExecutableElement ee : ees )
 			{    
 				ArrayList<Map.Entry<TypeMirror, String>> ms = finalMappings;
 				if ( contravariant )
-				{
-					ms = (ArrayList<Map.Entry<TypeMirror, String>>)ms.clone();
-					Collections.reverse( ms);
-				}
+					ms = reversed(ms);
 				for ( Map.Entry<TypeMirror, String> me : ms )
 				{
 					TypeMirror ktm = me.getKey();
@@ -2760,6 +2766,17 @@ hunt:	for ( ExecutableElement ee : ees )
 			av.getClass().getCanonicalName()) )
 			throw new AnnotationValueException();
 		return av.getValue();
+	}
+
+	/**
+	 * Return a reversed copy of an ArrayList.
+	 */
+	static <E, T extends ArrayList<E>> T reversed(T orig)
+	{
+		@SuppressWarnings("unchecked")
+		T list = (T)orig.clone();
+		Collections.reverse(list);
+		return list;
 	}
 }
 
@@ -2903,8 +2920,8 @@ class VertexPair<P>
 
 	VertexPair( P payload)
 	{
-		fwd = new Vertex( payload);
-		rev = new Vertex( payload);
+		fwd = new Vertex<>( payload);
+		rev = new Vertex<>( payload);
 	}
 
 	P payload()

--- a/pljava-api/src/main/java/org/postgresql/pljava/annotation/processing/DDRProcessor.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/annotation/processing/DDRProcessor.java
@@ -2018,23 +2018,16 @@ hunt:	for ( ExecutableElement ee : ees )
 
 	static enum BaseUDTFunctionID
 	{
-		INPUT( "in", "pg_catalog.cstring, pg_catalog.oid, integer", null),
-		OUTPUT( "out", null, "pg_catalog.cstring"),
-		RECEIVE( "recv", "pg_catalog.internal, pg_catalog.oid, integer", null),
-		SEND( "send", null, "pg_catalog.bytea");
-		BaseUDTFunctionID( String suffix, String param, String ret)
+		INPUT("in", null, "pg_catalog.cstring", "pg_catalog.oid", "integer"),
+		OUTPUT("out", "pg_catalog.cstring", (String[])null),
+		RECEIVE("recv", null, "pg_catalog.internal","pg_catalog.oid","integer"),
+		SEND("send", "pg_catalog.bytea", null);
+		BaseUDTFunctionID( String suffix, String ret, String... param)
 		{
 			this.suffix = suffix;
 			this.param = null == param ? null :
-				/*
-				 * Caution: do not assume this code is reusable for the general
-				 * case of parsing a comma-separated list of identifiers (there
-				 * could be commas in delimited ones!). It only needs to parse
-				 * the known comma-space-separated constants used in this enum.
-				 */
-				compile(", ").splitAsStream(param)
-				.map(Identifier.Qualified::nameFromJava)
-				.map(DBType.Named::new)
+				Arrays.stream(param)
+				.map(DBType::fromSQLTypeAnnotation)
 				.toArray(DBType[]::new);
 			this.ret = null == ret ? null :
 				new DBType.Named(Identifier.Qualified.nameFromJava(ret));

--- a/pljava-api/src/main/java/org/postgresql/pljava/annotation/processing/DDRWriter.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/annotation/processing/DDRWriter.java
@@ -21,6 +21,8 @@ import java.util.regex.Pattern;
 import static javax.tools.Diagnostic.Kind.ERROR;
 import static javax.tools.StandardLocation.CLASS_OUTPUT;
 
+import org.postgresql.pljava.sqlgen.Lexicals.Identifier;
+
 import static org.postgresql.pljava.sqlgen.Lexicals.ISO_PG_JAVA_IDENTIFIER;
 
 /**
@@ -64,13 +66,13 @@ public class DDRWriter
 		
 		for ( Snippet snip : fwdSnips )
 			for ( String s : snip.deployStrings() )
-				writeCommand( w, s, snip.implementor());
+				writeCommand( w, s, snip.implementorName());
 
 		w.write( "END INSTALL\",\n\"BEGIN REMOVE\n");
 		
 		for ( Snippet snip : revSnips )
 			for ( String s : snip.undeployStrings() )
-				writeCommand( w, s, snip.implementor());
+				writeCommand( w, s, snip.implementorName());
 
 		w.write( "END REMOVE\"\n}\n");
 		
@@ -91,13 +93,13 @@ public class DDRWriter
 	 * is implementor-nonspecific. PostgreSQL is the string to use for
 	 * PostgreSQL-specific commands.
 	 */
-	static void writeCommand( Writer w, String s, String implementor)
+	static void writeCommand( Writer w, String s, Identifier.Simple implementor)
 	throws IOException
 	{
 		if ( null != implementor )
 		{
 			w.write( "BEGIN ");
-			w.write( implementor);
+			w.write( implementor.toString());
 			w.write( '\n');
 		}
 
@@ -106,7 +108,7 @@ public class DDRWriter
 		if ( null != implementor )
 		{
 			w.write( "\nEND ");
-			w.write( implementor);
+			w.write( implementor.toString());
 		}
 
 		w.write( ";\n");
@@ -164,7 +166,7 @@ public class DDRWriter
 		
 		for ( Snippet snip : snips )
 		{
-			String implementor = snip.implementor();
+			String implementor = snip.implementorName().nonFolded();
 			if ( null != implementor )
 			{
 				i.reset( implementor);

--- a/pljava-api/src/main/java/org/postgresql/pljava/sqlgen/Lexicals.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/sqlgen/Lexicals.java
@@ -94,6 +94,17 @@ public abstract class Lexicals
 	/** The escape-specifier part of a Unicode delimited identifier or string.
 	 * The escape character itself is in the capturing group named {@code uec}.
 	 * The group can be absent, in which case \ should be used as the uec.
+	 *<p>
+	 * What makes this implementable as a regular expression is that what
+	 * precedes/follows {@code UESCAPE} is restricted to simple white space,
+	 * not the more general {@code separator} (which can include nesting
+	 * comments and therefore isn't a regular language). PostgreSQL enforces
+	 * the same restriction, and a bit of language lawyering does confirm
+	 * it's what ISO entails. ISO says "any {@code <token>} may be followed by
+	 * a {@code <separator>}", and enumerates the expansions of {@code <token>}.
+	 * While an entire {@code <Unicode character string literal>} or
+	 * {@code <Unicode delimited identifier>} is a {@code <token>}, the
+	 * constituent pieces of one, like {@code UESCAPE} here, are not.
 	 */
 	public static final Pattern ISO_UNICODE_ESCAPE_SPECIFIER =
 	Pattern.compile(

--- a/pljava-api/src/main/java/org/postgresql/pljava/sqlgen/Lexicals.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/sqlgen/Lexicals.java
@@ -550,6 +550,48 @@ public abstract class Lexicals
 			}
 
 			/**
+			 * Concatenates one or more strings or identifiers to the end of
+			 * this identifier.
+			 *<p>
+			 * The arguments may be instances of {@code Simple} or of
+			 * {@code CharSequence}, in any combination.
+			 *<p>
+			 * The resulting identifier folds if this identifier and all
+			 * identifier arguments fold and the concatenation (with all
+			 * {@code Simple} and {@code CharSequence} components included)
+			 * still matches the {@code ISO_AND_PG_REGULAR_IDENTIFIER} pattern.
+			 */
+			public Simple concat(Object... more)
+			{
+				boolean foldable = folds();
+				StringBuilder s = new StringBuilder(nonFolded());
+
+				for ( Object o : more )
+				{
+					if ( o instanceof Simple )
+					{
+						Simple si = (Simple)o;
+						foldable = foldable && si.folds();
+						s.append(si.nonFolded());
+					}
+					else if ( o instanceof CharSequence )
+					{
+						CharSequence cs = (CharSequence)o;
+						s.append(cs);
+					}
+					else
+						throw new IllegalArgumentException(
+							"arguments to Identifier.Simple.concat() must be " +
+							"Identifier.Simple or CharSequence");
+				}
+
+				if ( foldable )
+					foldable=ISO_AND_PG_REGULAR_IDENTIFIER.matcher(s).matches();
+
+				return from(s.toString(), ! foldable);
+			}
+
+			/**
 			 * Create an {@code Identifier.Simple} from a name string found in
 			 * a PostgreSQL system catalog.
 			 *<p>

--- a/pljava-api/src/main/java/org/postgresql/pljava/sqlgen/Lexicals.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/sqlgen/Lexicals.java
@@ -725,6 +725,28 @@ public abstract class Lexicals
 				return m_nonFolded.equals(oi.nonFolded());
 			}
 
+			/**
+			 * Case-fold a string by the PostgreSQL rules (assuming a
+			 * multibyte server encoding, where only the 26 uppercase ASCII
+			 * letters fold to lowercase).
+			 * @param s The non-folded value.
+			 * @return The folded value.
+			 */
+			public static String pgFold(String s)
+			{
+				Matcher m = s_pgFolded.matcher(s);
+				StringBuffer sb = new StringBuffer();
+				while ( m.find() )
+					m.appendReplacement(sb, m.group().toLowerCase());
+				return m.appendTail(sb).toString();
+			}
+
+			/**
+			 * The characters that PostgreSQL rules will fold: only the 26
+			 * uppercase ASCII letters.
+			 */
+			private static final Pattern s_pgFolded = Pattern.compile("[A-Z]");
+
 			private Simple(String nonFolded)
 			{
 				String diag = checkLength(nonFolded);
@@ -905,28 +927,6 @@ public abstract class Lexicals
 						m_nonFolded, oi.nonFolded()));
 				}
 				return eqPG || eqISO;
-			}
-
-			/**
-			 * The characters that PostgreSQL rules will fold: only the 26
-			 * uppercase ASCII letters.
-			 */
-			private static final Pattern s_pgFolded = Pattern.compile("[A-Z]");
-
-			/**
-			 * Case-fold a string by the PostgreSQL rules (assuming a
-			 * multibyte server encoding, where only the 26 uppercase ASCII
-			 * letters fold to lowercase).
-			 * @param s The non-folded value.
-			 * @return The folded value.
-			 */
-			private static String pgFold(String s)
-			{
-				Matcher m = s_pgFolded.matcher(s);
-				StringBuffer sb = new StringBuffer();
-				while ( m.find() )
-					m.appendReplacement(sb, m.group().toLowerCase());
-				return m.appendTail(sb).toString();
 			}
 		}
 

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/ComplexScalar.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/ComplexScalar.java
@@ -32,13 +32,13 @@ import static
 /**
  * Complex (re and im parts are doubles) implemented in Java as a scalar UDT.
  */
-@SQLAction(requires = { "scalar complex type", "complex assertHasValues" },
+@SQLAction(requires = "complex assertHasValues",
 	install = {
 		"SELECT javatest.assertHasValues(" +
 		" CAST('(1,2)' AS javatest.complex), 1, 2)"
 	}
 )
-@BaseUDT(schema="javatest", name="complex", provides="scalar complex type",
+@BaseUDT(schema="javatest", name="complex",
 	internalLength=16, alignment=BaseUDT.Alignment.DOUBLE)
 public class ComplexScalar implements SQLData {
 	private static Logger s_logger = Logger.getAnonymousLogger();
@@ -48,7 +48,7 @@ public class ComplexScalar implements SQLData {
 	 * @param cpl any instance of this UDT
 	 * @return the same instance passed in
 	 */
-	@Function(requires="scalar complex type",
+	@Function(
 		schema="javatest", name="logcomplex", effects=IMMUTABLE,
 		onNullInput=RETURNS_NULL)
 	public static ComplexScalar logAndReturn(ComplexScalar cpl) {
@@ -65,7 +65,7 @@ public class ComplexScalar implements SQLData {
 	 * @throws SQLException if the values do not match
 	 */
 	@Function(schema="javatest",
-		requires="scalar complex type", provides="complex assertHasValues",
+		provides="complex assertHasValues",
 		effects=IMMUTABLE, onNullInput=RETURNS_NULL)
 	public static void assertHasValues(ComplexScalar cpl, double re, double im)
 		throws SQLException

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/ComplexTuple.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/ComplexTuple.java
@@ -34,14 +34,13 @@ import static
  * Complex (re and im parts are doubles) implemented in Java as a mapped UDT.
  */
 @SQLAction(requires={
-	"complextuple type", "complextuple assertHasValues",
-	"complextuple setParameter"}, install={
+		"complextuple assertHasValues","complextuple setParameter"}, install={
 		"SELECT javatest.assertHasValues(" +
 		" CAST('(1,2)' AS javatest.complextuple), 1, 2)",
 		"SELECT javatest.setParameter()"
 	}
 )
-@MappedUDT(schema="javatest", name="complextuple", provides="complextuple type",
+@MappedUDT(schema="javatest", name="complextuple",
 structure={
 	"x float8",
 	"y float8"
@@ -56,8 +55,7 @@ public class ComplexTuple implements SQLData {
 	 * @return the same instance passed in
 	 */
 	@Function(schema="javatest", name="logcomplex",
-		effects=IMMUTABLE, onNullInput=RETURNS_NULL,
-		requires="complextuple type")
+		effects=IMMUTABLE, onNullInput=RETURNS_NULL)
 	public static ComplexTuple logAndReturn(ComplexTuple cpl) {
 		s_logger.info(cpl.getSQLTypeName() + "(" + cpl.m_x + ", " + cpl.m_y
 				+ ")");
@@ -72,8 +70,7 @@ public class ComplexTuple implements SQLData {
 	 * @param im the 'imaginary' value it should have
 	 * @throws SQLException if the values do not match
 	 */
-	@Function(schema="javatest",
-		requires="complextuple type", provides="complextuple assertHasValues",
+	@Function(schema="javatest", provides="complextuple assertHasValues",
 		effects=IMMUTABLE, onNullInput=RETURNS_NULL)
 	public static void assertHasValues(ComplexTuple cpl, double re, double im)
 		throws SQLException
@@ -86,8 +83,7 @@ public class ComplexTuple implements SQLData {
 	 * Pass a 'complextuple' UDT as a parameter to a PreparedStatement
 	 * that returns it, and verify that it makes the trip intact.
 	 */
-	@Function(schema="javatest",
-		requires="complextuple type", provides="complextuple setParameter",
+	@Function(schema="javatest", provides="complextuple setParameter",
 		effects=IMMUTABLE, onNullInput=RETURNS_NULL)
 	public static void setParameter() throws SQLException
 	{

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/IntWithMod.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/IntWithMod.java
@@ -77,7 +77,6 @@ import static
 )
 @BaseUDT(schema="javatest", provides="IntWithMod type",
 	implementor="postgresql_ge_80300",
-	requires={"IntWithMod modIn", "IntWithMod modOut"},
 	typeModifierInput="javatest.intwithmod_typmodin",
 	typeModifierOutput="javatest.intwithmod_typmodout",
 	like="pg_catalog.int4")
@@ -147,9 +146,9 @@ public class IntWithMod implements SQLData {
 	 * "even" or "odd". The modifier value is 0 for even or 1 for odd.
 	 */
 	@Function(schema="javatest", name="intwithmod_typmodin",
-		provides="IntWithMod modIn", implementor="postgresql_ge_80300",
+		implementor="postgresql_ge_80300",
 		effects=IMMUTABLE, onNullInput=RETURNS_NULL)
-	public static int modIn(@SQLType("cstring[]") String[] toks)
+	public static int modIn(@SQLType("pg_catalog.cstring[]") String[] toks)
 		throws SQLException {
 		if ( 1 != toks.length )
 			throw new SQLDataException(
@@ -166,7 +165,7 @@ public class IntWithMod implements SQLData {
 	 * Type modifier output function for IntWithMod type.
 	 */
 	@Function(schema="javatest", name="intwithmod_typmodout",
-		provides="IntWithMod modOut", type="cstring",
+		type="pg_catalog.cstring",
 		effects=IMMUTABLE, onNullInput=RETURNS_NULL)
 	public static String modOut(int mod) throws SQLException {
 		switch ( mod ) {
@@ -182,7 +181,7 @@ public class IntWithMod implements SQLData {
 	 */
 	@Function(schema="javatest", name="intwithmod_typmodapply",
 		implementor="postgresql_ge_80300",
-		requires="IntWithMod type", provides="IntWithMod modApply",
+		provides="IntWithMod modApply",
 		effects=IMMUTABLE, onNullInput=RETURNS_NULL)
 	public static IntWithMod modApply(IntWithMod iwm, int mod, boolean explicit)
 		throws SQLException


### PR DESCRIPTION
It was never satisfying to define a UDT in Java through annotations and still have the DDR generator not know that they need to be emitted before functions that use them, or after functions used in their definition, etc. It was easy enough (if tedious) to work around by adding explicit `provides`/`requires` annotations, but the DDR generator had all the necessary information to figure that out without such manual help. Now it does so, eliminating the tedium illustrated in jcflack/pljava-udt-type-extension@225ef5c.

Unlike pull request #159, which only needed to match Java types in order to improve the generator's ability to map types without explicit help, this follow-on work requires recognizing SQL types, and therefore needed considerably more infrastructure to model SQL identifiers and apply the peculiar sometimes-case-sensitive rules under which they match. It is still susceptible to false mismatches involving the few SQL types that are named by special SQL syntax rather than by qualified identifiers, but user-defined types will not fall in that category. (Such types can appear in function signatures, though, and make false negatives possible in the matching of functions; explicit `provides`/`requires` annotations are still available if needed for a case the implicit rules miss.)