### PR TITLE
Clean lint reported by compilers in CI runs

### DIFF
--- a/pljava-api/src/main/java/org/postgresql/pljava/annotation/processing/DDRProcessor.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/annotation/processing/DDRProcessor.java
@@ -2021,7 +2021,7 @@ hunt:	for ( ExecutableElement ee : ees )
 		INPUT("in", null, "pg_catalog.cstring", "pg_catalog.oid", "integer"),
 		OUTPUT("out", "pg_catalog.cstring", (String[])null),
 		RECEIVE("recv", null, "pg_catalog.internal","pg_catalog.oid","integer"),
-		SEND("send", "pg_catalog.bytea", null);
+		SEND("send", "pg_catalog.bytea", (String[])null);
 		BaseUDTFunctionID( String suffix, String ret, String... param)
 		{
 			this.suffix = suffix;

--- a/pljava-so/src/main/c/Function.c
+++ b/pljava-so/src/main/c/Function.c
@@ -790,6 +790,7 @@ Datum Function_invokeTrigger(Function self, PG_FUNCTION_ARGS)
 		 * it is created in the upper context (even after connecting SPI, should
 		 * that be necessary).
 		 */
+		MemoryContext currCtx;
 #if PG_VERSION_NUM >= 100000
 		/* If the invoked trigger function didn't connect SPI, do that here
 		 * (getTriggerReturnTuple now needs it), but there will be no need to
@@ -798,7 +799,7 @@ Datum Function_invokeTrigger(Function self, PG_FUNCTION_ARGS)
 		currentInvocation->triggerData = NULL;
 		Invocation_assertConnect();
 #endif
-		MemoryContext currCtx = Invocation_switchToUpperContext();
+		currCtx = Invocation_switchToUpperContext();
 		ret = PointerGetDatum(
 				pljava_TriggerData_getTriggerReturnTuple(
 					jtd, &fcinfo->isnull));
@@ -929,9 +930,10 @@ JNIEXPORT jboolean JNICALL
 
 		if ( 0 < numParams )
 		{
+			jint *paramOids;
 			self->func.nonudt.paramTypes =
 				(Type *)MemoryContextAlloc(ctx, numParams * sizeof (Type));
-			jint *paramOids = JNI_getIntArrayElements(paramTypes, NULL);
+			paramOids = JNI_getIntArrayElements(paramTypes, NULL);
 			for ( i = 0 ; i < numParams ; ++ i )
 			{
 				if ( NULL != paramJTypes )

--- a/pljava-so/src/main/c/Function.c
+++ b/pljava-so/src/main/c/Function.c
@@ -902,7 +902,7 @@ JNIEXPORT jboolean JNICALL
 	int i = 0;
 	uint16 refParams = 0;
 	uint16 primParams = 0;
-	bool returnTypeIsOutParameter;
+	bool returnTypeIsOutParameter = false;
 
 	p2l.longVal = wrappedPtr;
 	self = (Function)p2l.ptrVal;
@@ -983,7 +983,6 @@ JNIEXPORT jboolean JNICALL
 		Exception_throw_ERROR(PG_FUNCNAME_MACRO);
 	}
 	PG_END_TRY();
-	END_NATIVE
 
 	if ( returnTypeIsOutParameter  &&  JNI_TRUE != isMultiCall )
 		++ refParams;
@@ -991,6 +990,7 @@ JNIEXPORT jboolean JNICALL
 	self->func.nonudt.numRefParams = refParams;
 	self->func.nonudt.numPrimParams = primParams;
 
+	END_NATIVE
 	return returnTypeIsOutParameter;
 }
 

--- a/pljava-so/src/main/c/InstallHelper.c
+++ b/pljava-so/src/main/c/InstallHelper.c
@@ -119,7 +119,7 @@ static jmethodID s_InstallHelper_groundwork;
 static bool extensionExNihilo = false;
 
 static void checkLoadPath( bool *livecheck);
-static void getExtensionLoadPath();
+static void getExtensionLoadPath(void);
 static char *origUserName();
 
 char const *pljavaLoadPath = NULL;

--- a/pljava-so/src/main/c/PgSavepoint.c
+++ b/pljava-so/src/main/c/PgSavepoint.c
@@ -38,9 +38,6 @@ jobject pljava_PgSavepoint_forId(SubTransactionId subId)
 
 void PgSavepoint_initialize(void)
 {
-	StaticAssertStmt(sizeof(SubTransactionId) <= sizeof(jint),
-		"SubTransactionId wider than jint?!");
-
 	JNINativeMethod methods[] =
 	{
 		{
@@ -63,7 +60,14 @@ void PgSavepoint_initialize(void)
 	PgObject_registerNatives("org/postgresql/pljava/internal/PgSavepoint",
 		methods);
 
-	jclass s_PgSavepoint_class = JNI_newGlobalRef(PgObject_getJavaClass(
+	/*
+	 * I would rather put this at the top, but it counts as a statement, and
+	 * would trigger a declaration-after-statement warning.
+	 */
+	StaticAssertStmt(sizeof(SubTransactionId) <= sizeof(jint),
+		"SubTransactionId wider than jint?!");
+
+	s_PgSavepoint_class = JNI_newGlobalRef(PgObject_getJavaClass(
 		"org/postgresql/pljava/internal/PgSavepoint"));
 	s_forId =
 		PgObject_getStaticJavaMethod(s_PgSavepoint_class, "forId",

--- a/pljava-so/src/main/c/SPI.c
+++ b/pljava-so/src/main/c/SPI.c
@@ -30,7 +30,41 @@ StaticAssertStmt((c) == (org_postgresql_pljava_internal_##c), \
 extern void SPI_initialize(void);
 void SPI_initialize(void)
 {
-	/* Statically assert that the Java code has the right values for these. */
+	JNINativeMethod methods[] = {
+		{
+		"_exec",
+		"(Ljava/lang/String;I)I",
+		Java_org_postgresql_pljava_internal_SPI__1exec
+		},
+		{
+		"_getProcessed",
+		"()J",
+		Java_org_postgresql_pljava_internal_SPI__1getProcessed
+		},
+		{
+		"_getResult",
+		"()I",
+		Java_org_postgresql_pljava_internal_SPI__1getResult
+		},
+		{
+		"_getTupTable",
+		"(Lorg/postgresql/pljava/internal/TupleDesc;)Lorg/postgresql/pljava/internal/TupleTable;",
+		Java_org_postgresql_pljava_internal_SPI__1getTupTable
+		},
+		{
+		"_freeTupTable",
+		"()V",
+		Java_org_postgresql_pljava_internal_SPI__1freeTupTable
+		},
+		{ 0, 0, 0 }};
+
+	PgObject_registerNatives("org/postgresql/pljava/internal/SPI", methods);
+
+	/*
+	 * Statically assert that the Java code has the right values for these.
+	 * I would rather have this at the top, but these count as statements and
+	 * would trigger a declaration-after-statment warning.
+	 */
 	CONFIRMCONST(SPI_ERROR_CONNECT);
 	CONFIRMCONST(SPI_ERROR_COPY);
 	CONFIRMCONST(SPI_ERROR_OPUNKNOWN);
@@ -68,36 +102,6 @@ void SPI_initialize(void)
 	CONFIRMCONST(SPI_OK_REL_UNREGISTER);
 	CONFIRMCONST(SPI_OK_TD_REGISTER);
 #endif
-
-	JNINativeMethod methods[] = {
-		{
-		"_exec",
-		"(Ljava/lang/String;I)I",
-	  	Java_org_postgresql_pljava_internal_SPI__1exec
-		},
-		{
-		"_getProcessed",
-		"()J",
-		Java_org_postgresql_pljava_internal_SPI__1getProcessed
-		},
-		{
-		"_getResult",
-		"()I",
-		Java_org_postgresql_pljava_internal_SPI__1getResult
-		},
-		{
-		"_getTupTable",
-		"(Lorg/postgresql/pljava/internal/TupleDesc;)Lorg/postgresql/pljava/internal/TupleTable;",
-		Java_org_postgresql_pljava_internal_SPI__1getTupTable
-		},
-		{
-		"_freeTupTable",
-		"()V",
-		Java_org_postgresql_pljava_internal_SPI__1freeTupTable
-		},
-		{ 0, 0, 0 }};
-
-	PgObject_registerNatives("org/postgresql/pljava/internal/SPI", methods);
 }
 
 /****************************************

--- a/pljava-so/src/main/c/VarlenaWrapper.c
+++ b/pljava-so/src/main/c/VarlenaWrapper.c
@@ -513,7 +513,7 @@ Java_org_postgresql_pljava_internal_VarlenaWrapper_00024Input_00024State__1detoa
 	Ptr2Long p2ldetoasted;
 	_VL_TYPE detoasted;
 	MemoryContext prevcxt;
-	jobject dbb;
+	jobject dbb = NULL;
 
 	BEGIN_NATIVE_NO_ERRCHECK
 
@@ -570,18 +570,18 @@ JNIEXPORT jlong JNICALL Java_org_postgresql_pljava_internal_VarlenaWrapper_00024
 	MemoryContext prevcxt;
 	_VL_TYPE fetched;
 
-	BEGIN_NATIVE_NO_ERRCHECK;
 	p2lvl.longVal = varlena;
 	p2lcxt.longVal = memContext;
 
+	BEGIN_NATIVE_NO_ERRCHECK;
 	prevcxt = MemoryContextSwitchTo((MemoryContext) p2lcxt.ptrVal);
 	fetched = heap_tuple_fetch_attr((_VL_TYPE) p2lvl.ptrVal);
 	pfree(p2lvl.ptrVal);
 	p2lvl.longVal = 0L;
 	p2lvl.ptrVal = fetched;
 	MemoryContextSwitchTo(prevcxt);
-
 	END_NATIVE;
+
 	return p2lvl.longVal;
 }
 
@@ -599,7 +599,7 @@ Java_org_postgresql_pljava_internal_VarlenaWrapper_00024Output_00024State__1next
 	ExpandedVarlenaOutputStreamNode *node;
 	Ptr2Long p2l;
 	Datum d;
-	jobject dbb;
+	jobject dbb = NULL;
 
 	p2l.longVal = varlenaPtr;
 	d = PointerGetDatum(p2l.ptrVal);

--- a/pljava-so/src/main/c/type/Oid.c
+++ b/pljava-so/src/main/c/type/Oid.c
@@ -316,7 +316,7 @@ Java_org_postgresql_pljava_internal_Oid__1getJavaClassName(JNIEnv* env, jclass c
 JNIEXPORT jobject JNICALL
 Java_org_postgresql_pljava_internal_Oid__1getCurrentLoader(JNIEnv *env, jclass cls)
 {
-	jobject result;
+	jobject result = NULL;
 	BEGIN_NATIVE
 	result = Function_currentLoader();
 	END_NATIVE

--- a/pljava-so/src/main/c/type/SQLXMLImpl.c
+++ b/pljava-so/src/main/c/type/SQLXMLImpl.c
@@ -236,7 +236,7 @@ JNIEXPORT jobject JNICALL
 Java_org_postgresql_pljava_jdbc_SQLXMLImpl__1newWritable
 	(JNIEnv *env, jclass sqlxml_class)
 {
-	jobject sqlxml;
+	jobject sqlxml = NULL;
 	jobject vwo;
 	BEGIN_NATIVE
 	vwo = pljava_VarlenaWrapper_Output(

--- a/pljava-so/src/main/c/type/TriggerData.c
+++ b/pljava-so/src/main/c/type/TriggerData.c
@@ -165,9 +165,10 @@ JNIEXPORT jobject JNICALL
 Java_org_postgresql_pljava_internal_TriggerData__1getRelation(JNIEnv* env, jclass clazz, jlong _this)
 {
 	jobject result = 0;
+	TriggerData* self;
 	Ptr2Long p2l;
 	p2l.longVal = _this;
-	TriggerData* self = (TriggerData*)p2l.ptrVal;
+	self = (TriggerData*)p2l.ptrVal;
 	if(self != 0)
 	{
 		BEGIN_NATIVE
@@ -186,9 +187,10 @@ JNIEXPORT jobject JNICALL
 Java_org_postgresql_pljava_internal_TriggerData__1getTriggerTuple(JNIEnv* env, jclass clazz, jlong _this)
 {
 	jobject result = 0;
+	TriggerData* self;
 	Ptr2Long p2l;
 	p2l.longVal = _this;
-	TriggerData* self = (TriggerData*)p2l.ptrVal;
+	self = (TriggerData*)p2l.ptrVal;
 	if(self != 0)
 	{
 		BEGIN_NATIVE
@@ -207,9 +209,10 @@ JNIEXPORT jobject JNICALL
 Java_org_postgresql_pljava_internal_TriggerData__1getNewTuple(JNIEnv* env, jclass clazz, jlong _this)
 {
 	jobject result = 0;
+	TriggerData* self;
 	Ptr2Long p2l;
 	p2l.longVal = _this;
-	TriggerData* self = (TriggerData*)p2l.ptrVal;
+	self = (TriggerData*)p2l.ptrVal;
 	if(self != 0)
 	{
 		BEGIN_NATIVE
@@ -228,9 +231,10 @@ JNIEXPORT jobjectArray JNICALL
 Java_org_postgresql_pljava_internal_TriggerData__1getArguments(JNIEnv* env, jclass clazz, jlong _this)
 {
 	jobjectArray result = 0;
+	TriggerData* self;
 	Ptr2Long p2l;
 	p2l.longVal = _this;
-	TriggerData* self = (TriggerData*)p2l.ptrVal;
+	self = (TriggerData*)p2l.ptrVal;
 	if(self != 0)
 	{
 		char** cpp;
@@ -261,9 +265,10 @@ JNIEXPORT jstring JNICALL
 Java_org_postgresql_pljava_internal_TriggerData__1getName(JNIEnv* env, jclass clazz, jlong _this)
 {
 	jstring result = 0;
+	TriggerData* self;
 	Ptr2Long p2l;
 	p2l.longVal = _this;
-	TriggerData* self = (TriggerData*)p2l.ptrVal;
+	self = (TriggerData*)p2l.ptrVal;
 	if(self != 0)
 	{
 		BEGIN_NATIVE
@@ -282,9 +287,10 @@ JNIEXPORT jboolean JNICALL
 Java_org_postgresql_pljava_internal_TriggerData__1isFiredAfter(JNIEnv* env, jclass clazz, jlong _this)
 {
 	jboolean result = JNI_FALSE;
+	TriggerData* self;
 	Ptr2Long p2l;
 	p2l.longVal = _this;
-	TriggerData* self = (TriggerData*)p2l.ptrVal;
+	self = (TriggerData*)p2l.ptrVal;
 	if(self != 0)
 		result = (jboolean)TRIGGER_FIRED_AFTER(self->tg_event);
 	return result;
@@ -299,9 +305,10 @@ JNIEXPORT jboolean JNICALL
 Java_org_postgresql_pljava_internal_TriggerData__1isFiredBefore(JNIEnv* env, jclass clazz, jlong _this)
 {
 	jboolean result = JNI_FALSE;
+	TriggerData* self;
 	Ptr2Long p2l;
 	p2l.longVal = _this;
-	TriggerData* self = (TriggerData*)p2l.ptrVal;
+	self = (TriggerData*)p2l.ptrVal;
 	if(self != 0)
 		result = (jboolean)TRIGGER_FIRED_BEFORE(self->tg_event);
 	return result;
@@ -316,9 +323,10 @@ JNIEXPORT jboolean JNICALL
 Java_org_postgresql_pljava_internal_TriggerData__1isFiredForEachRow(JNIEnv* env, jclass clazz, jlong _this)
 {
 	jboolean result = JNI_FALSE;
+	TriggerData* self;
 	Ptr2Long p2l;
 	p2l.longVal = _this;
-	TriggerData* self = (TriggerData*)p2l.ptrVal;
+	self = (TriggerData*)p2l.ptrVal;
 	if(self != 0)
 		result = (jboolean)TRIGGER_FIRED_FOR_ROW(self->tg_event);
 	return result;
@@ -333,9 +341,10 @@ JNIEXPORT jboolean JNICALL
 Java_org_postgresql_pljava_internal_TriggerData__1isFiredForStatement(JNIEnv* env, jclass clazz, jlong _this)
 {
 	jboolean result = JNI_FALSE;
+	TriggerData* self;
 	Ptr2Long p2l;
 	p2l.longVal = _this;
-	TriggerData* self = (TriggerData*)p2l.ptrVal;
+	self = (TriggerData*)p2l.ptrVal;
 	if(self != 0)
 		result = (jboolean)TRIGGER_FIRED_FOR_STATEMENT(self->tg_event);
 	return result;
@@ -350,9 +359,10 @@ JNIEXPORT jboolean JNICALL
 Java_org_postgresql_pljava_internal_TriggerData__1isFiredByDelete(JNIEnv* env, jclass clazz, jlong _this)
 {
 	jboolean result = JNI_FALSE;
+	TriggerData* self;
 	Ptr2Long p2l;
 	p2l.longVal = _this;
-	TriggerData* self = (TriggerData*)p2l.ptrVal;
+	self = (TriggerData*)p2l.ptrVal;
 	if(self != 0)
 		result = (jboolean)TRIGGER_FIRED_BY_DELETE(self->tg_event);
 	return result;
@@ -367,9 +377,10 @@ JNIEXPORT jboolean JNICALL
 Java_org_postgresql_pljava_internal_TriggerData__1isFiredByInsert(JNIEnv* env, jclass clazz, jlong _this)
 {
 	jboolean result = JNI_FALSE;
+	TriggerData* self;
 	Ptr2Long p2l;
 	p2l.longVal = _this;
-	TriggerData* self = (TriggerData*)p2l.ptrVal;
+	self = (TriggerData*)p2l.ptrVal;
 	if(self != 0)
 		result = (jboolean)TRIGGER_FIRED_BY_INSERT(self->tg_event);
 	return result;
@@ -384,9 +395,10 @@ JNIEXPORT jboolean JNICALL
 Java_org_postgresql_pljava_internal_TriggerData__1isFiredByUpdate(JNIEnv* env, jclass clazz, jlong _this)
 {
 	jboolean result = JNI_FALSE;
+	TriggerData* self;
 	Ptr2Long p2l;
 	p2l.longVal = _this;
-	TriggerData* self = (TriggerData*)p2l.ptrVal;
+	self = (TriggerData*)p2l.ptrVal;
 	if(self != 0)
 		result = (jboolean)TRIGGER_FIRED_BY_UPDATE(self->tg_event);
 	return result;

--- a/pljava-so/src/main/include/pljava/Function.h
+++ b/pljava-so/src/main/include/pljava/Function.h
@@ -87,7 +87,7 @@ extern void pljava_Function_setParameter(Function self, int idx, jvalue val);
 /*
  * Not intended for any caller other than Invocation_popInvocation.
  */
-extern void pljava_Function_popFrame();
+extern void pljava_Function_popFrame(void);
 
 /*
  * These actually invoke a target Java method (returning, respectively, a

--- a/pljava-so/src/main/include/pljava/InstallHelper.h
+++ b/pljava-so/src/main/include/pljava/InstallHelper.h
@@ -76,13 +76,13 @@ extern bool InstallHelper_isPLJavaFunction(Oid fn);
  * In a background worker, there's no MyProcPort, and the name is found another
  * way and strdup'd in TopMemoryContext, it'll keep, don't bother freeing it.
  */
-extern char *pljavaDbName();
+extern char *pljavaDbName(void);
 
 /*
  * Return the name of the cluster if it has been set (only possible in 9.5+),
  * or an empty string, never NULL.
  */
-extern char const *pljavaClusterName();
+extern char const *pljavaClusterName(void);
 
 /*
  * Construct a default for pljava.module_path ($sharedir/pljava/pljava-$VER.jar
@@ -113,7 +113,7 @@ extern char const *InstallHelper_defaultModulePath(char *, char);
  * and disrupt the abort. The trickiest bit was finding available API to
  * recognize the ABORT_PENDING cases.
  */
-extern bool pljavaViableXact();
+extern bool pljavaViableXact(void);
 
 /*
  * Backend's initsequencer needs to know whether it's being called in a 9.3+
@@ -123,10 +123,10 @@ extern bool pljavaViableXact();
  * version-specific Windows visibility issues, so the ugly details are in
  * InstallHelper, and Backend just asks this nice function.
  */
-extern bool InstallHelper_shouldDeferInit();
+extern bool InstallHelper_shouldDeferInit(void);
 
-extern char *InstallHelper_hello();
+extern char *InstallHelper_hello(void);
 
-extern void InstallHelper_groundwork();
+extern void InstallHelper_groundwork(void);
 
-extern void InstallHelper_initialize();
+extern void InstallHelper_initialize(void);

--- a/pljava-so/src/main/include/pljava/type/Portal.h
+++ b/pljava-so/src/main/include/pljava/type/Portal.h
@@ -29,7 +29,7 @@ extern "C" {
  * @author Thomas Hallgren
  *****************************************************************/
 
-extern void pljava_Portal_initialize();
+extern void pljava_Portal_initialize(void);
 
 /*
  * Create the org.postgresql.pljava.Portal instance


### PR DESCRIPTION
With the build process now using PostgreSQL's `CFLAGS` from `pg_config` and therefore being somewhat reasonable in the warnings it reports, the time seems right to fix some of them.