### PR TITLE
Give Checked a nicer idiom, java8ify more

### DIFF
--- a/pljava/src/main/java/org/postgresql/pljava/sqlj/Loader.java
+++ b/pljava/src/main/java/org/postgresql/pljava/sqlj/Loader.java
@@ -267,7 +267,7 @@ public class Loader extends ClassLoader
 		};
 		ClassLoader loader = Loader.getSchemaLoader(schema);
 		try (
-			Statement stmt = Checked.Supplier.of((() ->
+			Statement stmt = Checked.Supplier.use((() ->
 			{
 				Statement s = getDefaultConnection().createStatement();
 				s.unwrap(SPIReadOnlyControl.class).clearReadOnly();
@@ -377,7 +377,7 @@ public class Loader extends ClassLoader
 				// prepared statements are backed by ExecutionPlans that stick
 				// around in an MRU cache after being closed.)
 				//
-				PreparedStatement stmt = Checked.Supplier.of((() ->
+				PreparedStatement stmt = Checked.Supplier.use((() ->
 					{
 						PreparedStatement s = getDefaultConnection()
 							.prepareStatement(


### PR DESCRIPTION
`XMLEventToStreamConsumer` even had a comment saying "Do the below with lambdas once Java back horizon >= 8" and (probably because of the words between Java and 8) `grep` missed it in the earlier rounds of java8ification.

It would be trivial but for the fact that `n -> add(n)` could throw `XMLStreamException`, while an `Iterator`'s `forEachRemaining` doesn't accept a lambda that can throw anything. Happily, that's the kind of infelicity that `Checked` was meant to smooth over.

It turns out the initial commit of `Checked` had narrowly missed a much more pleasing way to set up the idiom. Now it's just

```
  use(lambda that could throw stuff).in(code wanting lambda that can't)
```

as in this case

```java
  use((Namespace n) -> add(n))
  .in(event.getNamespaces()::forEachRemaining)
```

Conforming changes in `Loader`, the only other current user of `Checked`.

First changed `of` to `use` because the language was tricky, a `Checked.Supplier.of(() -> foo)` could sound like "a Supplier of () -> foo", which would be a supplier of suppliers of foo, when it's really a direct supplier of foo.

The name `use` wards off that confusion, *and* tees up the nice `use(...).in(...)` idiom.