### PR TITLE
Simplify the Eclipse-specific stuff in pom.xml

### DIFF
--- a/pljava-so/pom.xml
+++ b/pljava-so/pom.xml
@@ -293,6 +293,7 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-antrun-plugin</artifactId>
 				<version>1.7</version>
+				<?m2e ignore?>
 				<executions>
 					<execution>
 						<id>pg_config to pgsql.properties</id>
@@ -399,7 +400,7 @@ if ( null !== jvmdflt )
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>properties-maven-plugin</artifactId>
-				<version>1.0-alpha-2</version>
+				<version>1.0.0</version>
 				<executions>
 					<execution>
 						<phase>initialize</phase>
@@ -476,77 +477,5 @@ if ( null !== jvmdflt )
 			</plugin> -->
 
 		</plugins>
-		<pluginManagement>
-			<plugins>
-				<!--This plugin's configuration is used to store Eclipse m2e settings
-					only. It has no influence on the Maven build itself. -->
-				<plugin>
-					<groupId>org.eclipse.m2e</groupId>
-					<artifactId>lifecycle-mapping</artifactId>
-					<version>1.0.0</version>
-					<configuration>
-						<lifecycleMappingMetadata>
-							<pluginExecutions>
-								<pluginExecution>
-									<pluginExecutionFilter>
-										<groupId>org.apache.maven.plugins</groupId>
-										<artifactId>maven-antrun-plugin</artifactId>
-										<versionRange>[1.7,)</versionRange>
-										<goals>
-											<goal>run</goal>
-										</goals>
-									</pluginExecutionFilter>
-									<action>
-										<ignore></ignore>
-									</action>
-								</pluginExecution>
-								<pluginExecution>
-									<pluginExecutionFilter>
-										<groupId>org.codehaus.mojo</groupId>
-										<artifactId>properties-maven-plugin</artifactId>
-										<versionRange>[1.0-alpha-2,)</versionRange>
-										<goals>
-											<goal>
-												read-project-properties
-											</goal>
-										</goals>
-									</pluginExecutionFilter>
-									<action>
-										<ignore></ignore>
-									</action>
-								</pluginExecution>
-								<pluginExecution>
-									<pluginExecutionFilter>
-										<groupId>com.github.maven-nar</groupId>
-										<artifactId>nar-maven-plugin</artifactId>
-										<versionRange>[3.2.3]</versionRange>
-										<goals>
-											<goal>nar-compile</goal>
-											<goal>nar-download</goal>
-											<goal>nar-gnu-configure</goal>
-											<goal>nar-gnu-make</goal>
-											<goal>nar-gnu-process</goal>
-											<goal>nar-gnu-resources</goal>
-											<goal>nar-javah</goal>
-											<goal>nar-system-generate</goal>
-											<goal>nar-resources</goal>
-											<goal>nar-testCompile</goal>
-											<goal>nar-testDownload</goal>
-											<goal>nar-testUnpack</goal>
-											<goal>nar-unpack</goal>
-											<goal>nar-validate</goal>
-											<goal>nar-vcproj</goal>
-										</goals>
-									</pluginExecutionFilter>
-									<action>
-										<ignore></ignore>
-									</action>
-								</pluginExecution>
-							</pluginExecutions>
-						</lifecycleMappingMetadata>
-					</configuration>
-				</plugin>
-			</plugins>
-		</pluginManagement>
 	</build>
 </project>

--- a/src/site/markdown/build/versions.md
+++ b/src/site/markdown/build/versions.md
@@ -47,7 +47,7 @@ with [GraalVM][].
 
 ## Maven
 
-PL/Java can be built with Maven versions at least as far back as 3.3.
+PL/Java can be built with Maven versions as far back as 3.5.2.
 Maven's requirements can be seen in the [Maven release history][mvnhist].
 
 [mvnhist]: https://maven.apache.org/docs/history.html


### PR DESCRIPTION
For Maven2Eclipse to know what to do with the various goals of a plugin, it was once necessary to have a `pluginManagement` section like the long one removed here. In M2E 1.1, it became possible for the plugin authors to include that information in the jar of a plugin. That is already done by the `nar-maven-plugin` and the `properties-maven-plugin` (at version 1.0.0, to which it is upgraded here). That leaves only the `maven-antrun-plugin` needing special treatment.

M2E 1.7 introduced a much less obtrusive form of special treatment, needing only the `<?m2e ignore?>` processing instruction added here.

However (nothing is ever simple), that requires declaring Maven 3.5.2 the minimum needed to build the project. Processing instructions made earlier versions crash ([MNG-6280][]).

So this can't be backpatched to `REL1_5_STABLE`; 3.5.2 requires Java 7.

[MNG-6280]: https://issues.apache.org/jira/browse/MNG-6280