### PR TITLE
Update maven-project-info-reports to 3.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -232,7 +232,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-project-info-reports-plugin</artifactId>
-				<version>3.0.0</version>
+				<version>3.1.0</version>
 			</plugin>
 		</plugins>
 	</reporting>


### PR DESCRIPTION
Continuing in the vein of the recent updates in 6fabe39.
3.1.0 reduces the volume of the overwhelming useless stack
traces described in https://issues.apache.org/jira/browse/MPIR-373