### PR TITLE
Fix some bugs (but not lack of multi-dimension support) in array handling

### DIFF
--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/jdk7/TypeRoundTripper.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/jdk7/TypeRoundTripper.java
@@ -135,6 +135,146 @@ import org.postgresql.pljava.example.annotation.ConditionalDDR; // for javadoc
 	" FROM" +
 	"  (VALUES (point '0,0')) AS p," +
 	"  roundtrip(p) AS (classjdbc text)",
+
+	" SELECT" +
+	"  CASE WHEN every(outcome.ok)" +
+	"  THEN javatest.logmessage('INFO',    'boolean[] passes')" +
+	"  ELSE javatest.logmessage('WARNING', 'boolean[] fails')" +
+	"  END" +
+	" FROM" +
+	"  (SELECT '{t,null,f}'::boolean[]) AS p(orig)," +
+	"  (VALUES (''), ('[Ljava.lang.Boolean;'), ('[Z')) as q(rqcls)," +
+	"  roundtrip(p, rqcls) AS (class text, roundtripped boolean[])," +
+	"  LATERAL (SELECT" +
+	"   (rqcls = class OR rqcls = '')" +
+	"   AND roundtripped =" +
+	"   CASE WHEN class LIKE '[_' THEN array_replace(orig, null, false)" +
+	"   ELSE orig END" +
+	"  ) AS outcome(ok)",
+
+	" SELECT" +
+	"  CASE WHEN every(outcome.ok)" +
+	"  THEN javatest.logmessage('INFO',    '\"char\"[] passes')" +
+	"  ELSE javatest.logmessage('WARNING', '\"char\"[] fails')" +
+	"  END" +
+	" FROM" +
+	"  (SELECT '{A,null,B}'::\"char\"[]) AS p(orig)," +
+	"  (VALUES (''), ('[Ljava.lang.Byte;'), ('[B')) as q(rqcls)," +
+	"  roundtrip(p, rqcls) AS (class text, roundtripped \"char\"[])," +
+	"  LATERAL (SELECT" +
+	"   (rqcls = class OR rqcls = '')" +
+	"   AND roundtripped =" +
+	"   CASE WHEN class LIKE '[_' THEN array_replace(orig, null, 0::\"char\")" +
+	"   ELSE orig END" +
+	"  ) AS outcome(ok)",
+
+	" SELECT" +
+	"  CASE WHEN every(outcome.ok)" +
+	"  THEN javatest.logmessage('INFO',    'bytea passes')" +
+	"  ELSE javatest.logmessage('WARNING', 'bytea fails')" +
+	"  END" +
+	" FROM" +
+	"  (SELECT '\\x010203'::bytea) AS p(orig)," +
+	"  (VALUES (''), ('[B')) as q(rqcls)," +
+	"  roundtrip(p, rqcls) AS (class text, roundtripped bytea)," +
+	"  LATERAL (SELECT" +
+	"   (rqcls = class OR rqcls = '')" +
+	"   AND roundtripped = orig" +
+	"  ) AS outcome(ok)",
+
+	" SELECT" +
+	"  CASE WHEN every(outcome.ok)" +
+	"  THEN javatest.logmessage('INFO',    'int2[] passes')" +
+	"  ELSE javatest.logmessage('WARNING', 'int2[] fails')" +
+	"  END" +
+	" FROM" +
+	"  (SELECT '{1,null,3}'::int2[]) AS p(orig)," +
+	"  (VALUES (''), ('[Ljava.lang.Short;'), ('[S')) as q(rqcls)," +
+	"  roundtrip(p, rqcls) AS (class text, roundtripped int2[])," +
+	"  LATERAL (SELECT" +
+	"   (rqcls = class OR rqcls = '')" +
+	"   AND roundtripped =" +
+	"   CASE WHEN class LIKE '[_' THEN array_replace(orig, null, 0::int2)" +
+	"   ELSE orig END" +
+	"  ) AS outcome(ok)",
+
+	" SELECT" +
+	"  CASE WHEN every(outcome.ok)" +
+	"  THEN javatest.logmessage('INFO',    'int4[] passes')" +
+	"  ELSE javatest.logmessage('WARNING', 'int4[] fails')" +
+	"  END" +
+	" FROM" +
+	"  (SELECT '{1,null,3}'::int4[]) AS p(orig)," +
+	"  (VALUES (''), ('[Ljava.lang.Integer;'), ('[I')) as q(rqcls)," +
+	"  roundtrip(p, rqcls) AS (class text, roundtripped int4[])," +
+	"  LATERAL (SELECT" +
+	"   (rqcls = class OR rqcls = '')" +
+	"   AND roundtripped =" +
+	"   CASE WHEN class LIKE '[_' THEN array_replace(orig, null, 0::int4)" +
+	"   ELSE orig END" +
+	"  ) AS outcome(ok)",
+
+	" SELECT" +
+	"  CASE WHEN every(outcome.ok)" +
+	"  THEN javatest.logmessage('INFO',    'int8[] passes')" +
+	"  ELSE javatest.logmessage('WARNING', 'int8[] fails')" +
+	"  END" +
+	" FROM" +
+	"  (SELECT '{1,null,3}'::int8[]) AS p(orig)," +
+	"  (VALUES (''), ('[Ljava.lang.Long;'), ('[J')) as q(rqcls)," +
+	"  roundtrip(p, rqcls) AS (class text, roundtripped int8[])," +
+	"  LATERAL (SELECT" +
+	"   (rqcls = class OR rqcls = '')" +
+	"   AND roundtripped =" +
+	"   CASE WHEN class LIKE '[_' THEN array_replace(orig, null, 0::int8)" +
+	"   ELSE orig END" +
+	"  ) AS outcome(ok)",
+
+	" SELECT" +
+	"  CASE WHEN every(outcome.ok)" +
+	"  THEN javatest.logmessage('INFO',    'float4[] passes')" +
+	"  ELSE javatest.logmessage('WARNING', 'float4[] fails')" +
+	"  END" +
+	" FROM" +
+	"  (SELECT '{1,null,3}'::float4[]) AS p(orig)," +
+	"  (VALUES (''), ('[Ljava.lang.Float;'), ('[F')) as q(rqcls)," +
+	"  roundtrip(p, rqcls) AS (class text, roundtripped float4[])," +
+	"  LATERAL (SELECT" +
+	"   (rqcls = class OR rqcls = '')" +
+	"   AND roundtripped =" +
+	"   CASE WHEN class LIKE '[_' THEN array_replace(orig, null, 0::float4)" +
+	"   ELSE orig END" +
+	"  ) AS outcome(ok)",
+
+	" SELECT" +
+	"  CASE WHEN every(outcome.ok)" +
+	"  THEN javatest.logmessage('INFO',    'float8[] passes')" +
+	"  ELSE javatest.logmessage('WARNING', 'float8[] fails')" +
+	"  END" +
+	" FROM" +
+	"  (SELECT '{1,null,3}'::float8[]) AS p(orig)," +
+	"  (VALUES (''), ('[Ljava.lang.Double;'), ('[D')) as q(rqcls)," +
+	"  roundtrip(p, rqcls) AS (class text, roundtripped float8[])," +
+	"  LATERAL (SELECT" +
+	"   (rqcls = class OR rqcls = '')" +
+	"   AND roundtripped =" +
+	"   CASE WHEN class LIKE '[_' THEN array_replace(orig, null, 0::float8)" +
+	"   ELSE orig END" +
+	"  ) AS outcome(ok)",
+
+	" SELECT" +
+	"  CASE WHEN every(outcome.ok)" +
+	"  THEN javatest.logmessage('INFO',    'text[] passes')" +
+	"  ELSE javatest.logmessage('WARNING', 'text[] fails')" +
+	"  END" +
+	" FROM" +
+	"  (SELECT '{foo,null,bar}'::text[]) AS p(orig)," +
+	"  (VALUES (''), ('[Ljava.lang.String;')) as q(rqcls)," +
+	"  roundtrip(p, rqcls) AS (class text, roundtripped text[])," +
+	"  LATERAL (SELECT" +
+	"   (rqcls = class OR rqcls = '')" +
+	"   AND roundtripped = orig" +
+	"  ) AS outcome(ok)",
 	}
 )
 public class TypeRoundTripper

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/jdk7/TypeRoundTripper.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/jdk7/TypeRoundTripper.java
@@ -435,21 +435,25 @@ public class TypeRoundTripper
 		 * convenient. If *not* an array, it's the same as the canonical name,
 		 * with the primitive names spelled out. If it *is* an array, the
 		 * primitives get their one-letter codes, and other class names have L
-		 * prefix and ; suffix. Check the arrayness here to normalize the form
-		 * so that, after this check, any primitive will be represented by its
-		 * one-letter code, and any other type will have an L in front (but
-		 * no ; at the end).
+		 * prefix and ; suffix. Condense the two cases here into one offbeat
+		 * hybrid form that will be used below.
 		 */
 		if ( 0 == ndims )
 			noBrackets =
 				("L" + noBrackets +
 				":booleanZ:byteB:shortS:charC:intI:longJ:floatF:doubleD")
 				.replaceFirst(
-					"^L(boolean|byte|short|char|int|long|float|double)(?=:)" +
-					"(?:\\w*+:)*\\1(\\w)(?::.*+)?+$|:.++$",
+					"^L(\\w++)(?=:)(?:\\w*+:)*\\1(\\w)(?::.*+)?+$|:.++$",
 					"$2");
 		else
 			noBrackets = noBrackets.replaceFirst(";$", "");
+
+		/*
+		 * Invariant: thanks to the above normalization, whether array or not,
+		 * noBrackets will now have this form: either the first (and only)
+		 * character is one of the primitive character codes, or the first
+		 * character is L and the rest is a class name (with no ; at the end).
+		 */
 
 		Class<?> c;
 
@@ -466,7 +470,8 @@ public class TypeRoundTripper
 		default:
 			try
 			{
-				c = Class.forName(noBrackets.substring(1));
+				noBrackets = noBrackets.substring(1);
+				c = Class.forName(noBrackets);
 			}
 			catch ( ClassNotFoundException e )
 			{

--- a/pljava-so/src/main/c/Exception.c
+++ b/pljava-so/src/main/c/Exception.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2019 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2020 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -23,6 +23,7 @@
 
 jclass Class_class;
 jmethodID Class_getName;
+jmethodID Class_getCanonicalName;
 
 jclass    ServerException_class;
 jmethodID ServerException_getErrorData;
@@ -199,6 +200,8 @@ void Exception_initialize(void)
 	NoSuchMethodError_class = (jclass)JNI_newGlobalRef(PgObject_getJavaClass("java/lang/NoSuchMethodError"));
 
 	Class_getName = PgObject_getJavaMethod(Class_class, "getName", "()Ljava/lang/String;");
+	Class_getCanonicalName = PgObject_getJavaMethod(Class_class,
+		"getCanonicalName", "()Ljava/lang/String;");
 }
 
 extern void Exception_initialize2(void);

--- a/pljava-so/src/main/c/type/Array.c
+++ b/pljava-so/src/main/c/type/Array.c
@@ -1,10 +1,14 @@
 /*
- * Copyright (c) 2004, 2005, 2006 TADA AB - Taby Sweden
- * Distributed under the terms shown in the file COPYRIGHT
- * found in the root folder of this project or at
- * http://eng.tada.se/osprojects/COPYRIGHT.html
+ * Copyright (c) 2004-2020 Tada AB and other contributors, as listed below.
  *
- * @author Thomas Hallgren
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Tada AB
+ *   Chapman Flack
  */
 #include "pljava/type/Type_priv.h"
 #include "pljava/type/Array.h"
@@ -139,12 +143,21 @@ static Datum _Array_coerceObject(Type self, jobject objArray)
 	PG_RETURN_ARRAYTYPE_P(v);
 }
 
+/*
+ * For an array, canReplaceType can be computed a bit more generously.
+ * The primitive types are coded so that a boxed scalar can replace its
+ * corresponding primitive but not vice versa. For primitive arrays, we can also
+ * accept the other direction, that is, when getObjectType(self) == other. That
+ * will work because every primitive Type foo does contain _fooArray_coerceDatum
+ * and _fooArray_coerceObject and can handle both directions.
+ */
 static bool _Array_canReplaceType(Type self, Type other)
 {
 	Type oe = Type_getElementType(other);
 	if ( oe == 0 )
 		return false;
-	return Type_canReplaceType(Type_getElementType(self), oe);
+	return Type_canReplaceType(Type_getElementType(self), oe)
+		|| Type_getObjectType(self) == other;
 }
 
 Type Array_fromOid(Oid typeId, Type elementType)

--- a/pljava-so/src/main/c/type/Boolean.c
+++ b/pljava-so/src/main/c/type/Boolean.c
@@ -17,7 +17,6 @@
 
 static TypeClass s_booleanClass;
 static jclass    s_Boolean_class;
-static jclass    s_BooleanArray_class;
 static jmethodID s_Boolean_init;
 static jmethodID s_Boolean_booleanValue;
 
@@ -78,21 +77,8 @@ static Datum _booleanArray_coerceObject(Type self, jobject booleanArray)
 
 	v = createArrayType(nElems, sizeof(jboolean), BOOLOID, false);
 
-	if(!JNI_isInstanceOf( booleanArray, s_BooleanArray_class))
-		JNI_getBooleanArrayRegion((jbooleanArray)booleanArray, 0,
+	JNI_getBooleanArrayRegion((jbooleanArray)booleanArray, 0,
 					  nElems, (jboolean*)ARR_DATA_PTR(v));
-	else
-	{
-		int idx = 0;
-		jboolean *array = (jboolean*)ARR_DATA_PTR(v);
-
-		for(idx = 0; idx < nElems; ++idx)
-		{
-			jobject e = JNI_getObjectArrayElement(booleanArray, idx);
-			array[idx] = JNI_callBooleanMethod(e, s_Boolean_booleanValue);
-			JNI_deleteLocalRef(e);
-		}
-	}
 
 	PG_RETURN_ARRAYTYPE_P(v);
 }
@@ -133,7 +119,6 @@ void Boolean_initialize(void)
 	TypeClass cls;
 
 	s_Boolean_class = JNI_newGlobalRef(PgObject_getJavaClass("java/lang/Boolean"));
-	s_BooleanArray_class = JNI_newGlobalRef(PgObject_getJavaClass("[Ljava/lang/Boolean;"));
 	s_Boolean_init = PgObject_getJavaMethod(s_Boolean_class, "<init>", "(Z)V");
 	s_Boolean_booleanValue = PgObject_getJavaMethod(s_Boolean_class, "booleanValue", "()Z");
 

--- a/pljava-so/src/main/c/type/Double.c
+++ b/pljava-so/src/main/c/type/Double.c
@@ -17,7 +17,6 @@
 
 static TypeClass s_doubleClass;
 static jclass    s_Double_class;
-static jclass    s_DoubleArray_class;
 static jmethodID s_Double_init;
 static jmethodID s_Double_doubleValue;
 
@@ -83,21 +82,8 @@ static Datum _doubleArray_coerceObject(Type self, jobject doubleArray)
 
 	nElems = JNI_getArrayLength((jarray)doubleArray);
 	v = createArrayType(nElems, sizeof(jdouble), FLOAT8OID, false);
-	if(!JNI_isInstanceOf( doubleArray, s_DoubleArray_class))
-		JNI_getDoubleArrayRegion((jdoubleArray)doubleArray, 0,
+	JNI_getDoubleArrayRegion((jdoubleArray)doubleArray, 0,
 					 nElems, (jdouble*)ARR_DATA_PTR(v));
-	else
-	{
-		int idx = 0;
-		jdouble *array = (jdouble*)ARR_DATA_PTR(v);
-
-		for(idx = 0; idx < nElems; ++idx)
-		{
-			jobject e = JNI_getObjectArrayElement(doubleArray, idx);
-			array[idx] = JNI_callDoubleMethod(e, s_Double_doubleValue);
-			JNI_deleteLocalRef(e);
-		}
-	}
 
 	PG_RETURN_ARRAYTYPE_P(v);
 }
@@ -138,7 +124,6 @@ void Double_initialize(void)
 	TypeClass cls;
 
 	s_Double_class = JNI_newGlobalRef(PgObject_getJavaClass("java/lang/Double"));
-	s_DoubleArray_class = JNI_newGlobalRef(PgObject_getJavaClass("[Ljava/lang/Double;"));
 	s_Double_init = PgObject_getJavaMethod(s_Double_class, "<init>", "(D)V");
 	s_Double_doubleValue = PgObject_getJavaMethod(s_Double_class, "doubleValue", "()D");
 

--- a/pljava-so/src/main/c/type/Float.c
+++ b/pljava-so/src/main/c/type/Float.c
@@ -17,7 +17,6 @@
 
 static TypeClass s_floatClass;
 static jclass    s_Float_class;
-static jclass    s_FloatArray_class;
 static jmethodID s_Float_init;
 static jmethodID s_Float_floatValue;
 
@@ -85,21 +84,8 @@ static Datum _floatArray_coerceObject(Type self, jobject floatArray)
 
 	v = createArrayType(nElems, sizeof(jfloat), FLOAT4OID, false);
 
-	if(!JNI_isInstanceOf( floatArray, s_FloatArray_class))
-		JNI_getFloatArrayRegion((jfloatArray)floatArray, 0,
+	JNI_getFloatArrayRegion((jfloatArray)floatArray, 0,
 					  nElems, (jfloat*)ARR_DATA_PTR(v));
-	else
-	{
-		int idx = 0;
-		jfloat *array = (jfloat*)ARR_DATA_PTR(v);
-
-		for(idx = 0; idx < nElems; ++idx)
-		{
-			jobject e = JNI_getObjectArrayElement(floatArray, idx);
-			array[idx] = JNI_callFloatMethod(e, s_Float_floatValue);
-			JNI_deleteLocalRef(e);
-		}
-	}
 
 	PG_RETURN_ARRAYTYPE_P(v);
 }
@@ -140,7 +126,6 @@ void Float_initialize(void)
 	TypeClass cls;
 
 	s_Float_class = JNI_newGlobalRef(PgObject_getJavaClass("java/lang/Float"));
-	s_FloatArray_class = JNI_newGlobalRef(PgObject_getJavaClass("[Ljava/lang/Float;"));
 	s_Float_init = PgObject_getJavaMethod(s_Float_class, "<init>", "(F)V");
 	s_Float_floatValue = PgObject_getJavaMethod(s_Float_class, "floatValue", "()F");
 

--- a/pljava-so/src/main/c/type/Integer.c
+++ b/pljava-so/src/main/c/type/Integer.c
@@ -17,7 +17,6 @@
 
 static TypeClass s_intClass;
 static jclass    s_Integer_class;
-static jclass    s_IntegerArray_class;
 static jmethodID s_Integer_init;
 static jmethodID s_Integer_intValue;
 
@@ -78,22 +77,8 @@ static Datum _intArray_coerceObject(Type self, jobject intArray)
 
 	v = createArrayType(nElems, sizeof(jint), INT4OID, false);
 
-	if(!JNI_isInstanceOf( intArray, s_IntegerArray_class))
-		JNI_getIntArrayRegion(
+	JNI_getIntArrayRegion(
 			(jintArray)intArray, 0, nElems, (jint*)ARR_DATA_PTR(v));
-	else
-	{
-		int idx = 0;
-		jint *array = (jint*)ARR_DATA_PTR(v);
-
-		for(idx = 0; idx < nElems; ++idx)
-		{
-			jobject e = JNI_getObjectArrayElement(intArray, idx);
-			array[idx] = JNI_callIntMethod(e, s_Integer_intValue);
-			JNI_deleteLocalRef(e);
-		}
-	}
-
 
 	PG_RETURN_ARRAYTYPE_P(v);
 }
@@ -134,7 +119,6 @@ void Integer_initialize(void)
 	TypeClass cls;
 
 	s_Integer_class = JNI_newGlobalRef(PgObject_getJavaClass("java/lang/Integer"));
-	s_IntegerArray_class = JNI_newGlobalRef(PgObject_getJavaClass("[Ljava/lang/Integer;"));
 	s_Integer_init = PgObject_getJavaMethod(s_Integer_class, "<init>", "(I)V");
 	s_Integer_intValue = PgObject_getJavaMethod(s_Integer_class, "intValue", "()I");
 

--- a/pljava-so/src/main/c/type/Long.c
+++ b/pljava-so/src/main/c/type/Long.c
@@ -17,7 +17,6 @@
 
 static TypeClass s_longClass;
 static jclass    s_Long_class;
-static jclass    s_LongArray_class;
 static jmethodID s_Long_init;
 static jmethodID s_Long_longValue;
 
@@ -85,21 +84,8 @@ static Datum _longArray_coerceObject(Type self, jobject longArray)
 
 	v = createArrayType(nElems, sizeof(jlong), INT8OID, false);
 
-	if(!JNI_isInstanceOf( longArray, s_LongArray_class))
-		JNI_getLongArrayRegion(
+	JNI_getLongArrayRegion(
 			(jlongArray)longArray, 0, nElems, (jlong*)ARR_DATA_PTR(v));
-	else
-	{
-		int idx = 0;
-		jlong *array = (jlong*)ARR_DATA_PTR(v);
-
-		for(idx = 0; idx < nElems; ++idx)
-		{
-			jobject e = JNI_getObjectArrayElement(longArray, idx);
-			array[idx] = JNI_callLongMethod(e, s_Long_longValue);
-			JNI_deleteLocalRef(e);
-		}
-	}
 
 	PG_RETURN_ARRAYTYPE_P(v);
 }
@@ -140,7 +126,6 @@ void Long_initialize(void)
 	TypeClass cls;
 
 	s_Long_class = JNI_newGlobalRef(PgObject_getJavaClass("java/lang/Long"));
-	s_LongArray_class = JNI_newGlobalRef(PgObject_getJavaClass("[Ljava/lang/Long;"));
 	s_Long_init = PgObject_getJavaMethod(s_Long_class, "<init>", "(J)V");
 	s_Long_longValue = PgObject_getJavaMethod(s_Long_class, "longValue", "()J");
 

--- a/pljava-so/src/main/c/type/Short.c
+++ b/pljava-so/src/main/c/type/Short.c
@@ -17,7 +17,6 @@
 
 static TypeClass s_shortClass;
 static jclass    s_Short_class;
-static jclass    s_ShortArray_class;
 static jmethodID s_Short_init;
 static jmethodID s_Short_shortValue;
 
@@ -77,21 +76,8 @@ static Datum _shortArray_coerceObject(Type self, jobject shortArray)
 	nElems = JNI_getArrayLength((jarray)shortArray);
 	v = createArrayType(nElems, sizeof(jshort), INT2OID, false);
 
-	if(!JNI_isInstanceOf( shortArray, s_ShortArray_class))
-		JNI_getShortArrayRegion(
+	JNI_getShortArrayRegion(
 			(jshortArray)shortArray, 0, nElems, (jshort*)ARR_DATA_PTR(v));
-	else
-	{
-		int idx = 0;
-		jshort *array = (jshort*)ARR_DATA_PTR(v);
-
-		for(idx = 0; idx < nElems; ++idx)
-		{
-			jobject e = JNI_getObjectArrayElement(shortArray, idx);
-			array[idx] = JNI_callShortMethod(e, s_Short_shortValue);
-			JNI_deleteLocalRef(e);
-		}
-	}
 
 	PG_RETURN_ARRAYTYPE_P(v);
 }
@@ -132,7 +118,6 @@ void Short_initialize(void)
 	TypeClass cls;
 
 	s_Short_class = JNI_newGlobalRef(PgObject_getJavaClass("java/lang/Short"));
-	s_ShortArray_class = JNI_newGlobalRef(PgObject_getJavaClass("[Ljava/lang/Short;"));
 	s_Short_init = PgObject_getJavaMethod(s_Short_class, "<init>", "(S)V");
 	s_Short_shortValue = PgObject_getJavaMethod(s_Short_class, "shortValue", "()S");
 

--- a/pljava-so/src/main/c/type/TupleDesc.c
+++ b/pljava-so/src/main/c/type/TupleDesc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2019 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2020 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -81,7 +81,7 @@ Type pljava_TupleDesc_getColumnType(TupleDesc tupleDesc, int index)
 			"Invalid attribute index \"%d\"", (int)index);
 		type = 0;
 	}
-	else
+	else /* Type_objectTypeFromOid returns boxed types, when that matters */
 		type = Type_objectTypeFromOid(typeId, Invocation_getTypeMap());
 	return type;
 }
@@ -243,7 +243,8 @@ Java_org_postgresql_pljava_internal_TupleDesc__1formTuple(JNIEnv* env, jclass cl
 			jobject value = JNI_getObjectArrayElement(jvalues, idx);
 			if(value != 0)
 			{
-				Type type = Type_fromOid(SPI_gettypeid(self, idx + 1), typeMap);
+				/* Obtain boxed types here too, when that matters. */
+				Type type = Type_objectTypeFromOid(SPI_gettypeid(self, idx + 1), typeMap);
 				values[idx] = Type_coerceObjectBridged(type, value);
 				nulls[idx] = false;
 				JNI_deleteLocalRef(value);

--- a/pljava-so/src/main/c/type/Type.c
+++ b/pljava-so/src/main/c/type/Type.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2019 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2020 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -294,7 +294,7 @@ jvalue Type_coerceDatumAs(Type self, Datum value, jclass rqcls)
 	if ( NULL == rqcls  ||  Type_getJavaClass(self) == rqcls )
 		return Type_coerceDatum(self, value);
 
-	rqcname = JNI_callObjectMethod(rqcls, Class_getName);
+	rqcname = JNI_callObjectMethod(rqcls, Class_getCanonicalName);
 	rqcname0 = String_createNTS(rqcname);
 	JNI_deleteLocalRef(rqcname);
 	rqtype = Type_fromJavaType(self->typeId, rqcname0);

--- a/pljava-so/src/main/include/pljava/JNICalls.h
+++ b/pljava-so/src/main/include/pljava/JNICalls.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2019 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2020 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -49,6 +49,7 @@ extern jmethodID ServerException_init;
 
 extern jclass    Class_class;
 extern jmethodID Class_getName;
+extern jmethodID Class_getCanonicalName;
 
 extern jclass    Throwable_class;
 extern jmethodID Throwable_getMessage;

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/SingleRowWriter.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/SingleRowWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2018 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2020 Tada AB and other contributors, as listed below.
  * Copyright (c) 2010, 2011 PostgreSQL Global Development Group
  *
  * All rights reserved. This program and the accompanying materials
@@ -92,7 +92,8 @@ public class SingleRowWriter extends SingleRowResultSet
 		Class c = m_tupleDesc.getColumnClass(columnIndex);
 		TypeBridge<?>.Holder xAlt = TypeBridge.wrap(x);
 		if(null == xAlt  &&  !c.isInstance(x)
-		&& !(c == byte[].class && (x instanceof BlobValue)))
+		&& !(c == byte[].class && (x instanceof BlobValue))
+		&& !(isBoxedArray(c, x.getClass())))
 		{
 			if(Number.class.isAssignableFrom(c))
 				x = SPIConnection.basicNumericCoercion(c, x);
@@ -176,4 +177,20 @@ public class SingleRowWriter extends SingleRowResultSet
 	// End of implementation of JDBC 4 methods.
 	// ************************************************************
 
+	private boolean isBoxedArray(Class<?> b, Class<?> p)
+	{
+		if ( ! p.isArray() || ! p.getComponentType().isPrimitive() )
+			return false;
+		switch ( p.getName().charAt(1) )
+		{
+		case 'Z': return b ==   Boolean[].class;
+		case 'B': return b ==      Byte[].class;
+		case 'S': return b ==     Short[].class;
+		case 'C': return b == Character[].class;
+		case 'I': return b ==   Integer[].class;
+		case 'J': return b ==      Long[].class;
+		case 'F': return b ==     Float[].class;
+		default : return b ==    Double[].class;
+		}
+	}
 }

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/SingleRowWriter.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/SingleRowWriter.java
@@ -92,8 +92,7 @@ public class SingleRowWriter extends SingleRowResultSet
 		Class c = m_tupleDesc.getColumnClass(columnIndex);
 		TypeBridge<?>.Holder xAlt = TypeBridge.wrap(x);
 		if(null == xAlt  &&  !c.isInstance(x)
-		&& !(c == byte[].class && (x instanceof BlobValue))
-		&& !(isBoxedArray(c, x.getClass())))
+		&& !(c == byte[].class && (x instanceof BlobValue)))
 		{
 			if(Number.class.isAssignableFrom(c))
 				x = SPIConnection.basicNumericCoercion(c, x);
@@ -177,20 +176,4 @@ public class SingleRowWriter extends SingleRowResultSet
 	// End of implementation of JDBC 4 methods.
 	// ************************************************************
 
-	private boolean isBoxedArray(Class<?> b, Class<?> p)
-	{
-		if ( ! p.isArray() || ! p.getComponentType().isPrimitive() )
-			return false;
-		switch ( p.getName().charAt(1) )
-		{
-		case 'Z': return b ==   Boolean[].class;
-		case 'B': return b ==      Byte[].class;
-		case 'S': return b ==     Short[].class;
-		case 'C': return b == Character[].class;
-		case 'I': return b ==   Integer[].class;
-		case 'J': return b ==      Long[].class;
-		case 'F': return b ==     Float[].class;
-		default : return b ==    Double[].class;
-		}
-	}
 }


### PR DESCRIPTION
Issue #300 and a [pljava-dev thread][thd] identified some bugs in array handling. With these fixes:

* Arrays of primitive type can be retrieved from a `ResultSet` using `getObject`, either passing no requested class (the boxed array type will be returned, supporting nulls), or passing either the boxed array or primitive array class to the JDBC 4.1 `getObject` with a `Class` parameter, and getting that array type back (with any nulls mapped to zero/false for the primitive array type).
* Arrays of primitive or boxed primitive types can be passed to `updateObject` for columns of appropriate SQL types. Nulls in the boxed array type are handled.
* Value corruption in `updateObject(Byte[])` to an SQL `"char"[]` is resolved.

Regression tests are added for the above.

No work has been done on supporting PostgreSQL multi-dimensional arrays. Such an array will be returned by `getObject` as a one-dimensional Java array of all of the elements, and `updateObject` can only create a one-dimensional PostgreSQL array.

[thd]: https://www.postgresql.org/message-id/5F63FD3C.3080206%40anastigmatix.net