### PR TITLE
Add checks for so.debug and so.optimize in pljava-so build process

### DIFF
--- a/pljava-pgxs/src/main/java/org/postgresql/pljava/pgxs/ScriptingMojo.java
+++ b/pljava-pgxs/src/main/java/org/postgresql/pljava/pgxs/ScriptingMojo.java
@@ -12,6 +12,7 @@
  */
 package org.postgresql.pljava.pgxs;
 
+import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.AbstractMojoExecutionException;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -44,6 +45,10 @@ public class ScriptingMojo extends AbstractMojo
 	@Parameter(defaultValue = "${project}", readonly = true)
 	private MavenProject project;
 
+	@Parameter(defaultValue = "${session}", readonly = true)
+	private MavenSession session;
+
+
 	@Parameter
 	private PlexusConfiguration script;
 
@@ -63,6 +68,8 @@ public class ScriptingMojo extends AbstractMojo
 			ScriptEngine engine = utils.getScriptEngine(script);
 			getLog().debug(scriptText);
 
+			engine.getContext().setAttribute("session", session,
+				ScriptContext.GLOBAL_SCOPE);
 			engine.getContext().setAttribute("plugin", this,
 				ScriptContext.GLOBAL_SCOPE);
 			engine.put("quoteStringForC",

--- a/pljava-so/pom.xml
+++ b/pljava-so/pom.xml
@@ -33,6 +33,8 @@
 	var Paths = Java.type("java.nio.file.Paths");
 	var of = java.util.List.of;
 
+	var isDebugEnabled =  java.lang.Boolean.valueOf(session.userProperties.getProperty("so.debug"));
+
 	var base_dir_path = project.basedir.getAbsolutePath();
 	var source_path = Paths.get(base_dir_path, "src", "main", "c");
 	var target_path = Paths.get(project.build.directory, "pljava-pgxs");
@@ -88,7 +90,8 @@
 				includes.add(java_include.resolve("linux").toString());
 				defines.put("Linux", null);
 				flags.add("-c");
-
+				if(isDebugEnabled)
+					flags.add("-g");
 				var compileProcess = utils.processBuilder(function(l) {
 					l.add(cc);
 					l.addAll(pgxs.formatDefines(defines));
@@ -101,6 +104,8 @@
 			},
 
 			link : function(cc, flags, files, target_path) {
+				if(isDebugEnabled)
+					flags.add("-g");
 				flags.add("-shared-libgcc");
 				var linkingProcess = utils.processBuilder(function(l) {
 					l.add(cc);
@@ -126,7 +131,8 @@
 				includes.add(java_include.resolve("darwin").toString());
 				defines.put("Darwin", null);
 				flags.add("-c");
-
+				if(isDebugEnabled)
+					flags.add("-g");
 				var compileProcess = utils.processBuilder(function(l) {
 					l.add(cc);
 					l.addAll(pgxs.formatDefines(defines));
@@ -140,6 +146,8 @@
 
 			link : function(cc, flags, files, target_path) {
 				flags.addAll(of("-bundle_loader", Paths.get(bindir, "postgres").toString()));
+				if(isDebugEnabled)
+					flags.add("-g");
 				var linkingProcess = utils.processBuilder(function(l) {
 					l.add(cc);
 					l.addAll(flags);
@@ -169,7 +177,8 @@
 					Paths.get("fallback", "win32")).toString());
 				defines.put("Windows", null);
 				flags.add("-c");
-
+				if(isDebugEnabled)
+					flags.add("-g");
 				/*
 				 * -DBUILDING_DLL appears in the flags reported by pg_config
 				 * because it was used when building PostgreSQL itself; it
@@ -192,6 +201,8 @@
 
 			link : function(cc, flags, files, target_path) {
 				flags.addAll(of("-Wl,--export-all-symbols","-shared-libgcc"));
+				if(isDebugEnabled)
+					flags.add("-g");
 				var linkingProcess = utils.processBuilder(function(l) {
 					l.add(cc);
 					l.addAll(flags);
@@ -244,7 +255,11 @@
 
 				var compileProcess = utils.processBuilder(function(l) {
 					l.add("cl");
-					l.addAll(of("/c", "/nologo", "/MD"));
+					l.addAll(of("/c", "/nologo"));
+					if(isDebugEnabled)
+						l.addAll(of("/Zi", "/Od", "/RTC1", "/D_DEBUG", "/MDd"));
+					else
+						l.add("/MD");
 					l.addAll(pgxs.formatDefines(defines));
 					l.addAll(pgxs.formatIncludes(includes));
 					l.addAll(files);
@@ -260,7 +275,8 @@
 					l.add("link");
 					l.addAll(of("/MANIFEST", "/NOLOGO", "/DLL", "/SUBSYSTEM:CONSOLE", "/INCREMENTAL:NO"));
 					l.add("/OUT:" + library_name + ".dll");
-
+					if(isDebugEnabled)
+						l.add("/DEBUG");
 					// From compiler-msvc profile
 					l.add(Paths.get(pkglibdir, "postgres.lib").toString());
 					l.addAll(files);

--- a/pljava-so/pom.xml
+++ b/pljava-so/pom.xml
@@ -34,6 +34,8 @@
 	var of = java.util.List.of;
 
 	var isDebugEnabled =  java.lang.Boolean.valueOf(session.userProperties.getProperty("so.debug"));
+	if (!session.userProperties.getProperty("so.optimize", "none").equalsIgnoreCase("none"))
+		warn("Property so.optimize is currently not supported and will be ignored.");
 
 	var base_dir_path = project.basedir.getAbsolutePath();
 	var source_path = Paths.get(base_dir_path, "src", "main", "c");

--- a/src/site/markdown/build/debugopt.md
+++ b/src/site/markdown/build/debugopt.md
@@ -26,6 +26,10 @@ and built with `--enable-debug`.
 
 ## Compiler optimization in the native portion of PL/Java
 
+PL/Java used to support a `-Dso.optimize` option earlier. However, it is not
+yet implemented in the current build system. Following is the description
+of how the option worked when it was supported.
+
 `-Dso.optimize=` can be given on the `mvn` command line, with a value
 chosen from `none`, `size`, `speed`, `minimal`, `full`, `aggressive`,
 `extreme`, or `unsafe`. Depending on the compiler, these settings may


### PR DESCRIPTION
`so.debug` is supported now and can be used just as with the earlier nar maven build process. `so.optimize` is currently not supported and a warning is displayed if the option is used.