### PR TITLE
Key s_obtainerByJavaName by name+oid for arrays

### DIFF
--- a/pljava-so/src/main/include/pljava/HashMap.h
+++ b/pljava-so/src/main/include/pljava/HashMap.h
@@ -1,10 +1,14 @@
 /*
- * Copyright (c) 2004, 2005, 2006 TADA AB - Taby Sweden
- * Distributed under the terms shown in the file COPYRIGHT
- * found in the root folder of this project or at
- * http://eng.tada.se/osprojects/COPYRIGHT.html
+ * Copyright (c) 2004-2020 Tada AB and other contributors, as listed below.
  *
- * @author Thomas Hallgren
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Tada AB
+ *   Chapman Flack
  */
 #ifndef __pljava_HashMap_h
 #define __pljava_HashMap_h
@@ -77,6 +81,12 @@ extern void* HashMap_getByString(HashMap self, const char* key);
 extern void* HashMap_getByOid(HashMap self, Oid key);
 
 /*
+ * Returns the object stored using the given null
+ * terminated string and Oid, or NULL if no such object can be found.
+ */
+extern void* HashMap_getByStringOid(HashMap self, const char* string, Oid oid);
+
+/*
  * Returns the object stored using the given Opaque pointer or NULL
  * if no such object can be found.
  */
@@ -112,6 +122,14 @@ extern void* HashMap_putByOid(HashMap self, Oid key, void* value);
 extern void* HashMap_putByOpaque(HashMap self, void* key, void* value);
 
 /*
+ * Stores the given value under the given null terminated string and oid. If
+ * an old value was stored using this key, the old value is returned.
+ * Otherwise this method returns NULL.
+ */
+extern void* HashMap_putByStringOid(HashMap self, const char* string, Oid oid,
+	void* value);
+
+/*
  * Removes the value stored under the given key. The the old value
  * (if any) is returned.
  */
@@ -134,6 +152,12 @@ extern void* HashMap_removeByOid(HashMap self, Oid key);
  * (if any) is returned.
  */
 extern void* HashMap_removeByOpaque(HashMap self, void* key);
+
+/*
+ * Removes the value stored under the given key. The the old value
+ * (if any) is returned. The key associated with the value is deleted.
+ */
+extern void* HashMap_removeByStringOid(HashMap self, const char* str, Oid oid);
 
 /*
  * Returns the number of entries currently in the HashMap
@@ -161,8 +185,8 @@ extern void* Entry_setValue(Entry self, void* value);
 extern HashKey Entry_getKey(Entry self);
 
 /*************************************************************
- * The HashKey is an abstract class. Currently, three different
- * implementations are used. Oid, Opaque (void*), and String.
+ * The HashKey is an abstract class. Currently, four different
+ * implementations are used. Oid, Opaque (void*), String, and StringOid.
  *************************************************************/
 
 /*

--- a/pljava-so/src/main/include/pljava/HashMap_priv.h
+++ b/pljava-so/src/main/include/pljava/HashMap_priv.h
@@ -1,10 +1,14 @@
 /*
- * Copyright (c) 2004, 2005, 2006 TADA AB - Taby Sweden
- * Distributed under the terms shown in the file COPYRIGHT
- * found in the root folder of this project or at
- * http://eng.tada.se/osprojects/COPYRIGHT.html
+ * Copyright (c) 2004-2020 Tada AB and other contributors, as listed below.
  *
- * @author Thomas Hallgren
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Tada AB
+ *   Chapman Flack
  */
 #ifndef __pljava_HashMap_priv_h
 #define __pljava_HashMap_priv_h
@@ -88,6 +92,17 @@ struct StringKey_
 	const char* key;
 };
 typedef struct StringKey_* StringKey;
+
+/*
+ * HashKey for a string and an Oid.
+ */
+struct StringOidKey_
+{
+	struct StringKey_ StringKey_extension;
+
+	Oid oid;
+};
+typedef struct StringOidKey_* StringOidKey;
 
 /*
  * Default clone method. Allocates a new instance in the given MemoryContext


### PR DESCRIPTION
`Type_fromJavaType` can create a `Type` on the fly if it is for an array. It is possible for one Java array type to be associated with more than just one PostgreSQL type (for example, Java `Object[]` for an array of pretty much anything, `String[]` and types that can be rendered to text, and more obscure cases like `byte[]` being associated with `"char"[]` as well as `bytea`).

That led to order-dependent failures when the `s_obtainerByJavaName` cache was keyed only by Java name. Key it now by name+oid, but (to limit the intrusiveness of the patch), use `InvalidOid` in the key except when caching and looking up types that correspond to Java arrays.

This C-based type hierarchy implementation has grown to what is probably its ultimate height and wobbliness (to say nothing of how one would even begin to audit it for faithfulness to JDBC's specified mapping rules). My aim from here on out will be to wiggle it as little as possible while preparing a replacement for a future major-number update.