### PR TITLE
Add builds for linux-ppc64le to the Travis-CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,13 @@ env:
     MVN_VERSION: 3.6.3
 
 jobs:
+  exclude:
+    - arch: ppc64le
+      env:
+        POSTGRESQL_VERSION: 12
+        JAVA_VERSION: 9
+        JVM_IMPL: hotspot
+        MVN_VERSION: 3.6.3
   include:
     - os: osx
       osx_image: xcode11

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,98 @@
-language: java
+language: minimal
 os:
   - linux
-  - osx
+arch:
+  - amd64
+  - ppc64le
 dist: bionic
-osx_image: xcode11
-jdk:
-  - openjdk14
-  - openjdk13
-  - openjdk12
-  - openjdk11
-  - openjdk10
-  - openjdk9
 env:
-  - POSTGRESQL_VERSION=12
+  - POSTGRESQL_VERSION: 12
+    JAVA_VERSION: 14
+    JVM_IMPL: hotspot
+    MVN_VERSION: 3.5.2
+# - POSTGRESQL_VERSION: 12
+#   JAVA_VERSION: 14
+#   JVM_IMPL: openj9
+#   MVN_VERSION: 3.6.3
+  - POSTGRESQL_VERSION: 12
+    JAVA_VERSION: 11
+    JVM_IMPL: hotspot
+    MVN_VERSION: 3.6.3
+  - POSTGRESQL_VERSION: 12
+    JAVA_VERSION: 9
+    JVM_IMPL: hotspot
+    MVN_VERSION: 3.6.3
+  - POSTGRESQL_VERSION: 10
+    JAVA_VERSION: 14
+    JVM_IMPL: hotspot
+    MVN_VERSION: 3.6.3
+  - POSTGRESQL_VERSION: 9.5
+    JAVA_VERSION: 14
+    JVM_IMPL: hotspot
+    MVN_VERSION: 3.6.3
+
+jobs:
+  include:
+    - os: osx
+      osx_image: xcode11
+      arch: amd64
+      env:
+        - POSTGRESQL_VERSION: 11
+          JAVA_VERSION: 14
+          JVM_IMPL: hotspot
+          MVN_VERSION: 3.6.3
+    - os: osx
+      osx_image: xcode11
+      arch: amd64
+      env:
+        - POSTGRESQL_VERSION: 10
+          JAVA_VERSION: 14
+          JVM_IMPL: hotspot
+          MVN_VERSION: 3.6.3
+    - os: osx
+      osx_image: xcode11
+      arch: amd64
+      env:
+        - POSTGRESQL_VERSION: 9.5
+          JAVA_VERSION: 14
+          JVM_IMPL: hotspot
+          MVN_VERSION: 3.6.3
+
 cache:
   directories:
     - $HOME/.m2
-before_install:
-  - . .travis/travis_install_postgresql.sh
+
+before_install: |
+  javaUrl=https://api.adoptopenjdk.net/v3/binary/latest
+  javaUrl="$javaUrl/$JAVA_VERSION/ga/${TRAVIS_OS_NAME//osx/mac}"
+  javaUrl="$javaUrl/${TRAVIS_CPU_ARCH//amd64/x64}/jdk"
+  javaUrl="$javaUrl/$JVM_IMPL/normal/adoptopenjdk"
+
+  installJdk=$(which install-jdk.sh) || {
+    wget https://raw.githubusercontent.com/sormuras/bach/8c457fd6e46bd9f3f575867dd0c9af1d7edfd5b4/install-jdk.sh
+    installJdk=./install-jdk.sh
+
+    printf '%s\n%s\n%s\n%s\n%s\n' \
+      '--- install-jdk.sh' \
+      '+++ install-jdk.sh' \
+      '@@ -257 +257 @@' \
+      '-            target="${workspace}"/$(tar --list ${tar_options} | head -2 | tail -1 | cut -f 2 -d '"'/' -)/Contents/Home" \
+      '+            target="${workspace}"/$(tar --list ${tar_options} | sed -n '"'/\/bin\/javac/s///p')" \
+    | patch "$installJdk"
+  }
+
+  [[ $JAVA_VERSION == 9 ]] && certs=--cacerts || unset certs
+
+  . "$installJdk" --url "$javaUrl" ${certs+"$certs"}
+
+  mvnUrl=https://archive.apache.org/dist/maven/maven-3
+  mvnUrl="$mvnUrl/$MVN_VERSION/binaries/apache-maven-$MVN_VERSION-bin.tar.gz"
+
+  wget --no-verbose "$mvnUrl" && tar xzf "apache-maven-$MVN_VERSION-bin.tar.gz"
+  mvn="./apache-maven-$MVN_VERSION/bin/mvn"
+  "$mvn" --version
+
+  . .travis/travis_install_postgresql.sh
 
 install: |
   $pgConfig
@@ -29,7 +104,7 @@ install: |
   fi
   libjvm=$(find "$JAVA_HOME" -mindepth 2 -name $libjvm_name | head -n 1)
 
-  mvn clean install --batch-mode \
+  "$mvn" clean install --batch-mode \
    -Dpgsql.pgconfig="$pgConfig" \
    -Dpljava.libjvmdefault="$libjvm" \
    -Psaxon-examples -Ppgjdbc-ng \
@@ -55,9 +130,9 @@ script: |
     tail -n 1
   )
 
-  sudo java -Dpgconfig="$pgConfig" -jar "$packageJar"
+  sudo "$JAVA_HOME"/bin/java -Dpgconfig="$pgConfig" -jar "$packageJar"
 
-  jshell \
+  "$JAVA_HOME"/bin/jshell \
     -execution local \
     "-J--class-path=$packageJar:$jdbcJar" \
     "--class-path=$packageJar" \
@@ -65,7 +140,7 @@ script: |
     "-J-Dpgconfig=$pgConfig" \
     "-J-Dcom.impossibl.shadow.io.netty.noUnsafe=true" \
     "-J-DmavenRepo=$mavenRepo" \
-    "-J-DsaxonVer=$saxonVer" - <<\ENDJSHELL
+    "-J-DsaxonVer=$saxonVer" - <<\ENDJSHELL && # continues after here document
 
   boolean succeeding = false; // begin pessimistic
 
@@ -179,27 +254,4 @@ script: |
   succeeding &= (0 == results.get("ng"));
   System.exit(succeeding ? 0 : 1)
   ENDJSHELL
-
-jobs:
-  include:
-    - os: linux
-      jdk: openjdk14
-      env: POSTGRESQL_VERSION=11
-    - os: linux
-      jdk: openjdk14
-      env: POSTGRESQL_VERSION=10
-    - os: linux
-      jdk: openjdk14
-      env: POSTGRESQL_VERSION=9.5
-    - os: osx
-      jdk: openjdk14
-      env: POSTGRESQL_VERSION=11
-    - os: osx
-      jdk: openjdk14
-      env: POSTGRESQL_VERSION=10
-    - os: osx
-      jdk: openjdk14
-      env: POSTGRESQL_VERSION=9.5
-    - os: linux
-      jdk: openjdk14
-      env: POSTGRESQL_VERSION=SOURCE
+  : travis wants something after the end of the here document

--- a/.travis/travis_install_postgresql.sh
+++ b/.travis/travis_install_postgresql.sh
@@ -13,8 +13,7 @@ if [ "$TRAVIS_OS_NAME" = "osx" ]; then
 
     pgConfig="/usr/local/opt/postgresql${POSTGRESQL_VERSION}/bin/pg_config"
 else
-    sudo chmod 777 /home/travis
-    sudo service postgresql stop
+    sudo sh -c 'service postgresql stop || true'
     sudo apt-get -qq remove postgresql libpq-dev libpq5 postgresql-client-common postgresql-common --purge
     if [ "$POSTGRESQL_VERSION" = "SOURCE" ]; then
         sudo apt-get -qq install build-essential libreadline-dev zlib1g-dev flex bison libxml2-dev libxslt-dev libssl-dev libxml2-utils xsltproc


### PR DESCRIPTION
The `language: java` runner environment isn't able to install the same selection of JDKs on ppc64le as on amd64, so switch instead to the `language: minimal` runner, and explicitly get Java from adoptopenjdk.

That can be done with the `install-jdk.sh` script, which already exists in `/usr/local/bin` on and amd64 linux runner ... but not on ppc64le (or osx, for that matter). So, get that script from GitHub (at a specific SHA after reviewing it) when it isn't already installed. (It might be just as well to download it unconditionally, and never wonder what version the runner has.)

The `install-jdk.sh` script needs a patch to compute the right `JAVA_HOME` value on osx.

In constructing the URL for downloading from adoptopenjdk, the Travis arch value 'amd64' must be 'x64', and the Travis OS 'osx' must be 'mac'.

Naturally, the minimal runner doesn't have Maven preinstalled either. It's not a bad thing to have to fetch Maven; it is good to confirm the build works back to 3.5.2, as the documentation claims.

The minimal runner doesn't have PostgreSQL installed, which doesn't change much, except `travis_install_postgresql.sh` needs to be undeterred if 'service postgresql stop' fails. (I don't know what that chmod was doing there; builds seem to work without it.)

For Java 9, the `--cacerts` option has to be given to the `install-jdk.sh` script, or Maven won't be able to download dependencies because it won't be able to verify connections to repository hosts. On ppc64le even that doesn't help, so exclude that configuration there.

Use the matrix now to generate linux builds for amd64 and ppc64le with various PostgreSQL versions, Java feature versions, JVM implementations (hotspot, openj9) and Maven versions. There isn't support for osx-ppc64le, so remove osx from the matrix, and just use include: to add some osx builds manually.

The `env` section in the matrix is also kind of manually populated for a plausible subset of possible builds. The full Cartesian product of {arch}x{pg version}x{java version}x{hotspot,openj9}x{maven version} would be a test of Travis's generosity.

It is good to have added OpenJ9 into the matrix, and discovered a segfault. So comment that back out of the matrix for now.