### PR TITLE
Avoid MSVC TZ workaround in PG 10.2 and later

### DIFF
--- a/pljava-so/src/main/c/type/Timestamp.c
+++ b/pljava-so/src/main/c/type/Timestamp.c
@@ -406,7 +406,7 @@ static Datum _Timestamptz_coerceObject(Type self, jobject ts)
 static int32 Timestamp_getTimeZone(pg_time_t time)
 {
 #if defined(_MSC_VER) && ( \
-	100000<=PG_VERSION_NUM && PG_VERSION_NUM<102000 || \
+	100000<=PG_VERSION_NUM && PG_VERSION_NUM<100002 || \
 	 90600<=PG_VERSION_NUM && PG_VERSION_NUM< 90607 || \
 	 90500<=PG_VERSION_NUM && PG_VERSION_NUM< 90511 || \
 	 90400<=PG_VERSION_NUM && PG_VERSION_NUM< 90416 || \


### PR DESCRIPTION
In 10.2, `session_timezone` gained a `PGDLLIMPORT` marking, making the workaround unnecessary. This typo'd conditional caused it to be used in later 10.x versions anyway.

It may be tempting to blame the change in `PG_VERSION_NUM` format with PG 10 (in 958fe54), but the value here was wrong for the old format too.

Addresses #297. Apparently the workaround wasn't reliable for all cases; as 10.2 has been out for 2½ years, there is probably no need to delve further into why.