### PR TITLE
Backpatch to REL1_5_STABLE the checkjni changes to master

### DIFF
--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/SetOfRecordTest.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/SetOfRecordTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2018 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2020 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -42,8 +42,8 @@ install=
 "  END " +
 " FROM " +
 "  javatest.executeselecttorecords( " +
-"   'select ''Foo'',  1,  1.5,  23.67,  ''2005-06-01'',  ''20:56''::time, " +
-"           ''192.168.0''') " +
+"   'select ''Foo'',  1,  1.5::float,  23.67,  ''2005-06-01'',  " +
+"           ''20:56''::time, ''192.168.0''') " +
 "  AS r(t_varchar varchar, t_integer integer, t_float float, " +
 "      t_decimal decimal(8,2), t_date date, t_time time, t_cidr cidr)"
 )

--- a/pljava-so/src/main/c/Backend.c
+++ b/pljava-so/src/main/c/Backend.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2019 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2020 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -892,6 +892,7 @@ static void initPLJavaClasses(void)
 		},
 		{ 0, 0, 0 }
 	};
+	jclass cls;
 
 	JavaMemoryContext = AllocSetContextCreate(TopMemoryContext,
 												"PL/Java",
@@ -900,9 +901,10 @@ static void initPLJavaClasses(void)
 	Exception_initialize();
 
 	elog(DEBUG2, "checking for a PL/Java Backend class on the given classpath");
-	s_Backend_class = PgObject_getJavaClass(
-		"org/postgresql/pljava/internal/Backend");
+
+	cls = PgObject_getJavaClass("org/postgresql/pljava/internal/Backend");
 	elog(DEBUG2, "successfully loaded Backend class");
+	s_Backend_class = JNI_newGlobalRef(cls);
 	PgObject_registerNatives2(s_Backend_class, backendMethods);
 
 	tlField = PgObject_getStaticJavaField(s_Backend_class, "THREADLOCK", "Ljava/lang/Object;");

--- a/pljava-so/src/main/c/Invocation.c
+++ b/pljava-so/src/main/c/Invocation.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2019 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2020 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -103,6 +103,7 @@ jobject Invocation_getTypeMap(void)
 
 void Invocation_pushBootContext(Invocation* ctx)
 {
+	JNI_pushLocalFrame(LOCAL_FRAME_SIZE);
 	ctx->invocation      = 0;
 	ctx->function        = 0;
 	ctx->trusted         = false;
@@ -120,6 +121,7 @@ void Invocation_pushBootContext(Invocation* ctx)
 
 void Invocation_popBootContext(void)
 {
+	JNI_popLocalFrame(0);
 	currentInvocation = 0;
 	--s_callLevel;
 }

--- a/pljava-so/src/main/c/type/Boolean.c
+++ b/pljava-so/src/main/c/type/Boolean.c
@@ -1,12 +1,15 @@
 /*
- * Copyright (c) 2004, 2005, 2006 TADA AB - Taby Sweden
- * Copyright (c) 2010, 2011 PostgreSQL Global Development Group
+ * Copyright (c) 2004-2020 Tada AB and other contributors, as listed below.
  *
- * Distributed under the terms shown in the file COPYRIGHT
- * found in the root folder of this project or at
- * http://wiki.tada.se/index.php?title=PLJava_License
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
  *
- * @author Thomas Hallgren
+ * Contributors:
+ *   Tada AB
+ *   PostgreSQL Global Development Group
+ *   Chapman Flack
  */
 #include "pljava/type/Type_priv.h"
 #include "pljava/type/Array.h"
@@ -85,8 +88,9 @@ static Datum _booleanArray_coerceObject(Type self, jobject booleanArray)
 
 		for(idx = 0; idx < nElems; ++idx)
 		{
-			array[idx] = JNI_callBooleanMethod(JNI_getObjectArrayElement(booleanArray, idx),
-							   s_Boolean_booleanValue);
+			jobject e = JNI_getObjectArrayElement(booleanArray, idx);
+			array[idx] = JNI_callBooleanMethod(e, s_Boolean_booleanValue);
+			JNI_deleteLocalRef(e);
 		}
 	}
 

--- a/pljava-so/src/main/c/type/Double.c
+++ b/pljava-so/src/main/c/type/Double.c
@@ -1,12 +1,15 @@
 /*
- * Copyright (c) 2004, 2005, 2006 TADA AB - Taby Sweden
- * Copyright (c) 2010, 2011 PostgreSQL Global Development Group
+ * Copyright (c) 2004-2020 Tada AB and other contributors, as listed below.
  *
- * Distributed under the terms shown in the file COPYRIGHT
- * found in the root folder of this project or at
- * http://wiki.tada.se/index.php?title=PLJava_License
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
  *
- * @author Thomas Hallgren
+ * Contributors:
+ *   Tada AB
+ *   PostgreSQL Global Development Group
+ *   Chapman Flack
  */
 #include "pljava/type/Type_priv.h"
 #include "pljava/type/Array.h"
@@ -90,10 +93,10 @@ static Datum _doubleArray_coerceObject(Type self, jobject doubleArray)
 
 		for(idx = 0; idx < nElems; ++idx)
 		{
-			array[idx] = JNI_callDoubleMethod(JNI_getObjectArrayElement(doubleArray, idx),
-						       s_Double_doubleValue);
+			jobject e = JNI_getObjectArrayElement(doubleArray, idx);
+			array[idx] = JNI_callDoubleMethod(e, s_Double_doubleValue);
+			JNI_deleteLocalRef(e);
 		}
-
 	}
 
 	PG_RETURN_ARRAYTYPE_P(v);

--- a/pljava-so/src/main/c/type/Float.c
+++ b/pljava-so/src/main/c/type/Float.c
@@ -1,12 +1,15 @@
 /*
- * Copyright (c) 2004, 2005, 2006 TADA AB - Taby Sweden
- * Copyright (c) 2010, 2011 PostgreSQL Global Development Group
+ * Copyright (c) 2004-2020 Tada AB and other contributors, as listed below.
  *
- * Distributed under the terms shown in the file COPYRIGHT
- * found in the root folder of this project or at
- * http://wiki.tada.se/index.php?title=PLJava_License
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
  *
- * @author Thomas Hallgren
+ * Contributors:
+ *   Tada AB
+ *   PostgreSQL Global Development Group
+ *   Chapman Flack
  */
 #include "pljava/type/Type_priv.h"
 #include "pljava/type/Array.h"
@@ -92,8 +95,9 @@ static Datum _floatArray_coerceObject(Type self, jobject floatArray)
 
 		for(idx = 0; idx < nElems; ++idx)
 		{
-			array[idx] = JNI_callFloatMethod(JNI_getObjectArrayElement(floatArray, idx),
-							   s_Float_floatValue);
+			jobject e = JNI_getObjectArrayElement(floatArray, idx);
+			array[idx] = JNI_callFloatMethod(e, s_Float_floatValue);
+			JNI_deleteLocalRef(e);
 		}
 	}
 

--- a/pljava-so/src/main/c/type/Integer.c
+++ b/pljava-so/src/main/c/type/Integer.c
@@ -1,12 +1,15 @@
 /*
- * Copyright (c) 2004, 2005, 2006 TADA AB - Taby Sweden
- * Copyright (c) 2010, 2011 PostgreSQL Global Development Group
+ * Copyright (c) 2004-2020 Tada AB and other contributors, as listed below.
  *
- * Distributed under the terms shown in the file COPYRIGHT
- * found in the root folder of this project or at
- * http://wiki.tada.se/index.php?title=PLJava_License
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
  *
- * @author Thomas Hallgren
+ * Contributors:
+ *   Tada AB
+ *   PostgreSQL Global Development Group
+ *   Chapman Flack
  */
 #include "pljava/type/Type_priv.h"
 #include "pljava/type/Array.h"
@@ -76,18 +79,20 @@ static Datum _intArray_coerceObject(Type self, jobject intArray)
 	v = createArrayType(nElems, sizeof(jint), INT4OID, false);
 
 	if(!JNI_isInstanceOf( intArray, s_IntegerArray_class))
-	  JNI_getIntArrayRegion((jintArray)intArray, 0, nElems, (jint*)ARR_DATA_PTR(v));
+		JNI_getIntArrayRegion(
+			(jintArray)intArray, 0, nElems, (jint*)ARR_DATA_PTR(v));
 	else
-	  {
-	    int idx = 0;
-	    jint *array = (jint*)ARR_DATA_PTR(v);
+	{
+		int idx = 0;
+		jint *array = (jint*)ARR_DATA_PTR(v);
 
-	    for(idx = 0; idx < nElems; ++idx)
-	      {
-		array[idx] = JNI_callIntMethod(JNI_getObjectArrayElement(intArray, idx),
-					       s_Integer_intValue);
-	      }
-	  }
+		for(idx = 0; idx < nElems; ++idx)
+		{
+			jobject e = JNI_getObjectArrayElement(intArray, idx);
+			array[idx] = JNI_callIntMethod(e, s_Integer_intValue);
+			JNI_deleteLocalRef(e);
+		}
+	}
 
 
 	PG_RETURN_ARRAYTYPE_P(v);

--- a/pljava-so/src/main/c/type/Long.c
+++ b/pljava-so/src/main/c/type/Long.c
@@ -1,12 +1,15 @@
 /*
- * Copyright (c) 2004, 2005, 2006 TADA AB - Taby Sweden
- * Copyright (c) 2010, 2011 PostgreSQL Global Development Group
+ * Copyright (c) 2004-2020 Tada AB and other contributors, as listed below.
  *
- * Distributed under the terms shown in the file COPYRIGHT
- * found in the root folder of this project or at
- * http://wiki.tada.se/index.php?title=PLJava_License
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
  *
- * @author Thomas Hallgren
+ * Contributors:
+ *   Tada AB
+ *   PostgreSQL Global Development Group
+ *   Chapman Flack
  */
 #include "pljava/type/Type_priv.h"
 #include "pljava/type/Array.h"
@@ -83,7 +86,8 @@ static Datum _longArray_coerceObject(Type self, jobject longArray)
 	v = createArrayType(nElems, sizeof(jlong), INT8OID, false);
 
 	if(!JNI_isInstanceOf( longArray, s_LongArray_class))
-		JNI_getLongArrayRegion((jlongArray)longArray, 0, nElems, (jlong*)ARR_DATA_PTR(v));
+		JNI_getLongArrayRegion(
+			(jlongArray)longArray, 0, nElems, (jlong*)ARR_DATA_PTR(v));
 	else
 	{
 		int idx = 0;
@@ -91,8 +95,9 @@ static Datum _longArray_coerceObject(Type self, jobject longArray)
 
 		for(idx = 0; idx < nElems; ++idx)
 		{
-			array[idx] = JNI_callLongMethod(JNI_getObjectArrayElement(longArray, idx),
-							s_Long_longValue);
+			jobject e = JNI_getObjectArrayElement(longArray, idx);
+			array[idx] = JNI_callLongMethod(e, s_Long_longValue);
+			JNI_deleteLocalRef(e);
 		}
 	}
 

--- a/pljava-so/src/main/c/type/Short.c
+++ b/pljava-so/src/main/c/type/Short.c
@@ -1,12 +1,15 @@
 /*
- * Copyright (c) 2004, 2005, 2006 TADA AB - Taby Sweden
- * Copyright (c) 2010, 2011 PostgreSQL Global Development Group
+ * Copyright (c) 2004-2020 Tada AB and other contributors, as listed below.
  *
- * Distributed under the terms shown in the file COPYRIGHT
- * found in the root folder of this project or at
- * http://wiki.tada.se/index.php?title=PLJava_License
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
  *
- * @author Thomas Hallgren
+ * Contributors:
+ *   Tada AB
+ *   PostgreSQL Global Development Group
+ *   Chapman Flack
  */
 #include "pljava/type/Type_priv.h"
 #include "pljava/type/Array.h"
@@ -75,18 +78,20 @@ static Datum _shortArray_coerceObject(Type self, jobject shortArray)
 	v = createArrayType(nElems, sizeof(jshort), INT2OID, false);
 
 	if(!JNI_isInstanceOf( shortArray, s_ShortArray_class))
-	  JNI_getShortArrayRegion((jshortArray)shortArray, 0, nElems, (jshort*)ARR_DATA_PTR(v));
+		JNI_getShortArrayRegion(
+			(jshortArray)shortArray, 0, nElems, (jshort*)ARR_DATA_PTR(v));
 	else
-	  {
-	    int idx = 0;
-	    jshort *array = (jshort*)ARR_DATA_PTR(v);
+	{
+		int idx = 0;
+		jshort *array = (jshort*)ARR_DATA_PTR(v);
 
-	    for(idx = 0; idx < nElems; ++idx)
-	      {
-		array[idx] = JNI_callShortMethod(JNI_getObjectArrayElement(shortArray, idx),
-					       s_Short_shortValue);
-	      }
-	  }
+		for(idx = 0; idx < nElems; ++idx)
+		{
+			jobject e = JNI_getObjectArrayElement(shortArray, idx);
+			array[idx] = JNI_callShortMethod(e, s_Short_shortValue);
+			JNI_deleteLocalRef(e);
+		}
+	}
 
 	PG_RETURN_ARRAYTYPE_P(v);
 }


### PR DESCRIPTION
The changes pulled to `master` from `chore/master/checkjni` in PR #276 should be applied here too.

The issues with JNI usage are bugs, and the filter on logging is important for spotting bugs (as the logging otherwise gets spammed with warnings from internal Java JMX code we're powerless to fix).