### PR TITLE
Fix one JNI method-type mismatch

### DIFF
--- a/pljava-so/src/main/c/Function.c
+++ b/pljava-so/src/main/c/Function.c
@@ -371,7 +371,7 @@ jdouble pljava_Function_doubleInvoke(Function self)
 
 void pljava_Function_udtWriteInvoke(jobject value, jobject stream)
 {
-	JNI_callStaticObjectMethod(s_EntryPoints_class,
+	JNI_callStaticVoidMethod(s_EntryPoints_class,
 		s_EntryPoints_udtWriteInvoke, value, stream);
 }
 


### PR DESCRIPTION
... introduced in cdea77f, using `CallStaticObjectMethod` on a method that returns `void`. Hotspot's `-Xcheck:jni` never complained, but OpenJ9's catches it, and unless given as `-Xcheck:jni:nonfatal`, OpenJ9's will abort the process, reported as a `SIGSEGV`, making it perhaps more alarming than it needed to be.

As in Hotspot, OpenJ9's `-Xcheck:jni` messages are delivered through the `my_vfprintf` hook in `Backend.c`, and the problem is most easily found by setting a breakpoint there, then following a stack trace back to the offending call. The location reported _in_ the message is less useful, as it may just be the most recent native method call on the stack, which could be several calls above where the trouble is.