### PR TITLE
Fix several problems with doc site generation in master

### DIFF
--- a/pljava-api/pom.xml
+++ b/pljava-api/pom.xml
@@ -47,10 +47,14 @@
 					   - this exact potpourri of weirdness just to avoid forcing
 					   - the javadoc tool to do the wrong thing, you would call me
 					   - crazy. See the git commit comment for more explanation.
+					   - Then see the git commit comment for THIS line for even
+					   - MORE explanation.
 					  -->
 					<additionalOptions>
 						<additionalOption>--module</additionalOption>
 						<additionalOption>org.postgresql.pljava</additionalOption>
+						<additionalOption>--module-source-path</additionalOption>
+						<additionalOption>org.postgresql.pljava=${basedir}/src/main/java</additionalOption>
 					</additionalOptions>
 					<sourceFileExcludes>
 						<sourceFileExclude>**/org/**/*.java</sourceFileExclude>

--- a/pljava-examples/pom.xml
+++ b/pljava-examples/pom.xml
@@ -87,6 +87,12 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
+				<!-- Limiting the plugin version, for this subproject only,
+				   - works around javadoc's inability to document unnamed-module
+				   - code (these examples) that depends on named-module code
+				   - (such as PL/Java's API). I hope that gets fixed soon.
+				  -->
+				<version>3.0.1</version>
 				<configuration>
 					<excludePackageNames>org.postgresql.pljava.example.saxon</excludePackageNames>
 				</configuration>

--- a/pljava/pom.xml
+++ b/pljava/pom.xml
@@ -46,10 +46,14 @@
 					   - this exact potpourri of weirdness just to avoid forcing
 					   - the javadoc tool to do the wrong thing, you would call me
 					   - crazy. See the git commit comment for more explanation.
+					   - Then see the git commit comment for THIS line for even
+					   - MORE explanation.
 					  -->
 					<additionalOptions>
 						<additionalOption>--module</additionalOption>
 						<additionalOption>org.postgresql.pljava.internal</additionalOption>
+						<additionalOption>--module-source-path</additionalOption>
+						<additionalOption>org.postgresql.pljava.internal=${basedir}/src/main/java</additionalOption>
 						<additionalOption>--show-module-contents</additionalOption>
 						<additionalOption>all</additionalOption>
 						<additionalOption>--show-packages</additionalOption>

--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-site-plugin</artifactId>
-				<version>3.4</version>
+				<version>3.8.2</version>
 				<dependencies>
 					<dependency>
 						<groupId>org.apache.maven.doxia</groupId>
@@ -183,7 +183,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-project-info-reports-plugin</artifactId>
-				<version>2.8</version>
+				<version>3.0.0</version>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -188,7 +188,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>3.1.1</version>
+				<version>3.2.0</version>
 				<reportSets>
 					<reportSet>
 						<reports>

--- a/pom.xml
+++ b/pom.xml
@@ -196,6 +196,12 @@
 						</reports>
 					</reportSet>
 				</reportSets>
+				<configuration>
+					<detectJavaApiLink>false</detectJavaApiLink>
+					<links>
+						<link>https://docs.oracle.com/javase/10/docs/api/</link>
+					</links>
+				</configuration>
 			</plugin>
 		</plugins>
 	</reporting>

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -9,15 +9,15 @@
 		<name>PL/Java - Stored procedures for PostgreSQL in Java</name>
 		<src>images/pljava_logo.jpg</src>
 		<alt>PL/Java logo combining the PostgreSQL elephant and a Java bean</alt>
-		<href>${project.url}</href>
+		<href>${this.url}</href>
 	</bannerLeft>
 	<body>
 		<links>
 			<item name='Wiki' href='https://github.com/tada/pljava/wiki/'/>
-			<item name='Issues' href='${project.issueManagement.url}'/>
+			<item name='Issues' href='${this.issueManagement.url}'/>
 			<item name='Mailing list'
 			 href='https://www.postgresql.org/list/pljava-dev/'/>
-			<item name='Code' href='${project.scm.url}'/>
+			<item name='Code' href='${this.scm.url}'/>
 		</links>
 		<menu name='Usage' inherit='top'>
 			<item name='Building PL/Java'


### PR DESCRIPTION
Deal with an assortment of Maven plugin passing wrong options to javadoc, newer Java bytecodes requiring newer BCEL and cascading updates to other Maven plugin versions, and version-specific Javadoc and Oracle apidocs website issues.

Maven makes things seem easy a lot of the time, but when it doesn't, it _really_ doesn't.