### PR TITLE
Continued development of the Checked* classes

### DIFF
--- a/pljava/src/main/java/org/postgresql/pljava/internal/Checked.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/Checked.java
@@ -11,6 +11,9 @@
  */
 package org.postgresql.pljava.internal;
 
+import java.util.OptionalDouble;
+import java.util.OptionalInt;
+import java.util.OptionalLong;
 import java.util.NoSuchElementException;
 import static java.util.Objects.requireNonNull;
 import java.util.stream.BaseStream;
@@ -1016,6 +1019,12 @@ public interface Checked<WT, EX extends Throwable>
 
 	/*
 	 * Optionals without checked-exception-less counterparts in the Java API.
+	 *
+	 * Rather than following Java's odd "Value-Based Class" conventions (which
+	 * would require each class to be final and therefore preclude a None/Some
+	 * implementation), these all have private constructors and constitute an
+	 * effectively sealed hierarchy. Client code can and should treat them as
+	 * value-based classes, and they will behave.
 	 */
 
 	abstract class OptionalBase
@@ -1026,9 +1035,74 @@ public interface Checked<WT, EX extends Throwable>
 		}
 
 		@Override
+		public boolean equals(Object obj)
+		{
+			/*
+			 * This is the equals() inherited by every EMPTY instance, and
+			 * therefore can only return true when obj is an instance of the
+			 * exact same type.
+			 */
+			return null != obj && getClass().equals(obj.getClass());
+		}
+
+		@Override
+		public int hashCode()
+		{
+			return 0;
+		}
+
+		@Override
 		public String toString()
 		{
 			return getClass().getSimpleName() + ".empty";
+		}
+
+		public static OptionalDouble ofNullable(Double value)
+		{
+			return null == value ?
+				OptionalDouble.empty() : OptionalDouble.of(value);
+		}
+
+		public static OptionalInt ofNullable(Integer value)
+		{
+			return null == value ?
+				OptionalInt.empty() : OptionalInt.of(value);
+		}
+
+		public static OptionalLong ofNullable(Long value)
+		{
+			return null == value ?
+				OptionalLong.empty() : OptionalLong.of(value);
+		}
+
+		public static OptionalBoolean ofNullable(Boolean value)
+		{
+			return null == value ?
+				OptionalBoolean.EMPTY : OptionalBoolean.of(value);
+		}
+
+		public static OptionalByte ofNullable(Byte value)
+		{
+			return null == value ?
+				OptionalByte.EMPTY : OptionalByte.of(value);
+		}
+
+		public static OptionalShort ofNullable(Short value)
+		{
+			return null == value ?
+				OptionalShort.EMPTY : OptionalShort.of(value);
+		}
+
+		public static OptionalChar ofNullable(Character value)
+		{
+			return null == value ?
+				OptionalChar.EMPTY : OptionalChar.of(value);
+		}
+
+		public static OptionalFloat ofNullable(Float value)
+		{
+			return null == value ?
+				OptionalFloat.EMPTY : OptionalFloat.of(value);
 		}
 	}
 
@@ -1095,6 +1169,17 @@ public interface Checked<WT, EX extends Throwable>
 			public boolean isPresent()
 			{
 				return true;
+			}
+
+			/*
+			 * The inherited equals() works here too; this and obj must be both
+			 * of class False or both of class True.
+			 */
+
+			@Override
+			public int hashCode()
+			{
+				return Boolean.hashCode(getAsBoolean());
 			}
 
 			@Override
@@ -1239,6 +1324,19 @@ public interface Checked<WT, EX extends Throwable>
 			}
 
 			@Override
+			public boolean equals(Object obj)
+			{
+				return obj instanceof Present
+					&& (m_value == ((Present)obj).m_value);
+			}
+
+			@Override
+			public int hashCode()
+			{
+				return Byte.hashCode(m_value);
+			}
+
+			@Override
 			public String toString()
 			{
 				return "OptionalByte[" + m_value + ']';
@@ -1355,6 +1453,19 @@ public interface Checked<WT, EX extends Throwable>
 			public boolean isPresent()
 			{
 				return true;
+			}
+
+			@Override
+			public boolean equals(Object obj)
+			{
+				return obj instanceof Present
+					&& (m_value == ((Present)obj).m_value);
+			}
+
+			@Override
+			public int hashCode()
+			{
+				return Short.hashCode(m_value);
 			}
 
 			@Override
@@ -1476,6 +1587,19 @@ public interface Checked<WT, EX extends Throwable>
 			}
 
 			@Override
+			public boolean equals(Object obj)
+			{
+				return obj instanceof Present
+					&& (m_value == ((Present)obj).m_value);
+			}
+
+			@Override
+			public int hashCode()
+			{
+				return Character.hashCode(m_value);
+			}
+
+			@Override
 			public String toString()
 			{
 				return "OptionalChar[" + (int)m_value + ']';
@@ -1591,6 +1715,19 @@ public interface Checked<WT, EX extends Throwable>
 			public boolean isPresent()
 			{
 				return true;
+			}
+
+			@Override
+			public boolean equals(Object obj)
+			{
+				return obj instanceof Present
+					&& (0 == Float.compare(m_value, ((Present)obj).m_value));
+			}
+
+			@Override
+			public int hashCode()
+			{
+				return Float.hashCode(m_value);
 			}
 
 			@Override

--- a/pljava/src/main/java/org/postgresql/pljava/internal/Checked.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/Checked.java
@@ -278,7 +278,7 @@ public interface Checked<WT, EX extends Throwable>
 	 * later, and the compiler will infer that it can throw whatever
 	 * {@code thing.release()} can throw:
 	 *<pre>
-	 *  try(var ac = closing(() -&gt; thing.release()))
+	 *  try(var ac = closing(() -&gt; { thing.release(); }))
 	 *  {
 	 *    ...
 	 *  }
@@ -289,7 +289,7 @@ public interface Checked<WT, EX extends Throwable>
 	 * interface:
 	 *<pre>
 	 *  try(Checked.AutoCloseable&lt;ThingException&gt; ac =
-	 *		closing(() -&gt; thing.release()))
+	 *		closing(() -&gt; { thing.release(); }))
 	 *  {
 	 *    ...
 	 *  }

--- a/pljava/src/main/java/org/postgresql/pljava/internal/Checked.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/Checked.java
@@ -108,63 +108,63 @@ public interface Checked<WT, EX extends Throwable>
 	}
 
 	default <RT, RX extends Throwable>
-	RT in(Function<? super WT, RT, RX> f)
+	RT inReturning(Function<? super WT, RT, RX> f)
 	throws EX, RX
 	{
 		return f.apply(ederWrap());
 	}
 
 	default <RX extends Throwable>
-	double in(ToDoubleFunction<? super WT, RX> f)
+	double inDoubleReturning(ToDoubleFunction<? super WT, RX> f)
 		throws EX, RX
 	{
 		return f.apply(ederWrap());
 	}
 
 	default <RX extends Throwable>
-	int in(ToIntFunction<? super WT, RX> f)
+	int inIntReturning(ToIntFunction<? super WT, RX> f)
 	throws EX, RX
 	{
 		return f.apply(ederWrap());
 	}
 
 	default <RX extends Throwable>
-	long in(ToLongFunction<? super WT, RX> f)
+	long inLongReturning(ToLongFunction<? super WT, RX> f)
 	throws EX, RX
 	{
 		return f.apply(ederWrap());
 	}
 
 	default <RX extends Throwable>
-	boolean in(Predicate<? super WT, RX> f)
+	boolean inBooleanReturning(Predicate<? super WT, RX> f)
 		throws EX, RX
 	{
 		return f.test(ederWrap());
 	}
 
 	default <RX extends Throwable>
-	byte in(ToByteFunction<? super WT, RX> f)
+	byte inByteReturning(ToByteFunction<? super WT, RX> f)
 		throws EX, RX
 	{
 		return f.apply(ederWrap());
 	}
 
 	default <RX extends Throwable>
-	short in(ToShortFunction<? super WT, RX> f)
+	short inShortReturning(ToShortFunction<? super WT, RX> f)
 	throws EX, RX
 	{
 		return f.apply(ederWrap());
 	}
 
 	default <RX extends Throwable>
-	char in(ToCharFunction<? super WT, RX> f)
+	char inCharReturning(ToCharFunction<? super WT, RX> f)
 	throws EX, RX
 	{
 		return f.apply(ederWrap());
 	}
 
 	default <RX extends Throwable>
-	float in(ToFloatFunction<? super WT, RX> f)
+	float inFloatReturning(ToFloatFunction<? super WT, RX> f)
 	throws EX, RX
 	{
 		return f.apply(ederWrap());
@@ -827,7 +827,7 @@ public interface Checked<WT, EX extends Throwable>
 	interface ToFloatFunction<T,E extends Throwable>
 	extends Closing.Trivial<ToFloatFunction<T,E>, E>
 	{
-		char apply(T t) throws E;
+		float apply(T t) throws E;
 
 		static <T, E extends Throwable>
 		ToFloatFunction<T,E> use(ToFloatFunction<T,E> o)

--- a/pljava/src/test/java/CheckedTest.java
+++ b/pljava/src/test/java/CheckedTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2020 Tada AB and other contributors, as listed below.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Chapman Flack
+ */
+package org.postgresql.pljava.internal;
+
+import java.util.OptionalDouble;
+import java.util.OptionalInt;
+import java.util.OptionalLong;
+
+import java.util.stream.Stream;
+import java.util.stream.DoubleStream;
+import java.util.stream.IntStream;
+import java.util.stream.LongStream;
+
+import static org.postgresql.pljava.internal.Checked.closing;
+import static org.postgresql.pljava.internal.Checked.OptionalBase.ofNullable;
+
+public class CheckedTest
+{
+	public void compilability()
+	{
+		try
+		{
+			Checked.Consumer
+			.use((String n) -> { Class.forName(n); })
+			.in(l -> { Stream.of("Foo").forEach(l); });
+		}
+		catch ( ClassNotFoundException e )
+		{
+		}
+
+		try
+		{
+			Checked.DoubleConsumer
+			.use(v -> {throw new IllegalAccessException();})
+			.in(l -> { DoubleStream.of(4.2).forEach(l); });
+
+			Checked.IntConsumer
+			.use(v -> {throw new IllegalAccessException();})
+			.in(l -> { IntStream.of(42).forEach(l); });
+
+			Checked.LongConsumer
+			.use(v -> {throw new IllegalAccessException();})
+			.in(l -> { LongStream.of(4).forEach(l); });
+
+			Checked.Runnable
+			.use(() -> {throw new IllegalAccessException();})
+			.in(r -> { Stream.of("").forEach(o -> {r.run();}); });
+		}
+		catch ( IllegalAccessException e )
+		{
+		}
+
+		Boolean zl =
+			Checked.Supplier
+			.use(() -> Boolean.TRUE)
+			.inReturning(s -> s.get());
+
+		boolean z =
+			Checked.BooleanSupplier
+			.use(() -> true)
+			.inBooleanReturning(zs -> zs.getAsBoolean());
+
+		double d =
+			Checked.DoubleSupplier
+			.use(() -> 4.2)
+			.inDoubleReturning(ds -> ds.getAsDouble());
+
+		int i =
+			Checked.IntSupplier
+			.use(() -> 4)
+			.inIntReturning(is -> is.getAsInt());
+
+		long j =
+			Checked.LongSupplier
+			.use(() -> 4)
+			.inLongReturning(ls -> ls.getAsLong());
+
+		byte b =
+			Checked.ByteSupplier
+			.use(() -> 4)
+			.inByteReturning(bs -> bs.getAsByte());
+
+		short s =
+			Checked.ShortSupplier
+			.use(() -> 4)
+			.inShortReturning(ss -> ss.getAsShort());
+
+		char c =
+			Checked.CharSupplier
+			.use(() -> 4)
+			.inCharReturning(cs -> cs.getAsChar());
+
+		float f =
+			Checked.FloatSupplier
+			.use(() -> 2.4f)
+			.inFloatReturning(fs -> fs.getAsFloat());
+
+		try (Checked.AutoCloseable<IllegalAccessException> ac = // Java 10: var
+			closing(() -> {throw new IllegalAccessException();}))
+		{
+		}
+		catch ( IllegalAccessException e )
+		{
+		}
+
+		OptionalDouble opd = ofNullable(4.2);
+		OptionalInt opi = ofNullable(4);
+		OptionalLong opj = ofNullable(4L);
+		Checked.OptionalBoolean opz = ofNullable(true);
+		Checked.OptionalByte opb = ofNullable((byte)2);
+		Checked.OptionalShort ops = ofNullable((short)2);
+		Checked.OptionalChar opc = ofNullable('2');
+		Checked.OptionalFloat opf = ofNullable(2f);
+	}
+}


### PR DESCRIPTION
`Checked` contains versions and analogues of Java API functional interfaces, allowing checked exceptions where the Java versions don't, to simplify use of checked-exception-heavy APIs (JDBC or JAXP, anyone?) with Java's newer functional and stream APIs.

Here the set of To*prim*Function interfaces is expanded to cover all the Java primitive types, and all of them can participate in the `use(...).in(...)` idiom. An `AutoCloseable` with parameterized exception type is provided, along with Python-inspired `closing(...)` methods. New `Optional`s now cover all the primitive types.