### PR TITLE
Update Saxon-based examples to use Saxon 10

### DIFF
--- a/pljava-examples/pom.xml
+++ b/pljava-examples/pom.xml
@@ -75,7 +75,7 @@
 				<dependency>
 					<groupId>net.sf.saxon</groupId>
 					<artifactId>Saxon-HE</artifactId>
-					<version>[9.9.1-5,9.10)</version>
+					<version>[10.0,11)</version>
 				</dependency>
 			</dependencies>
 			<build>

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/saxon/S9.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/saxon/S9.java
@@ -1988,14 +1988,14 @@ public class S9 implements ResultSetProvider
 			rs.updateObject(col, bv.getValue());
 
 		else if ( ItemType.DATE.subsumes(xt) )
-			rs.updateObject(col, LocalDate.parse(bv.getStringValue()));
+			rs.updateObject(col, bv.getLocalDate());
 		else if ( ItemType.DATE_TIME.subsumes(xt) )
 		{
 			if ( ((CalendarValue)bv.getUnderlyingValue()).hasTimezone() )
-				rs.updateObject(col, OffsetDateTime.parse(bv.getStringValue()));
+				rs.updateObject(col, bv.getOffsetDateTime());
 			else
 			{
-				LocalDateTime jv = LocalDateTime.parse(bv.getStringValue());
+				LocalDateTime jv = bv.getLocalDateTime();
 				rs.updateObject(col,
 					Types.TIMESTAMP_WITH_TIMEZONE == p.typeJDBC() ?
 						jv.atOffset(UTC) : jv);
@@ -2075,16 +2075,28 @@ public class S9 implements ResultSetProvider
 			return new XdmAtomicValue((Boolean)dv);
 
 		if ( ItemType.DATE.equals(xst) )
+		{
+			if ( dv instanceof LocalDate )
+				return new XdmAtomicValue((LocalDate)dv);
 			return new XdmAtomicValue(dv.toString(), xst);
+		}
 
 		if ( ItemType.TIME.equals(xst) )
 			return new XdmAtomicValue(dv.toString(), xst);
 
 		if ( ItemType.DATE_TIME.equals(xst) )
+		{
+			if ( dv instanceof LocalDateTime )
+				return new XdmAtomicValue((LocalDateTime)dv);
 			return new XdmAtomicValue(dv.toString(), xst);
+		}
 
 		if ( ItemType.DATE_TIME_STAMP.equals(xst) )
+		{
+			if ( dv instanceof OffsetDateTime )
+				return new XdmAtomicValue((OffsetDateTime)dv);
 			return new XdmAtomicValue(dv.toString(), xst);
+		}
 
 		if ( ItemType.DURATION.equals(xst) )
 			return new XdmAtomicValue(toggleIntervalRepr((String)dv), xst);

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/saxon/S9.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/saxon/S9.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2019 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2018-2020 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -63,6 +63,7 @@ import net.sf.saxon.lib.NamespaceConstant;
 
 import static net.sf.saxon.om.NameChecker.isValidNCName;
 import net.sf.saxon.om.SequenceIterator;
+import static net.sf.saxon.om.SequenceIterator.Property.LOOKAHEAD;
 
 import net.sf.saxon.query.QueryResult;
 import net.sf.saxon.query.StaticQueryContext;
@@ -805,7 +806,7 @@ public class S9 implements ResultSetProvider
 		if ( nullOnEmpty )
 		{
 			xs = x.getUnderlyingValue().iterate();
-			if ( 0 == ( SequenceIterator.LOOKAHEAD & xs.getProperties() ) )
+			if ( ! xs.getProperties().contains(LOOKAHEAD) )
 				throw new SQLException(
 				"nullOnEmpty requested and result sequence lacks lookahead",
 					"XX000");


### PR DESCRIPTION
Probably the most significant of the [changes in Saxon 10][chgs] for PostgreSQL's purposes will be that the XQuery [higher-order function feature][hof] is now included in the freely-licensed Saxon-HE, so that it is now possible without cost to have an XQuery 3.1 implementation that is lacking only the [schema-aware feature][saf] and the [typed data feature][tdf] (for those, the paid Saxon-EE product is needed), and the [static typing feature][stf] (which is not in any Saxon edition).

To compensate for delivering the higher-order function support in -HE, some optimizations have been moved to -EE. This seems a justifiable trade, as it is better for development purposes to have the more complete implementation of the language, leaving better optimization to be bought if and when needed.

Thanks to a tip from Saxon's developer, the returning of results to SQL is now done in a way that may incur less copying in some cases.

[chgs]: https://www.saxonica.com/html/documentation/changes/v10.0/installation.html
[hof]: https://www.w3.org/TR/xquery-31/#id-higher-order-function-feature
[saf]: https://www.w3.org/TR/xquery-31/#id-schema-aware-feature
[tdf]: https://www.w3.org/TR/xquery-31/#id-typed-data-feature
[stf]: https://www.w3.org/TR/xquery-31/#id-static-typing-feature