### PR TITLE
Fix second bug found by GSoC 2020

### DIFF
--- a/pljava-so/src/main/c/PgSavepoint.c
+++ b/pljava-so/src/main/c/PgSavepoint.c
@@ -27,7 +27,7 @@ static jmethodID s_forId;
 static jfieldID s_nestLevel;
 
 extern void PgSavepoint_initialize(void);
-static void unwind(void (*f)(void), int nestingLevel, int xid);
+static void unwind(void (*f)(void), jint xid, jint nestingLevel);
 static void assertXid(SubTransactionId);
 
 jobject pljava_PgSavepoint_forId(SubTransactionId subId)


### PR DESCRIPTION
There were two issues here. That the prototype and function had the parameters in a different order was not a compile error (because the types were the same), but certainly misleading and a risk for future maintenance.

That the types were `int` in the prototype and `jint` in the function is a compile error, but has never been flagged by any compiler until building with Mingw-w64 (where presumably there is more of a distinction between `jint` and `int`).

Addresses #282.

Was introduced in 1.5.3 so should be backpatched to 1.5.