### PR TITLE
PG13 drops CREATE EXTENSION ... FROM unpackaged

### DIFF
--- a/pljava-packaging/build.xml
+++ b/pljava-packaging/build.xml
@@ -273,7 +273,7 @@ jos.close();
 			<utf8 dir="target/classes" includes="pljava.sql"
 				fullpath="pljava/sharedir/pljava/pljava--${project.version}.sql"
 			/>
-			<utf8 dir="target/classes" includes="pljava--unpackaged.sql"
+			<utf8 dir="target/classes" includes="pljava--unpackaged--.sql"
 				fullpath=
 			"pljava/sharedir/pljava/pljava--unpackaged--${project.version}.sql"
 			/>
@@ -331,7 +331,7 @@ jos.close();
 			/>
 			<utf8 dir="target/classes" prefix="pljava/sharedir/pljava/"
 				includes="*.sql"
-				excludes="pljava.sql pljava--.sql pljava--unpackaged.sql"/>			
+				excludes="pljava.sql pljava--.sql pljava--unpackaged--.sql"/>			
 <!-- If editing the script below, expand tabs to spaces (at 4 columns, and only
 	 for the lines of the script) before saving. Line-wrapped into the manifest,
 	 it looks horrible with tabs.

--- a/pljava-packaging/src/main/resources/pljava--unpackaged--.sql
+++ b/pljava-packaging/src/main/resources/pljava--unpackaged--.sql
@@ -1,0 +1,80 @@
+\echo Use "CREATE EXTENSION pljava FROM UNPACKAGED" to load this file. \quit
+
+/*
+ This script can "update" from any unpackaged PL/Java version supported by
+ the automigration code within PL/Java itself. The schema migration is first
+ touched off by the LOAD command, and then the ALTER EXTENSION commands gather
+ up the member objects according to the current schema version.
+ */
+
+DROP TABLE IF EXISTS
+@extschema@."see doc: do CREATE EXTENSION PLJAVA in new session";
+CREATE TABLE
+@extschema@."see doc: do CREATE EXTENSION PLJAVA in new session"
+(path, exnihilo) AS
+SELECT CAST('${module.pathname}' AS text), false;
+LOAD '${module.pathname}';
+
+/*
+ Why the CREATE / DROP?  When faced with a LOAD command, PostgreSQL only does it
+ if the library has not been loaded already in the session (as could have
+ happened if, for example, a PL/Java function has already been called). If the
+ LOAD was skipped, there could still be an old-layout schema, because the
+ migration only happens in an actual LOAD.  To avoid confusion later, it's
+ helpful to fail fast in that case. The loadpath table should have been dropped
+ by the LOAD actions, so the re-CREATE/DROP here will incur a (cryptic, but
+ dependable) error if those actions didn't happen. The error message will
+ include the table name, which is why the table name is phrased as an error
+ message.
+ 
+ The solution to a problem detected here is simply to exit the
+ session and repeat the CREATE EXTENSION in a new session where PL/Java has not
+ been loaded yet.
+ */
+CREATE TABLE
+@extschema@."see doc: do CREATE EXTENSION PLJAVA in new session"();
+DROP TABLE
+@extschema@."see doc: do CREATE EXTENSION PLJAVA in new session";
+
+/*
+ The language-hander functions do not need to be explicitly added, because the
+ LOAD actions always CREATE OR REPLACE them, which makes them extension members.
+ */
+
+ALTER EXTENSION pljava ADD LANGUAGE java;
+ALTER EXTENSION pljava ADD LANGUAGE javau;
+
+ALTER EXTENSION pljava ADD
+ FUNCTION sqlj.add_type_mapping(character varying,character varying);
+ALTER EXTENSION pljava ADD
+ FUNCTION sqlj.drop_type_mapping(character varying);
+ALTER EXTENSION pljava ADD
+ FUNCTION sqlj.get_classpath(character varying);
+ALTER EXTENSION pljava ADD
+ FUNCTION sqlj.install_jar(bytea,character varying,boolean);
+ALTER EXTENSION pljava ADD
+ FUNCTION sqlj.install_jar(character varying,character varying,boolean);
+ALTER EXTENSION pljava ADD
+ FUNCTION sqlj.remove_jar(character varying,boolean);
+ALTER EXTENSION pljava ADD
+ FUNCTION sqlj.replace_jar(bytea,character varying,boolean);
+ALTER EXTENSION pljava ADD
+ FUNCTION sqlj.replace_jar(character varying,character varying,boolean);
+ALTER EXTENSION pljava ADD
+ FUNCTION sqlj.set_classpath(character varying,character varying);
+
+ALTER EXTENSION pljava ADD TABLE sqlj.classpath_entry;
+ALTER EXTENSION pljava ADD TABLE sqlj.jar_descriptor;
+ALTER EXTENSION pljava ADD TABLE sqlj.jar_entry;
+ALTER EXTENSION pljava ADD TABLE sqlj.jar_repository;
+ALTER EXTENSION pljava ADD TABLE sqlj.typemap_entry;
+
+ALTER EXTENSION pljava ADD SEQUENCE sqlj.jar_entry_entryid_seq;
+ALTER EXTENSION pljava ADD SEQUENCE sqlj.jar_repository_jarid_seq;
+ALTER EXTENSION pljava ADD SEQUENCE sqlj.typemap_entry_mapid_seq;
+
+SELECT pg_catalog.pg_extension_config_dump('@extschema@.jar_repository', '');
+SELECT pg_catalog.pg_extension_config_dump('@extschema@.jar_entry', '');
+SELECT pg_catalog.pg_extension_config_dump('@extschema@.jar_descriptor', '');
+SELECT pg_catalog.pg_extension_config_dump('@extschema@.classpath_entry', '');
+SELECT pg_catalog.pg_extension_config_dump('@extschema@.typemap_entry', '');

--- a/pljava-packaging/src/main/resources/pljava--unpackaged.sql
+++ b/pljava-packaging/src/main/resources/pljava--unpackaged.sql
@@ -1,80 +1,25 @@
-\echo Use "CREATE EXTENSION pljava FROM UNPACKAGED" to load this file. \quit
+\echo 'Use "CREATE EXTENSION pljava VERSION unpackaged" to load this file.'
+\echo 'Then start a new connection (use \\c in psql) and'
+\echo 'use "ALTER EXTENSION pljava UPDATE" to complete packaging.' \quit
 
 /*
- This script can "update" from any unpackaged PL/Java version supported by
- the automigration code within PL/Java itself. The schema migration is first
- touched off by the LOAD command, and then the ALTER EXTENSION commands gather
- up the member objects according to the current schema version.
+ * PostgreSQL 13 drops support for CREATE EXTENSION ... FROM unpackaged;
+ * on the rationale that any sensible site has already updated old unpackaged
+ * extensions to their extension versions. For PL/Java, though, there is still
+ * a realistic scenario where it ends up installed as 'unpackaged': if a
+ * CREATE EXTENSION failed because a setting needed adjustment, the admin
+ * supplied the right setting, and the installation then succeeded. That leaves
+ * PL/Java installed, but not as a packaged extension. The old CREATE EXTENSION
+ * ... FROM unpackaged; syntax was the perfect recovery method for that. It will
+ * still work in versions < 13.
+ *
+ * For PostgreSQL 13, recovery now requires two steps instead. The first step
+ * is CREATE EXTENSION pljava VERSION unpackaged; which will use this script to
+ * simply confirm the unpackaged installation has already happened, and
+ * otherwise do absolutely nothing. The second step (which must happen in a new
+ * session) is ALTER EXTENSION pljava UPDATE; which will package it as the
+ * latest extension version, even running the exact script that CREATE EXTENSION
+ * ... FROM unpackaged; would have run to do it.
  */
 
-DROP TABLE IF EXISTS
-@extschema@."see doc: do CREATE EXTENSION PLJAVA in new session";
-CREATE TABLE
-@extschema@."see doc: do CREATE EXTENSION PLJAVA in new session"
-(path, exnihilo) AS
-SELECT CAST('${module.pathname}' AS text), false;
-LOAD '${module.pathname}';
-
-/*
- Why the CREATE / DROP?  When faced with a LOAD command, PostgreSQL only does it
- if the library has not been loaded already in the session (as could have
- happened if, for example, a PL/Java function has already been called). If the
- LOAD was skipped, there could still be an old-layout schema, because the
- migration only happens in an actual LOAD.  To avoid confusion later, it's
- helpful to fail fast in that case. The loadpath table should have been dropped
- by the LOAD actions, so the re-CREATE/DROP here will incur a (cryptic, but
- dependable) error if those actions didn't happen. The error message will
- include the table name, which is why the table name is phrased as an error
- message.
- 
- The solution to a problem detected here is simply to exit the
- session and repeat the CREATE EXTENSION in a new session where PL/Java has not
- been loaded yet.
- */
-CREATE TABLE
-@extschema@."see doc: do CREATE EXTENSION PLJAVA in new session"();
-DROP TABLE
-@extschema@."see doc: do CREATE EXTENSION PLJAVA in new session";
-
-/*
- The language-hander functions do not need to be explicitly added, because the
- LOAD actions always CREATE OR REPLACE them, which makes them extension members.
- */
-
-ALTER EXTENSION pljava ADD LANGUAGE java;
-ALTER EXTENSION pljava ADD LANGUAGE javau;
-
-ALTER EXTENSION pljava ADD
- FUNCTION sqlj.add_type_mapping(character varying,character varying);
-ALTER EXTENSION pljava ADD
- FUNCTION sqlj.drop_type_mapping(character varying);
-ALTER EXTENSION pljava ADD
- FUNCTION sqlj.get_classpath(character varying);
-ALTER EXTENSION pljava ADD
- FUNCTION sqlj.install_jar(bytea,character varying,boolean);
-ALTER EXTENSION pljava ADD
- FUNCTION sqlj.install_jar(character varying,character varying,boolean);
-ALTER EXTENSION pljava ADD
- FUNCTION sqlj.remove_jar(character varying,boolean);
-ALTER EXTENSION pljava ADD
- FUNCTION sqlj.replace_jar(bytea,character varying,boolean);
-ALTER EXTENSION pljava ADD
- FUNCTION sqlj.replace_jar(character varying,character varying,boolean);
-ALTER EXTENSION pljava ADD
- FUNCTION sqlj.set_classpath(character varying,character varying);
-
-ALTER EXTENSION pljava ADD TABLE sqlj.classpath_entry;
-ALTER EXTENSION pljava ADD TABLE sqlj.jar_descriptor;
-ALTER EXTENSION pljava ADD TABLE sqlj.jar_entry;
-ALTER EXTENSION pljava ADD TABLE sqlj.jar_repository;
-ALTER EXTENSION pljava ADD TABLE sqlj.typemap_entry;
-
-ALTER EXTENSION pljava ADD SEQUENCE sqlj.jar_entry_entryid_seq;
-ALTER EXTENSION pljava ADD SEQUENCE sqlj.jar_repository_jarid_seq;
-ALTER EXTENSION pljava ADD SEQUENCE sqlj.typemap_entry_mapid_seq;
-
-SELECT pg_catalog.pg_extension_config_dump('@extschema@.jar_repository', '');
-SELECT pg_catalog.pg_extension_config_dump('@extschema@.jar_entry', '');
-SELECT pg_catalog.pg_extension_config_dump('@extschema@.jar_descriptor', '');
-SELECT pg_catalog.pg_extension_config_dump('@extschema@.classpath_entry', '');
-SELECT pg_catalog.pg_extension_config_dump('@extschema@.typemap_entry', '');
+SELECT sqlj.get_classpath('public'); -- just fail unless already installed

--- a/pljava-so/src/main/c/Backend.c
+++ b/pljava-so/src/main/c/Backend.c
@@ -717,7 +717,14 @@ static void initsequencer(enum initstage is, bool tolerant)
 					"the working settings are saved, exit this session, and "
 					"in a new session, either: "
 					"1. if committed, run "
-					"\"CREATE EXTENSION pljava FROM unpackaged\", or 2. "
+#if PG_VERSION_NUM < 130000
+					"\"CREATE EXTENSION pljava FROM unpackaged\""
+#else
+					"\"CREATE EXTENSION pljava VERSION unpackaged\", "
+					"then (after starting another new session) "
+					"\"ALTER EXTENSION pljava UPDATE\""
+#endif
+					", or 2. "
 					"if rolled back, simply \"CREATE EXTENSION pljava\" again."
 					)));
 			}


### PR DESCRIPTION
PostgreSQL 13 drops support for `CREATE EXTENSION ... FROM unpackaged`, on the rationale that any sensible site has already updated old unpackaged extensions to their extension versions. For PL/Java, though, there is still a realistic scenario where it ends up installed as 'unpackaged': if a `CREATE EXTENSION` failed because a setting needed adjustment, the admin supplied the right setting, and the installation then succeeded. That leaves PL/Java installed, but not as a packaged extension. The old `CREATE EXTENSION ... FROM unpackaged` syntax was the perfect recovery method for that. It will still work in PG versions < 13.

For PostgreSQL 13, recovery now requires two steps instead. The first step is `CREATE EXTENSION pljava VERSION unpackaged`, which will simply confirm the unpackaged installation has already happened, and otherwise do absolutely nothing. The second step (which must happen in a new session) is `ALTER EXTENSION pljava UPDATE` which will package it as the latest extension version, even running the exact script that `CREATE EXTENSION ... FROM unpackaged` would have run to do it.