### PR TITLE
One bug in new compile/link code, and a couple of cleanups

### DIFF
--- a/pljava-so/pom.xml
+++ b/pljava-so/pom.xml
@@ -286,7 +286,19 @@
 	var pgxs = new org.postgresql.pljava.pgxs.AbstractPGXS(implementation);
 
 	var files = utils.getFilesWithExtension(source_path, ".c");
+
 	var compile_flags = new ArrayList();
+	var link_flags = new ArrayList();
+	/*
+	 * pg_config can sometimes sneak options into the value of CC (for example,
+	 * gcc -std=gnu99). Add it to compile_flags as a list, then snatch the first
+	 * element back out to use as the CC executable. Copy any remaining flags
+	 * to link_flags also.
+	 */
+	compile_flags.addAll(pgxs.getPgConfigPropertyAsList(cc));
+	cc = compile_flags.remove(0);
+	link_flags.addAll(compile_flags);
+
 	compile_flags.addAll(pgxs.getPgConfigPropertyAsList(cflags));
 	compile_flags.addAll(pgxs.getPgConfigPropertyAsList(cppflags));
 	compile_flags.addAll(pgxs.getPgConfigPropertyAsList(cflags_sl));
@@ -296,7 +308,6 @@
 			.MojoExecutionException("Compilation failed with exit code: " + exitCode);
 
 	var object_files =  utils.getFilesWithExtension(target_path, extension);
-	var link_flags = new ArrayList();
 	link_flags.addAll(pgxs.getPgConfigPropertyAsList(ldflags));
 	link_flags.addAll(pgxs.getPgConfigPropertyAsList(ldflags_sl));
 	link_flags.addAll(pgxs.getPgConfigPropertyAsList(ldflags_ex));

--- a/pljava-so/src/main/c/Backend.c
+++ b/pljava-so/src/main/c/Backend.c
@@ -169,7 +169,8 @@ static void JVMOptList_addVisualVMName(JVMOptList*);
 static void JVMOptList_addModuleMain(JVMOptList*);
 static void addUserJVMOptions(JVMOptList*);
 static char* getModulePath(const char*);
-static jint JNICALL my_vfprintf(FILE*, const char*, va_list);
+static jint JNICALL my_vfprintf(FILE*, const char*, va_list)
+	pg_attribute_printf(2, 0);
 static void _destroyJavaVM(int, Datum);
 static void initPLJavaClasses(void);
 static void initJavaSession(void);

--- a/pljava/src/main/java/org/postgresql/pljava/management/Commands.java
+++ b/pljava/src/main/java/org/postgresql/pljava/management/Commands.java
@@ -1026,7 +1026,7 @@ public class Commands
 	throws SQLException
 	{
 		Oid typeId = Oid.forTypeName(sqlTypeName);
-		s_logger.info("Type id = " + typeId.toString());
+		s_logger.finer("Type id = " + typeId.toString());
 
 		AclId invoker = AclId.getOuterUser();
 


### PR DESCRIPTION
In some circumstances, `pg_config` can report a `CC` value that includes flags. For example, a vanilla build of PostgreSQL 12 in my Linux environment results in `gcc -std=gnu99` as the value of `CC`. So it seems it has to be treated as a list, with its first element used as the executable, and any others as arguments.

In the same PR, a couple cleanups that are not bugs, but quieting of messages showing up in CI builds.