### PR TITLE
Fix stored non-global-JNI-reference bug #274

### DIFF
--- a/pljava-so/src/main/c/Backend.c
+++ b/pljava-so/src/main/c/Backend.c
@@ -970,9 +970,9 @@ static void initPLJavaClasses(void)
 		"org/postgresql/pljava/internal/Backend$EarlyNatives");
 	PgObject_registerNatives2(cls, earlyMethods);
 
-	s_Backend_class = PgObject_getJavaClass(
-		"org/postgresql/pljava/internal/Backend");
+	cls = PgObject_getJavaClass("org/postgresql/pljava/internal/Backend");
 	elog(DEBUG2, "successfully loaded Backend class");
+	s_Backend_class = JNI_newGlobalRef(cls);
 	PgObject_registerNatives2(s_Backend_class, backendMethods);
 
 	tlField = PgObject_getStaticJavaField(s_Backend_class,

--- a/pljava-so/src/main/c/Invocation.c
+++ b/pljava-so/src/main/c/Invocation.c
@@ -103,6 +103,7 @@ jobject Invocation_getTypeMap(void)
 
 void Invocation_pushBootContext(Invocation* ctx)
 {
+	JNI_pushLocalFrame(LOCAL_FRAME_SIZE);
 	ctx->invocation      = 0;
 	ctx->function        = 0;
 	ctx->pushedFrame     = false;
@@ -121,6 +122,7 @@ void Invocation_pushBootContext(Invocation* ctx)
 
 void Invocation_popBootContext(void)
 {
+	JNI_popLocalFrame(0);
 	currentInvocation = 0;
 	--s_callLevel;
 }


### PR DESCRIPTION
Caught (#274) after 15 years during setup of CI for Google Summer of Code 2020.