### PR TITLE
Chase down issues reported by -Xcheck:jni

### DIFF
--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/SetOfRecordTest.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/SetOfRecordTest.java
@@ -42,8 +42,8 @@ install=
 "  END " +
 " FROM " +
 "  javatest.executeselecttorecords( " +
-"   'select ''Foo'',  1,  1.5,  23.67,  ''2005-06-01'',  ''20:56''::time, " +
-"           ''192.168.0''') " +
+"   'select ''Foo'',  1,  1.5::float,  23.67,  ''2005-06-01'',  " +
+"           ''20:56''::time, ''192.168.0''') " +
 "  AS r(t_varchar varchar, t_integer integer, t_float float, " +
 "      t_decimal decimal(8,2), t_date date, t_time time, t_cidr cidr)"
 )

--- a/pljava-so/src/main/c/Backend.c
+++ b/pljava-so/src/main/c/Backend.c
@@ -1035,11 +1035,73 @@ int Backend_setJavaLogLevel(int logLevel)
  */
 static jint JNICALL my_vfprintf(FILE* fp, const char* format, va_list args)
 {
+	static char const * const cap_format =
+		"WARNING: JNI local refs: %u, exceeds capacity: %u";
+	static char const at_prefix[] = "\tat ";
+	static char const locked_prefix[] = "\t- locked <";
+	static char const class_prefix[] = "(a ";
+	static char const culprit[] =
+		" com.sun.management.internal.DiagnosticCommandImpl.";
+	static enum matchstate
+	{
+		VFP_INITIAL,
+		VFP_MAYBE,
+		VFP_ATE_AT,
+		VFP_ATE_LOCKED
+	}
+	state = VFP_INITIAL;
+	static unsigned int lastlive, lastcap;
+
 	char buf[1024];
 	char* ep;
 	char* bp = buf;
+	unsigned int live, cap;
+	int got;
 
     vsnprintf(buf, sizeof(buf), format, args);
+
+	/* Try to eliminate annoying -Xcheck:jni messages from deep in JMX that
+	 * nothing can be done about here.
+	 */
+	for ( ;; state = VFP_INITIAL )
+	{
+		switch ( state )
+		{
+		case VFP_INITIAL:
+			got = sscanf(buf, cap_format, &live, &cap);
+			if ( 2 != got )
+				break;
+			lastlive = live;
+			lastcap = cap;
+			state = VFP_MAYBE;
+			return 0;
+
+		case VFP_MAYBE:
+			if ( 0 == strncmp(buf, at_prefix, sizeof at_prefix - 1)
+				&& NULL != strstr(buf, culprit) )
+			{
+				state = VFP_ATE_AT;
+				return 0;
+			}
+			elog(s_javaLogLevel, cap_format, lastlive, lastcap);
+			continue;
+
+		case VFP_ATE_AT:
+			if ( 0 == strncmp(buf, at_prefix, sizeof at_prefix - 1) )
+				return 0; /* remain in ATE_AT state */
+			if ( 0 != strncmp(buf, locked_prefix, sizeof locked_prefix - 1) )
+				continue;
+			state = VFP_ATE_LOCKED;
+			return 0;
+
+		case VFP_ATE_LOCKED:
+			if ( 0 != strncmp(buf, class_prefix, sizeof class_prefix - 1) )
+				continue;
+			state = VFP_ATE_AT;
+			return 0;
+		}
+		break;
+	}
 
     /* Trim off trailing newline and other whitespace.
      */

--- a/pljava-so/src/main/c/Backend.c
+++ b/pljava-so/src/main/c/Backend.c
@@ -1042,6 +1042,8 @@ static jint JNICALL my_vfprintf(FILE* fp, const char* format, va_list args)
 	static char const class_prefix[] = "(a ";
 	static char const culprit[] =
 		" com.sun.management.internal.DiagnosticCommandImpl.";
+	static char const nostack[] =
+		"No stacktrace, probably called from PostgreSQL";
 	static enum matchstate
 	{
 		VFP_INITIAL,
@@ -1057,6 +1059,7 @@ static jint JNICALL my_vfprintf(FILE* fp, const char* format, va_list args)
 	char* bp = buf;
 	unsigned int live, cap;
 	int got;
+	char const *detail;
 
     vsnprintf(buf, sizeof(buf), format, args);
 
@@ -1077,14 +1080,25 @@ static jint JNICALL my_vfprintf(FILE* fp, const char* format, va_list args)
 			return 0;
 
 		case VFP_MAYBE:
-			if ( 0 == strncmp(buf, at_prefix, sizeof at_prefix - 1)
-				&& NULL != strstr(buf, culprit) )
+			if ( 0 != strncmp(buf, at_prefix, sizeof at_prefix - 1) )
+				detail = nostack;
+			else
 			{
+				detail = buf;
 				state = VFP_ATE_AT;
-				return 0;
+				if ( NULL != strstr(buf, culprit) )
+					return 0;
 			}
-			elog(s_javaLogLevel, cap_format, lastlive, lastcap);
-			continue;
+			ereport(INFO, (
+				errmsg_internal(cap_format, lastlive, lastcap),
+				errdetail_internal("%s", detail),
+				errhint(
+					"To pinpoint location, set a breakpoint on this ereport "
+					"and follow stacktrace to a functionExit(), its caller "
+					"(a JNI method), and the immediate caller of that.")));
+			if ( nostack == detail )
+				continue;
+			return 0;
 
 		case VFP_ATE_AT:
 			if ( 0 == strncmp(buf, at_prefix, sizeof at_prefix - 1) )

--- a/pljava-so/src/main/c/type/Boolean.c
+++ b/pljava-so/src/main/c/type/Boolean.c
@@ -88,8 +88,9 @@ static Datum _booleanArray_coerceObject(Type self, jobject booleanArray)
 
 		for(idx = 0; idx < nElems; ++idx)
 		{
-			array[idx] = JNI_callBooleanMethod(JNI_getObjectArrayElement(booleanArray, idx),
-							   s_Boolean_booleanValue);
+			jobject e = JNI_getObjectArrayElement(booleanArray, idx);
+			array[idx] = JNI_callBooleanMethod(e, s_Boolean_booleanValue);
+			JNI_deleteLocalRef(e);
 		}
 	}
 

--- a/pljava-so/src/main/c/type/Double.c
+++ b/pljava-so/src/main/c/type/Double.c
@@ -93,10 +93,10 @@ static Datum _doubleArray_coerceObject(Type self, jobject doubleArray)
 
 		for(idx = 0; idx < nElems; ++idx)
 		{
-			array[idx] = JNI_callDoubleMethod(JNI_getObjectArrayElement(doubleArray, idx),
-						       s_Double_doubleValue);
+			jobject e = JNI_getObjectArrayElement(doubleArray, idx);
+			array[idx] = JNI_callDoubleMethod(e, s_Double_doubleValue);
+			JNI_deleteLocalRef(e);
 		}
-
 	}
 
 	PG_RETURN_ARRAYTYPE_P(v);

--- a/pljava-so/src/main/c/type/Float.c
+++ b/pljava-so/src/main/c/type/Float.c
@@ -95,8 +95,9 @@ static Datum _floatArray_coerceObject(Type self, jobject floatArray)
 
 		for(idx = 0; idx < nElems; ++idx)
 		{
-			array[idx] = JNI_callFloatMethod(JNI_getObjectArrayElement(floatArray, idx),
-							   s_Float_floatValue);
+			jobject e = JNI_getObjectArrayElement(floatArray, idx);
+			array[idx] = JNI_callFloatMethod(e, s_Float_floatValue);
+			JNI_deleteLocalRef(e);
 		}
 	}
 

--- a/pljava-so/src/main/c/type/Integer.c
+++ b/pljava-so/src/main/c/type/Integer.c
@@ -79,18 +79,20 @@ static Datum _intArray_coerceObject(Type self, jobject intArray)
 	v = createArrayType(nElems, sizeof(jint), INT4OID, false);
 
 	if(!JNI_isInstanceOf( intArray, s_IntegerArray_class))
-	  JNI_getIntArrayRegion((jintArray)intArray, 0, nElems, (jint*)ARR_DATA_PTR(v));
+		JNI_getIntArrayRegion(
+			(jintArray)intArray, 0, nElems, (jint*)ARR_DATA_PTR(v));
 	else
-	  {
-	    int idx = 0;
-	    jint *array = (jint*)ARR_DATA_PTR(v);
+	{
+		int idx = 0;
+		jint *array = (jint*)ARR_DATA_PTR(v);
 
-	    for(idx = 0; idx < nElems; ++idx)
-	      {
-		array[idx] = JNI_callIntMethod(JNI_getObjectArrayElement(intArray, idx),
-					       s_Integer_intValue);
-	      }
-	  }
+		for(idx = 0; idx < nElems; ++idx)
+		{
+			jobject e = JNI_getObjectArrayElement(intArray, idx);
+			array[idx] = JNI_callIntMethod(e, s_Integer_intValue);
+			JNI_deleteLocalRef(e);
+		}
+	}
 
 
 	PG_RETURN_ARRAYTYPE_P(v);

--- a/pljava-so/src/main/c/type/Long.c
+++ b/pljava-so/src/main/c/type/Long.c
@@ -86,7 +86,8 @@ static Datum _longArray_coerceObject(Type self, jobject longArray)
 	v = createArrayType(nElems, sizeof(jlong), INT8OID, false);
 
 	if(!JNI_isInstanceOf( longArray, s_LongArray_class))
-		JNI_getLongArrayRegion((jlongArray)longArray, 0, nElems, (jlong*)ARR_DATA_PTR(v));
+		JNI_getLongArrayRegion(
+			(jlongArray)longArray, 0, nElems, (jlong*)ARR_DATA_PTR(v));
 	else
 	{
 		int idx = 0;
@@ -94,8 +95,9 @@ static Datum _longArray_coerceObject(Type self, jobject longArray)
 
 		for(idx = 0; idx < nElems; ++idx)
 		{
-			array[idx] = JNI_callLongMethod(JNI_getObjectArrayElement(longArray, idx),
-							s_Long_longValue);
+			jobject e = JNI_getObjectArrayElement(longArray, idx);
+			array[idx] = JNI_callLongMethod(e, s_Long_longValue);
+			JNI_deleteLocalRef(e);
 		}
 	}
 

--- a/pljava-so/src/main/c/type/Short.c
+++ b/pljava-so/src/main/c/type/Short.c
@@ -78,18 +78,20 @@ static Datum _shortArray_coerceObject(Type self, jobject shortArray)
 	v = createArrayType(nElems, sizeof(jshort), INT2OID, false);
 
 	if(!JNI_isInstanceOf( shortArray, s_ShortArray_class))
-	  JNI_getShortArrayRegion((jshortArray)shortArray, 0, nElems, (jshort*)ARR_DATA_PTR(v));
+		JNI_getShortArrayRegion(
+			(jshortArray)shortArray, 0, nElems, (jshort*)ARR_DATA_PTR(v));
 	else
-	  {
-	    int idx = 0;
-	    jshort *array = (jshort*)ARR_DATA_PTR(v);
+	{
+		int idx = 0;
+		jshort *array = (jshort*)ARR_DATA_PTR(v);
 
-	    for(idx = 0; idx < nElems; ++idx)
-	      {
-		array[idx] = JNI_callShortMethod(JNI_getObjectArrayElement(shortArray, idx),
-					       s_Short_shortValue);
-	      }
-	  }
+		for(idx = 0; idx < nElems; ++idx)
+		{
+			jobject e = JNI_getObjectArrayElement(shortArray, idx);
+			array[idx] = JNI_callShortMethod(e, s_Short_shortValue);
+			JNI_deleteLocalRef(e);
+		}
+	}
 
 	PG_RETURN_ARRAYTYPE_P(v);
 }


### PR DESCRIPTION
Change one test case that was triggering (what seems to be) an overly strict `-Xcheck:jni` error, but arguably isn't a real problem. It could be revisited: there is a systematic way to eliminate the issue, but more work.

Primitive coercers of Java boxed arrays were not deleting their local refs, accounting for the vast majority of local ref capacity exceeded warnings. (Possible future optimization: have them use `PushLocalFrame`/`PopLocalFrame` at intervals, rather than deleting every local ref at retail.)

The rest of the messages were local ref capacity exceeded from internal Java code in the Java Management Extensions. No way to fix those in PL/Java, but because those warnings go through the `vfprintf` hook, that hook now contains a small state machine to recognize and suppress them.
Hacky (and will probably not recognize or suppress them except in `en_US` locales), but without doing something like that, they make a big-enough torrent of output to obscure any real PL/Java issues that might be worth fixing.

For the moment, this set of changes seems to have eliminated all `-Xcheck:jni` messages in my build/test environment.