### PR TITLE
Further develop the Adjusting.XML API

### DIFF
--- a/pljava-api/src/main/java/org/postgresql/pljava/Adjusting.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/Adjusting.java
@@ -17,6 +17,7 @@ import java.sql.SQLXML;
 import javax.xml.stream.XMLInputFactory; // for javadoc
 import javax.xml.stream.XMLResolver; // for javadoc
 import javax.xml.stream.XMLStreamReader;
+import javax.xml.validation.Schema;
 import org.xml.sax.EntityResolver;
 import org.xml.sax.InputSource;
 import org.xml.sax.XMLReader;
@@ -294,6 +295,27 @@ public final class Adjusting
 			 * underlying flavor of source or result.
 			 */
 			T entityResolver(EntityResolver resolver);
+
+			/**
+			 * Set a {@link Schema} to be applied during SAX or DOM parsing
+			 *<em>(optional operation)</em>.
+			 *<p>
+			 * This method only succeeds for a {@code SAXSource} or
+			 * {@code DOMSource} (or a {@code StreamResult}, where the schema
+			 * is set on the parser that will verify the content written).
+			 * Unlike the best-effort behavior of most methods in this
+			 * interface, this one will report failure with an exception.
+			 *<p>
+			 * In the SAX case, this must be called <em>before</em> other
+			 * methods of this interface.
+			 * @param schema an instance of javax.xml.validation.Schema
+			 * @throws UnsupportedOperationException if not supported by the
+			 * underlying flavor of source or result.
+			 * @throws IllegalStateException if the underlying implementation is
+			 * SAX-based and another method from this interface has been called
+			 * already.
+			 */
+			T schema(Schema schema);
 		}
 
 		/**

--- a/pljava-api/src/main/java/org/postgresql/pljava/Adjusting.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/Adjusting.java
@@ -14,7 +14,10 @@ package org.postgresql.pljava;
 import java.io.Reader;
 import java.sql.SQLException;
 import java.sql.SQLXML;
+import javax.xml.stream.XMLInputFactory; // for javadoc
+import javax.xml.stream.XMLResolver; // for javadoc
 import javax.xml.stream.XMLStreamReader;
+import org.xml.sax.EntityResolver;
 import org.xml.sax.InputSource;
 import org.xml.sax.XMLReader;
 
@@ -272,6 +275,25 @@ public final class Adjusting
 			 * A protocol name prefixed with "jar:" is also a protocol name.
 			 */
 			T accessExternalSchema(String protocols);
+
+			/**
+			 * Set an {@link EntityResolver} of the type used by SAX and DOM
+			 * <em>(optional operation)</em>.
+			 *<p>
+			 * This method only succeeds for a {@code SAXSource} or
+			 * {@code DOMSource} (or a {@code StreamResult}, where the resolver
+			 * is set on the parser that will verify the content written).
+			 * Unlike the best-effort behavior of most methods in this
+			 * interface, this one will report failure with an exception.
+			 *<p>
+			 * If the StAX API is wanted, a StAX {@link XMLResolver} should be
+			 * set instead, using {@code setFirstSupportedProperty} with the
+			 * property name {@link XMLInputFactory#RESOLVER}.
+			 * @param resolver an instance of org.xml.sax.EntityResolver
+			 * @throws UnsupportedOperationException if not supported by the
+			 * underlying flavor of source or result.
+			 */
+			T entityResolver(EntityResolver resolver);
 		}
 
 		/**

--- a/pljava-api/src/main/java/org/postgresql/pljava/Adjusting.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/Adjusting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2019-2020 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -188,6 +188,90 @@ public final class Adjusting
 			 *</pre>
 			 */
 			T defaults();
+
+			/**
+			 * For a parser property (in DOM parlance, attribute) that may have
+			 * been identified by more than one URI in different parsers or
+			 * versions, try passing the supplied <em>value</em> with each URI
+			 * from <em>names</em> in order until one is not rejected by the
+			 * underlying parser.
+			 *<p>
+			 * A property differs from a feature in taking a value of some
+			 * specified type, rather than being simply enabled/disabled with
+			 * a boolean.
+			 */
+			T setFirstSupportedProperty(Object value, String... names);
+
+			/**
+			 * Maximum number of attributes on an element, with a negative or
+			 * zero value indicating no limit.
+			 */
+			T elementAttributeLimit(int limit);
+
+			/**
+			 * Maximum number of entity expansions, with a negative or
+			 * zero value indicating no limit.
+			 */
+			T entityExpansionLimit(int limit);
+
+			/**
+			 * Limit on total number of nodes in all entity referenced,
+			 * with a negative or zero value indicating no limit.
+			 */
+			T entityReplacementLimit(int limit);
+
+			/**
+			 * Maximum element depth,
+			 * with a negative or zero value indicating no limit.
+			 */
+			T maxElementDepth(int depth);
+
+			/**
+			 * Maximum size of any general entities,
+			 * with a negative or zero value indicating no limit.
+			 */
+			T maxGeneralEntitySizeLimit(int limit);
+
+			/**
+			 * Maximum size of any parameter entities (including the result
+			 * of nesting parameter entities),
+			 * with a negative or zero value indicating no limit.
+			 */
+			T maxParameterEntitySizeLimit(int limit);
+
+			/**
+			 * Maximum size of XML names (including element and attribute names,
+			 * namespace prefix, and namespace URI even though that isn't an
+			 * XML name),
+			 * with a negative or zero value indicating no limit.
+			 */
+			T maxXMLNameLimit(int limit);
+
+			/**
+			 * Limit on total size of all entities, general or parameter,
+			 * with a negative or zero value indicating no limit.
+			 */
+			T totalEntitySizeLimit(int limit);
+
+			/**
+			 * Protocol schemes allowed in the URL of an external DTD to be
+			 * fetched.
+			 * @param protocols Empty string to deny all external DTD access,
+			 * the string "all" to allow fetching by any protocol, or a
+			 * comma-separated, case insensitive list of protocols to allow.
+			 * A protocol name prefixed with "jar:" is also a protocol name.
+			 */
+			T accessExternalDTD(String protocols);
+
+			/**
+			 * Protocol schemes allowed in the URL of an external schema to be
+			 * fetched.
+			 * @param protocols Empty string to deny all external DTD access,
+			 * the string "all" to allow fetching by any protocol, or a
+			 * comma-separated, case insensitive list of protocols to allow.
+			 * A protocol name prefixed with "jar:" is also a protocol name.
+			 */
+			T accessExternalSchema(String protocols);
 		}
 
 		/**

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/PassXML.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/PassXML.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2019 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2018-2020 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -59,6 +59,9 @@ import javax.xml.transform.sax.SAXResult;
 import javax.xml.transform.sax.SAXSource;
 import javax.xml.transform.stax.StAXResult;
 import javax.xml.transform.stax.StAXSource;
+
+import javax.xml.validation.Schema;
+import javax.xml.validation.SchemaFactory;
 
 import org.postgresql.pljava.Adjusting;
 import org.postgresql.pljava.annotation.Function;
@@ -165,6 +168,48 @@ import org.w3c.dom.bootstrap.DOMImplementationRegistry;
 		" END " +
 		"FROM" +
 		" r"
+	),
+
+	@SQLAction(implementor="postgresql_xml_ge84", requires="lowLevelXMLEcho",
+		install={
+		"SELECT" +
+		" preparexmlschema('schematest', $$" +
+		"<xs:schema" +
+		" xmlns:xs='http://www.w3.org/2001/XMLSchema'" +
+		" targetNamespace='urn:testme'" +
+		" elementFormDefault='qualified'>" +
+		" <xs:element name='row'>" +
+		"  <xs:complexType>" +
+		"   <xs:sequence>" +
+		"    <xs:element name='textcol' type='xs:string' nillable='true'/>" +
+		"    <xs:element name='intcol' type='xs:integer' nillable='true'/>" +
+		"   </xs:sequence>" +
+		"  </xs:complexType>" +
+		" </xs:element>" +
+		"</xs:schema>" +
+		"$$, 'http://www.w3.org/2001/XMLSchema', 5)",
+
+		"WITH" +
+		" s(how) AS (SELECT unnest('{4,5,7}'::int[]))," +
+		" r(isdoc) AS (" +
+		" SELECT" +
+		"  javatest.lowlevelxmlecho(" +
+		"   query_to_xml(" +
+		"    'SELECT ''hi'' AS textcol, 1 AS intcol', true, true, 'urn:testme'"+
+		"   ), how, params) IS DOCUMENT" +
+		" FROM" +
+		"  s," +
+		"  (SELECT 'schematest' AS schema) AS params" +
+		" )" +
+		"SELECT" +
+		" CASE WHEN every(isdoc)" +
+		"  THEN javatest.logmessage('INFO', 'XML Schema tests succeeded')" +
+		"  ELSE javatest.logmessage('WARNING'," +
+		"       'XML Schema tests had problems')" +
+		" END " +
+		"FROM" +
+		" r"
+		}
 	)
 })
 @MappedUDT(schema="javatest", name="onexml", structure="c1 xml",
@@ -177,6 +222,8 @@ public class PassXML implements SQLData
 	static TransformerFactory s_tf = TransformerFactory.newInstance();
 
 	static Map<String,Templates> s_tpls = new HashMap<String,Templates>();
+
+	static Map<String,Schema> s_schemas = new HashMap<String,Schema>();
 
 	@Function(schema="javatest", implementor="postgresql_xml")
 	public static String inXMLoutString(SQLXML in) throws SQLException
@@ -365,6 +412,35 @@ public class PassXML implements SQLData
 		return ensureClosed(rlt, result, howout);
 	}
 
+	/**
+	 * Precompile a schema {@code source} in schema language {@code lang}
+	 * and save it (for the current session) as {@code name}.
+	 *<p>
+	 * Each value of {@code how}, 1-7, selects a different way of presenting
+	 * the {@code SQLXML} object to the schema parser.
+	 *<p>
+	 * The {@code lang} parameter is a URI that identifies a known schema
+	 * language. The only language a Java runtime is required to support is
+	 * W3C XML Schema 1.0, with URI {@code http://www.w3.org/2001/XMLSchema}.
+	 */
+	@Function(schema="javatest", implementor="postgresql_xml")
+	public static void prepareXMLSchema(
+		String name, SQLXML source, String lang, int how)
+	throws SQLException
+	{
+		try
+		{
+			s_schemas.put(name,
+				SchemaFactory.newInstance(lang)
+				.newSchema(sxToSource(source, how)));
+		}
+		catch ( SAXException e )
+		{
+			throw new SQLException(
+				"failed to prepare schema: " + e.getMessage(), e);
+		}
+	}
+
 	private static SQLXML echoSQLXML(SQLXML sx, int howin, int howout)
 	throws SQLException
 	{
@@ -420,7 +496,8 @@ public class PassXML implements SQLData
 	 * still be exercised by calling this method, explicitly passing
 	 * {@code adjust => NULL}.
 	 */
-	@Function(schema="javatest", implementor="postgresql_xml_ge84")
+	@Function(schema="javatest", implementor="postgresql_xml_ge84",
+		provides="lowLevelXMLEcho")
 	public static SQLXML lowLevelXMLEcho(
 		SQLXML sx, int how, @SQLType(defaultValue={}) ResultSet adjust)
 	throws SQLException
@@ -518,6 +595,36 @@ public class PassXML implements SQLData
 				axp.xIncludeAware(adjust.getBoolean(i));
 			else if ( "expandEntityReferences".equalsIgnoreCase(k) )
 				axp.expandEntityReferences(adjust.getBoolean(i));
+			else if ( "elementAttributeLimit".equalsIgnoreCase(k) )
+				axp.elementAttributeLimit(adjust.getInt(i));
+			else if ( "entityExpansionLimit".equalsIgnoreCase(k) )
+				axp.entityExpansionLimit(adjust.getInt(i));
+			else if ( "entityReplacementLimit".equalsIgnoreCase(k) )
+				axp.entityReplacementLimit(adjust.getInt(i));
+			else if ( "maxElementDepth".equalsIgnoreCase(k) )
+				axp.maxElementDepth(adjust.getInt(i));
+			else if ( "maxGeneralEntitySizeLimit".equalsIgnoreCase(k) )
+				axp.maxGeneralEntitySizeLimit(adjust.getInt(i));
+			else if ( "maxParameterEntitySizeLimit".equalsIgnoreCase(k) )
+				axp.maxParameterEntitySizeLimit(adjust.getInt(i));
+			else if ( "maxXMLNameLimit".equalsIgnoreCase(k) )
+				axp.maxXMLNameLimit(adjust.getInt(i));
+			else if ( "totalEntitySizeLimit".equalsIgnoreCase(k) )
+				axp.totalEntitySizeLimit(adjust.getInt(i));
+			else if ( "accessExternalDTD".equalsIgnoreCase(k) )
+				axp.accessExternalDTD(adjust.getString(i));
+			else if ( "accessExternalSchema".equalsIgnoreCase(k) )
+				axp.accessExternalSchema(adjust.getString(i));
+			else if ( "schema".equalsIgnoreCase(k) )
+			{
+				try
+				{
+					axp.schema(s_schemas.get(adjust.getString(i)));
+				}
+				catch (UnsupportedOperationException e)
+				{
+				}
+			}
 			else
 				throw new SQLDataException(
 					"unrecognized name \"" + k + "\" for parser adjustment",

--- a/pljava/src/main/java/org/postgresql/pljava/internal/VarlenaWrapper.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/VarlenaWrapper.java
@@ -296,8 +296,8 @@ public interface VarlenaWrapper extends Closeable
 				catch ( Exception e )
 				{
 					throw new SQLException(
-						"Error verifying variable-length input data, " +
-						"not otherwise provided for", "XX000", e);
+						"Exception verifying variable-length data: " +
+						e.getMessage(), "XX000", e);
 				}
 				finally
 				{
@@ -1141,8 +1141,8 @@ public interface VarlenaWrapper extends Closeable
 				if ( t instanceof RuntimeException )
 					throw (RuntimeException) t;
 				throw new SQLException(
-					"Exception verifying variable-length data, not " +
-					"otherwise provided for", "XX000", exce);
+					"Exception verifying variable-length data: " +
+					exce.getMessage(), "XX000", exce);
 			}
 
 			if ( ! m_queue.isEmpty() )

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/SQLXMLImpl.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/SQLXMLImpl.java
@@ -3847,7 +3847,11 @@ public abstract class SQLXMLImpl<V extends VarlenaWrapper> implements SQLXML
 						SAX2PROPERTY.LEXICAL_HANDLER.propertyUri(), lh);
 				xr.parse(sxs.getInputSource());
 			}
-			catch ( ParserConfigurationException | SAXException e )
+			catch ( ParserConfigurationException e )
+			{
+				throw new SQLDataException(e.getMessage(), "22000", e);
+			}
+			catch ( SAXException e )
 			{
 				throw new SQLDataException(e.getMessage(), "22000", e);
 			}

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/SQLXMLImpl.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/SQLXMLImpl.java
@@ -619,6 +619,9 @@ public abstract class SQLXMLImpl<V extends VarlenaWrapper> implements SQLXML
 
 		XMLInputFactory xif = XMLInputFactory.newInstance();
 		xif.setProperty(xif.IS_NAMESPACE_AWARE, true);
+		xif.setProperty(xif.SUPPORT_DTD, false);// will still report one it sees
+		xif.setProperty(xif.IS_REPLACING_ENTITY_REFERENCES, false);
+
 		XMLStreamReader xsr = null;
 		try
 		{

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/SQLXMLImpl.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/SQLXMLImpl.java
@@ -157,6 +157,7 @@ import org.xml.sax.ext.LexicalHandler;
 import java.io.StringReader;
 import javax.xml.parsers.ParserConfigurationException;
 import org.postgresql.pljava.Adjusting;
+import org.xml.sax.EntityResolver;
 import org.xml.sax.SAXNotRecognizedException;
 import org.xml.sax.SAXNotSupportedException;
 
@@ -4075,6 +4076,14 @@ public abstract class SQLXMLImpl<V extends VarlenaWrapper> implements SQLXML
 		{
 			return setFirstSupportedProperty(protocols, ACCESS + "Schema");
 		}
+
+		@Override
+		public T entityResolver(EntityResolver resolver)
+		{
+			throw new UnsupportedOperationException(
+				"A SAX EntityResolver cannot be set on a " +
+				getClass().getCanonicalName());
+		}
 	}
 
 	/**
@@ -4384,6 +4393,13 @@ public abstract class SQLXMLImpl<V extends VarlenaWrapper> implements SQLXML
 			theAdjustable().setFirstSupportedProperty(value, names);
 			return this;
 		}
+
+		@Override
+		public AdjustingSourceResult entityResolver(EntityResolver resolver)
+		{
+			theAdjustable().entityResolver(resolver);
+			return this;
+		}
 	}
 
 	static class AdjustingStreamResult
@@ -4542,6 +4558,13 @@ public abstract class SQLXMLImpl<V extends VarlenaWrapper> implements SQLXML
 			theVerifierSource().setFirstSupportedProperty(value, names);
 			return this;
 		}
+
+		@Override
+		public AdjustingStreamResult entityResolver(EntityResolver resolver)
+		{
+			theVerifierSource().entityResolver(resolver);
+			return this;
+		}
 	}
 
 	static class AdjustingSAXSource
@@ -4566,6 +4589,12 @@ public abstract class SQLXMLImpl<V extends VarlenaWrapper> implements SQLXML
 			@Override
 			public AdjustingSAXSource setFirstSupportedProperty(
 				Object value, String... names)
+			{
+				return this;
+			}
+
+			@Override
+			public AdjustingSAXSource entityResolver(EntityResolver resolver)
 			{
 				return this;
 			}
@@ -4688,6 +4717,13 @@ public abstract class SQLXMLImpl<V extends VarlenaWrapper> implements SQLXML
 			}
 			return this;
 		}
+
+		@Override
+		public AdjustingSAXSource entityResolver(EntityResolver resolver)
+		{
+			theReader().setEntityResolver(resolver);
+			return this;
+		}
 	}
 
 	/*
@@ -4763,6 +4799,12 @@ public abstract class SQLXMLImpl<V extends VarlenaWrapper> implements SQLXML
 		@Override
 		public AdjustingSAXResult setFirstSupportedProperty(
 			Object value, String... names)
+		{
+			return checkedNoOp();
+		}
+
+		@Override
+		public AdjustingSAXResult entityResolver(EntityResolver resolver)
 		{
 			return checkedNoOp();
 		}
@@ -4917,6 +4959,7 @@ public abstract class SQLXMLImpl<V extends VarlenaWrapper> implements SQLXML
 		private DocumentBuilderFactory m_dbf;
 		private InputStream m_is;
 		private boolean m_wrapped;
+		private EntityResolver m_resolver;
 
 		AdjustingDOMSource(InputStream is, boolean wrapped)
 		{
@@ -4957,6 +5000,8 @@ public abstract class SQLXMLImpl<V extends VarlenaWrapper> implements SQLXML
 			try
 			{
 				DocumentBuilder db = m_dbf.newDocumentBuilder();
+				if ( null != m_resolver )
+					db.setEntityResolver(m_resolver);
 				DOMSource ds = new DOMSource(db.parse(m_is));
 				if ( m_wrapped )
 					domUnwrap(ds);
@@ -5021,6 +5066,13 @@ public abstract class SQLXMLImpl<V extends VarlenaWrapper> implements SQLXML
 					e.printStackTrace(); // XXX
 				}
 			}
+			return this;
+		}
+
+		@Override
+		public AdjustingDOMSource entityResolver(EntityResolver resolver)
+		{
+			m_resolver = resolver;
 			return this;
 		}
 	}

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/SQLXMLImpl.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/SQLXMLImpl.java
@@ -67,10 +67,11 @@ import javax.xml.transform.dom.DOMSource;
 
 import org.xml.sax.InputSource;
 import org.xml.sax.XMLReader;
-import org.xml.sax.helpers.XMLReaderFactory;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.parsers.SAXParserFactory;
 
 import org.w3c.dom.Document;
 import org.w3c.dom.DocumentFragment;
@@ -771,14 +772,18 @@ public abstract class SQLXMLImpl<V extends VarlenaWrapper> implements SQLXML
 		 *<p>
 		 * Override if the preferred flavor is not {@code SAXSource.class},
 		 * which this implementation returns.
-		 * @param adjust Whether the caller has requested an
-		 * Adjusting.XML.Source.
-		 * @return A preferred flavor of Adjusting.XML.Source, if adjust is
-		 * true, otherwise the corresponding flavor of ordinary Source.
+		 * @param sourceClass Either null, Source, or Adjusting.XML.Source.
+		 * @return A preferred flavor of Adjusting.XML.Source, if sourceClass is
+		 * Adjusting.XML.Source, otherwise the corresponding flavor of ordinary
+		 * Source.
 		 */
-		protected Class<? extends Source> preferredSourceClass(boolean adjust)
+		@SuppressWarnings("unchecked")
+		protected <T extends Source> Class<T> preferredSourceClass(
+			Class<T> sourceClass)
 		{
-			return adjust ? Adjusting.XML.SAXSource.class : SAXSource.class;
+			return Adjusting.XML.Source.class == sourceClass
+				? (Class<T>)Adjusting.XML.SAXSource.class
+				: (Class<T>)SAXSource.class;
 		}
 
 		/**
@@ -813,10 +818,10 @@ public abstract class SQLXMLImpl<V extends VarlenaWrapper> implements SQLXML
 			if ( null == backing )
 				return super.getSource(sourceClass);
 
-			if ( null == sourceClass || Source.class == sourceClass )
-				sourceClass = (Class<T>)preferredSourceClass(false);
-			else if ( Adjusting.XML.Source.class.equals(sourceClass) )
-				sourceClass = (Class<T>)preferredSourceClass(true);
+			if ( null == sourceClass
+				|| Source.class == sourceClass
+				|| Adjusting.XML.Source.class.equals(sourceClass) )
+				sourceClass = preferredSourceClass(sourceClass);
 
 			try
 			{
@@ -1255,6 +1260,27 @@ public abstract class SQLXMLImpl<V extends VarlenaWrapper> implements SQLXML
 			return setResult(vwo, resultClass);
 		}
 
+		/**
+		 * Return a {@code Class<? extends Result>} object representing the most
+		 * natural or preferred presentation if the caller has left it
+		 * unspecified.
+		 *<p>
+		 * Override if the preferred flavor is not {@code SAXResult.class},
+		 * which this implementation returns.
+		 * @param resultClass Either null, Result, or Adjusting.XML.Result.
+		 * @return A preferred flavor of Adjusting.XML.Result, if resultClass is
+		 * Adjusting.XML.Result, otherwise the corresponding flavor of ordinary
+		 * Result.
+		 */
+		@SuppressWarnings("unchecked")
+		protected <T extends Result> Class<T> preferredResultClass(
+			Class<T> resultClass)
+		{
+			return Adjusting.XML.Result.class == resultClass
+				? (Class<T>)AdjustingSAXResult.class
+				: (Class<T>)SAXResult.class;
+		}
+
 		/*
 		 * Internal version for use in the implementation of
 		 * AdjustingSourceResult, when 'officially' the instance is no longer
@@ -1265,10 +1291,10 @@ public abstract class SQLXMLImpl<V extends VarlenaWrapper> implements SQLXML
 			VarlenaWrapper.Output vwo, Class<T> resultClass)
 			throws SQLException
 		{
-			if ( null == resultClass || Result.class == resultClass )
-				resultClass = (Class<T>)SAXResult.class; // trust me on this
-			else if ( Adjusting.XML.Result.class.equals(resultClass) )
-				resultClass = (Class<T>)AdjustingSAXResult.class;
+			if ( null == resultClass
+				|| Result.class == resultClass
+				|| Adjusting.XML.Result.class == resultClass )
+				resultClass = preferredResultClass(resultClass);
 
 			try
 			{
@@ -3805,9 +3831,9 @@ public abstract class SQLXMLImpl<V extends VarlenaWrapper> implements SQLXML
 			{
 				if ( null == xr )
 				{
-					xr = XMLReaderFactory.createXMLReader();
-					xr.setFeature("http://xml.org/sax/features/namespaces",
-									true);
+					SAXParserFactory spf = SAXParserFactory.newInstance();
+					spf.setNamespaceAware(true);
+					xr = spf.newSAXParser().getXMLReader();
 				}
 				ContentHandler ch = sxr.getHandler();
 				xr.setContentHandler(ch);
@@ -3821,7 +3847,7 @@ public abstract class SQLXMLImpl<V extends VarlenaWrapper> implements SQLXML
 						SAX2PROPERTY.LEXICAL_HANDLER.propertyUri(), lh);
 				xr.parse(sxs.getInputSource());
 			}
-			catch ( SAXException e )
+			catch ( ParserConfigurationException | SAXException e )
 			{
 				throw new SQLDataException(e.getMessage(), "22000", e);
 			}
@@ -4608,9 +4634,16 @@ public abstract class SQLXMLImpl<V extends VarlenaWrapper> implements SQLXML
 		throws SAXException
 		{
 			m_is = is;
-			m_xr = XMLReaderFactory.createXMLReader();
-			m_xr.setFeature("http://xml.org/sax/features/namespaces",
-							true);
+			try
+			{
+				SAXParserFactory spf = SAXParserFactory.newInstance();
+				spf.setNamespaceAware(true);
+				m_xr = spf.newSAXParser().getXMLReader();
+			}
+			catch ( ParserConfigurationException e )
+			{
+				throw new SAXException(e.getMessage(), e);
+			}
 			if ( wrapped )
 				m_xr = new SAXUnwrapFilter(m_xr);
 		}

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/SQLXMLImpl.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/SQLXMLImpl.java
@@ -70,7 +70,6 @@ import org.xml.sax.XMLReader;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParserFactory;
 
 import org.w3c.dom.Document;
@@ -778,12 +777,12 @@ public abstract class SQLXMLImpl<V extends VarlenaWrapper> implements SQLXML
 		 * Source.
 		 */
 		@SuppressWarnings("unchecked")
-		protected <T extends Source> Class<T> preferredSourceClass(
+		protected <T extends Source> Class<? extends T> preferredSourceClass(
 			Class<T> sourceClass)
 		{
 			return Adjusting.XML.Source.class == sourceClass
-				? (Class<T>)Adjusting.XML.SAXSource.class
-				: (Class<T>)SAXSource.class;
+				? (Class<? extends T>)Adjusting.XML.SAXSource.class
+				: (Class<? extends T>)SAXSource.class;
 		}
 
 		/**
@@ -818,47 +817,49 @@ public abstract class SQLXMLImpl<V extends VarlenaWrapper> implements SQLXML
 			if ( null == backing )
 				return super.getSource(sourceClass);
 
-			if ( null == sourceClass
-				|| Source.class == sourceClass
-				|| Adjusting.XML.Source.class.equals(sourceClass) )
-				sourceClass = preferredSourceClass(sourceClass);
+			Class<? extends T> sc = sourceClass;
+
+			if ( null == sc
+				|| Source.class == sc
+				|| Adjusting.XML.Source.class.equals(sc) )
+				sc = preferredSourceClass(sc);
 
 			try
 			{
-				if ( sourceClass.isAssignableFrom(StreamSource.class) )
-					return sourceClass.cast(toStreamSource(backing));
+				if ( sc.isAssignableFrom(StreamSource.class) )
+					return sc.cast(toStreamSource(backing));
 
-				if ( sourceClass.isAssignableFrom(SAXSource.class)
-					|| sourceClass.isAssignableFrom(AdjustingSAXSource.class) )
+				if ( sc.isAssignableFrom(SAXSource.class)
+					|| sc.isAssignableFrom(AdjustingSAXSource.class) )
 				{
 					Adjusting.XML.SAXSource ss = toSAXSource(backing);
 					ss.defaults();
 					if ( Adjusting.XML.Source.class
-							.isAssignableFrom(sourceClass) )
-						return sourceClass.cast(ss);
-					return sourceClass.cast(ss.get());
+							.isAssignableFrom(sc) )
+						return sc.cast(ss);
+					return sc.cast(ss.get());
 				}
 
-				if ( sourceClass.isAssignableFrom(StAXSource.class)
-					|| sourceClass.isAssignableFrom(AdjustingStAXSource.class) )
+				if ( sc.isAssignableFrom(StAXSource.class)
+					|| sc.isAssignableFrom(AdjustingStAXSource.class) )
 				{
 					Adjusting.XML.StAXSource ss = toStAXSource(backing);
 					ss.defaults();
 					if ( Adjusting.XML.Source.class
-							.isAssignableFrom(sourceClass) )
-						return sourceClass.cast(ss);
-					return sourceClass.cast(ss.get());
+							.isAssignableFrom(sc) )
+						return sc.cast(ss);
+					return sc.cast(ss.get());
 				}
 
-				if ( sourceClass.isAssignableFrom(DOMSource.class)
-					|| sourceClass.isAssignableFrom(AdjustingDOMSource.class) )
+				if ( sc.isAssignableFrom(DOMSource.class)
+					|| sc.isAssignableFrom(AdjustingDOMSource.class) )
 				{
 					Adjusting.XML.DOMSource ds = toDOMSource(backing);
 					ds.defaults();
 					if ( Adjusting.XML.Source.class
-							.isAssignableFrom(sourceClass) )
-						return sourceClass.cast(ds);
-					return sourceClass.cast(ds.get());
+							.isAssignableFrom(sc) )
+						return sc.cast(ds);
+					return sc.cast(ds.get());
 				}
 			}
 			catch ( Exception e )
@@ -868,7 +869,7 @@ public abstract class SQLXMLImpl<V extends VarlenaWrapper> implements SQLXML
 
 			throw new SQLFeatureNotSupportedException(
 				"No support for SQLXML.getSource(" +
-				sourceClass.getName() + ".class)", "0A000");
+				sc.getName() + ".class)", "0A000");
 		}
 
 		@Override
@@ -1273,12 +1274,12 @@ public abstract class SQLXMLImpl<V extends VarlenaWrapper> implements SQLXML
 		 * Result.
 		 */
 		@SuppressWarnings("unchecked")
-		protected <T extends Result> Class<T> preferredResultClass(
+		protected <T extends Result> Class<? extends T> preferredResultClass(
 			Class<T> resultClass)
 		{
 			return Adjusting.XML.Result.class == resultClass
-				? (Class<T>)AdjustingSAXResult.class
-				: (Class<T>)SAXResult.class;
+				? (Class<? extends T>)AdjustingSAXResult.class
+				: (Class<? extends T>)SAXResult.class;
 		}
 
 		/*
@@ -1291,23 +1292,25 @@ public abstract class SQLXMLImpl<V extends VarlenaWrapper> implements SQLXML
 			VarlenaWrapper.Output vwo, Class<T> resultClass)
 			throws SQLException
 		{
-			if ( null == resultClass
-				|| Result.class == resultClass
-				|| Adjusting.XML.Result.class == resultClass )
-				resultClass = preferredResultClass(resultClass);
+			Class<? extends T> rc = resultClass;
+
+			if ( null == rc
+				|| Result.class == rc
+				|| Adjusting.XML.Result.class == rc )
+				rc = preferredResultClass(rc);
 
 			try
 			{
-				if ( resultClass.isAssignableFrom(StreamResult.class)
-					|| resultClass.isAssignableFrom(AdjustingStreamResult.class)
+				if ( rc.isAssignableFrom(StreamResult.class)
+					|| rc.isAssignableFrom(AdjustingStreamResult.class)
 				   )
 				{
 					AdjustingStreamResult sr =
 						new AdjustingStreamResult(vwo, m_serverCS).defaults();
 					if ( Adjusting.XML.Result.class
-							.isAssignableFrom(resultClass) )
-						return resultClass.cast(sr);
-					return resultClass.cast(sr.get());
+							.isAssignableFrom(rc) )
+						return rc.cast(sr);
+					return rc.cast(sr.get());
 				}
 
 				/*
@@ -1315,9 +1318,9 @@ public abstract class SQLXMLImpl<V extends VarlenaWrapper> implements SQLXML
 				 * call to this method with a different result class will be
 				 * made, setting it then.
 				 */
-				if ( resultClass.isAssignableFrom(AdjustingSourceResult.class) )
+				if ( rc.isAssignableFrom(AdjustingSourceResult.class) )
 				{
-					return resultClass.cast(
+					return rc.cast(
 						new AdjustingSourceResult(this, m_serverCS));
 				}
 
@@ -1328,8 +1331,8 @@ public abstract class SQLXMLImpl<V extends VarlenaWrapper> implements SQLXML
 				OutputStream os = vwo;
 				Writer w;
 
-				if ( resultClass.isAssignableFrom(SAXResult.class)
-					|| resultClass.isAssignableFrom(AdjustingSAXResult.class) )
+				if ( rc.isAssignableFrom(SAXResult.class)
+					|| rc.isAssignableFrom(AdjustingSAXResult.class) )
 				{
 					SAXTransformerFactory saxtf = (SAXTransformerFactory)
 						SAXTransformerFactory.newInstance();
@@ -1342,24 +1345,24 @@ public abstract class SQLXMLImpl<V extends VarlenaWrapper> implements SQLXML
 					th = SAXResultAdapter.newInstance(th, w);
 					SAXResult sr = new SAXResult(th);
 					if ( Adjusting.XML.Result.class
-							.isAssignableFrom(resultClass) )
-						return resultClass.cast(new AdjustingSAXResult(sr));
-					return resultClass.cast(sr);
+							.isAssignableFrom(rc) )
+						return rc.cast(new AdjustingSAXResult(sr));
+					return rc.cast(sr);
 				}
 
-				if ( resultClass.isAssignableFrom(StAXResult.class) )
+				if ( rc.isAssignableFrom(StAXResult.class) )
 				{
 					XMLOutputFactory xof = XMLOutputFactory.newInstance();
 					os = new DeclCheckedOutputStream(os, m_serverCS);
 					XMLStreamWriter xsw = xof.createXMLStreamWriter(
 						os, m_serverCS.name());
 					xsw = new StAXResultAdapter(xsw, os);
-					return resultClass.cast(new StAXResult(xsw));
+					return rc.cast(new StAXResult(xsw));
 				}
 
-				if ( resultClass.isAssignableFrom(DOMResult.class) )
+				if ( rc.isAssignableFrom(DOMResult.class) )
 				{
-					return resultClass.cast(m_domResult = new DOMResult());
+					return rc.cast(m_domResult = new DOMResult());
 				}
 			}
 			catch ( Exception e )
@@ -1369,7 +1372,7 @@ public abstract class SQLXMLImpl<V extends VarlenaWrapper> implements SQLXML
 
 			throw new SQLFeatureNotSupportedException(
 				"No support for SQLXML.setResult(" +
-				resultClass.getName() + ".class)", "0A000");
+				rc.getName() + ".class)", "0A000");
 		}
 
 		/**

--- a/src/site/markdown/use/sqlxml.md
+++ b/src/site/markdown/use/sqlxml.md
@@ -409,6 +409,16 @@ with a `javax.xml.validation.Validator`.
 
 Complete details can be found [in the API documentation][adjx].
 
+#### Using XML Catalogs when running on Java 9 or later
+
+When running on Java 9 or later, a local XML Catalog can be set up to
+efficiently and securely resolve what would otherwise be external resource
+references. The registration of a Catalog on a Java 9 or later parser involves
+only existing methods for setting features/properties, as described
+[in the Catalog API documentation][catapi], and can be done with the
+`setFirstSupportedFeature` and `setFirstSupportedProperty` methods
+in PL/Java's `Adjusting` API.
+
 ### Extended API to set the content of a PL/Java `SQLXML` instance
 
 When a `SQLXML` instance is returned from a PL/Java function, or passed in to
@@ -460,6 +470,7 @@ Java's extensive support for XML.
 [cheat]: https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html#java
 [adjx]: ../pljava-api/apidocs/index.html?org/postgresql/pljava/Adjusting.XML.html
 [jaxps]: https://docs.oracle.com/en/java/javase/13/security/java-api-xml-processing-jaxp-security-guide.html
+[catapi]: https://docs.oracle.com/javase/9/core/xml-catalog-api1.htm#JSCOR-GUID-51446739-F878-4B70-A36F-47FBBE12A26A
 
 ## Known limitations
 

--- a/src/site/markdown/use/sqlxml.md
+++ b/src/site/markdown/use/sqlxml.md
@@ -311,6 +311,21 @@ from `String` to XML uses PostgreSQL's `xml_in` function to verify the form of a
 configuration variable `xmloption` is not first set to `DOCUMENT` or `CONTENT`
 to match the type of the value.
 
+#### Validation against a schema
+
+Java's XML APIs support validation using a choice of schema languages;
+support for XML Schema 1.0 is included in the Java runtime, and implementations
+of others can be placed on the class path.
+
+A `schema` method is available through the "Extended API to configure
+XML parsers" described below, but will only work on a `SAXSource` or `DOMSource`
+(or a `StreamResult`, which uses a SAX parser to validate the stream written).
+Other limitations are described under "known limitations" below.
+
+More flexibly, `javax.xml.validation.Validator` or
+`javax.xml.validation.ValidatorHandler` can be used in more situations and with
+fewer limitations.
+
 ### Usable with or without native XML support in PostgreSQL
 
 In symmetry to using Java `String` for SQL XML types, PL/Java allows the Java
@@ -367,6 +382,31 @@ OWASP-recommended defaults, which would reject any content with a DTD. The
 second form would obtain a `SAXSource` configured to allow a DTD in the
 content, with other parser features left at the restrictive defaults.
 
+#### Additional adjustments in recent Java versions
+
+Additional security-related adjustments have appeared in various Java releases,
+and are described in the [Java API for XML Processing Security Guide][jaxps].
+They include a number of configurable limits on maximum sizes and nesting
+depths, and limits to the set of protocols allowable for fetching external
+resources. Corresponding methods are provided in [PL/Java's API][adjx].
+Also see "known limitations" below.
+
+#### Supplying a SAX or DOM `EntityResolver` or `Schema`
+
+Methods are provided to set an `EntityResolver` that controls how a SAX or DOM
+parser resolves references to external entities, or a `Schema` by which a SAX
+or DOM parser can validate content while parsing. Corresponding methods are
+supplied in PL/Java's API, but are implemented only when operating on a
+`SAXSource` or `DOMSource` (or `StreamResult`, affecting its validation of
+the content written).
+
+For StAX, control of resolution is done with a slightly different class,
+`XMLResolver`, which can be set on a StAX parser as an ordinary property;
+this can be done with PL/Java's `setFirstMatchingProperty` method.
+
+A StAX parser cannot have a `Schema` directly assigned, but can be used
+with a `javax.xml.validation.Validator`.
+
 Complete details can be found [in the API documentation][adjx].
 
 ### Extended API to set the content of a PL/Java `SQLXML` instance
@@ -419,6 +459,7 @@ Java's extensive support for XML.
 [OWASP]: https://www.owasp.org/index.php/About_The_Open_Web_Application_Security_Project
 [cheat]: https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html#java
 [adjx]: ../pljava-api/apidocs/index.html?org/postgresql/pljava/Adjusting.XML.html
+[jaxps]: https://docs.oracle.com/en/java/javase/13/security/java-api-xml-processing-jaxp-security-guide.html
 
 ## Known limitations
 
@@ -457,3 +498,24 @@ For convenience, the `SQLXML` API allows passing a null value to `getSource`
 or `setResult`, allowing the implementation to choose the type of `Source`
 or `Result` to supply. PL/Java's implementation will never supply a `StAX`
 variant when not explicitly requested.
+
+### Pay no attention to that man behind the curtain
+
+The processing done "behind the curtain" to be able to handle `XML(CONTENT)`
+and `XML(DOCUMENT)` form, when the form is not known in advance, can have
+some visible effects when combined with the newer [security limit][jaxps]
+adjustments, or `schema` set on a SAX or DOM parser. For example, a very tight
+setting of `maxElementDepth` may reveal that elements in the input are
+nested one level deeper than expected, or a very tight `maxXMLNameLimit` may
+reject a document whose expected names are all shorter. Schema validation for
+some schemas and schema languages may likewise report an unexpected element
+at the root of the document.
+
+Issues with `maxElementDepth` or `maxXMLNameLimit` can be avoided by using
+generous settings chosen to limit extreme resource consumption rather than
+trying to set them as tightly as possible.
+
+Problems with schema validation when assigning a `Schema` directly to the
+SAX or DOM parser can be alleviated by using a `javax.xml.validation.Validator`
+or `ValidatorHandler` instead, layered over PL/Java's parser, where it will
+see the expected view of the content.


### PR DESCRIPTION
At its introduction, this API only allowed adjustment to the handful of parser settings to be defaulted to restrictive values as recommended in the [OWASP cheat sheet][cheat].

However, there are several additional properties defined in recent Java releases for fine control of resource limits during parsing and individual protocols for accessing external resources. They are described in the [Java API for XML Processing (JAXP) Security Guide][jaxps]; make those also controllable through the `Adjusting` API.

Finally, SAX and DOM parsers can make use of an application-supplied `EntityResolver` or `Schema`, but the opportunity for setting each of those, for at least one type of parser, is hidden beneath the `SQLXML` API. Provide `Adjusting` methods for those too.

[cheat]: https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html#java
[jaxps]: https://docs.oracle.com/en/java/javase/13/security/java-api-xml-processing-jaxp-security-guide.html