### PR TITLE
Update doc of oldest usable Maven version for 1.5 branch

### DIFF
--- a/src/site/markdown/build/versions.md
+++ b/src/site/markdown/build/versions.md
@@ -53,7 +53,8 @@ newer protocol versions needed to reach the servers.
 
 ## Maven
 
-PL/Java can be built with Maven versions at least as far back as 3.0.4.
+As of mid-2020, PL/Java can be built with Maven versions at least as far back
+as 3.2.5.
 As shown in the [Maven release history][mvnhist], **Maven releases after
 3.2.5 require Java 7 or later**. If you wish to *build* PL/Java using a
 Java 6 development kit, you must use a Maven version not newer than 3.2.5.


### PR DESCRIPTION
As reported in #207, owing to incompatible later versions of plugins we haven't pinned, Mavens as old as 3.0.5 or so are no longer usable.

As of today, 3.2.5 will still complete a build starting with an empty repository, and 3.2.5 is as old as anyone should need; it will run on Java 6.

The larger issue that we should be more systematic about pinning dependency versions has merit, but it's, well, a larger issue.