### PR TITLE
Support variadic functions

### DIFF
--- a/pljava-api/src/main/java/org/postgresql/pljava/annotation/Function.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/annotation/Function.java
@@ -93,6 +93,14 @@ category</a>
 	String schema() default "";
 
 	/**
+	 * Whether PostgreSQL should gather trailing arguments into an array that
+	 * will be bound to the last (non-output) Java parameter (which must have an
+	 * array type).
+	 * Appeared in PostgreSQL 8.4.
+	 */
+	boolean variadic() default false;
+
+	/**
 	 * Estimated cost in units of cpu_operator_cost.
 	 *
 	 * If left unspecified (-1) the backend's default will apply.
@@ -161,7 +169,7 @@ category</a>
 	 * please see <a href=
 '../../../../../../use/parallel.html'>the users' guide</a>.
 	 *<p>
-	 * Appeared in 9.6.
+	 * Appeared in PostgreSQL 9.6.
 	 */
 	Parallel parallel() default Parallel.UNSAFE;
 	

--- a/pljava-api/src/main/java/org/postgresql/pljava/annotation/processing/DDRProcessor.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/annotation/processing/DDRProcessor.java
@@ -1568,6 +1568,7 @@ hunt:	for ( ExecutableElement ee : ees )
 		public String             type() { return _type; }
 		public String             name() { return _name; }
 		public String           schema() { return _schema; }
+		public boolean        variadic() { return _variadic; }
 		public OnNullInput onNullInput() { return _onNullInput; }
 		public Security       security() { return _security; }
 		public Effects         effects() { return _effects; }
@@ -1586,6 +1587,7 @@ hunt:	for ( ExecutableElement ee : ees )
 		public String      _type;
 		public String      _name;
 		public String      _schema;
+		public boolean     _variadic;
 		public OnNullInput _onNullInput;
 		public Security    _security;
 		public Effects     _effects;
@@ -1736,6 +1738,15 @@ hunt:	for ( ExecutableElement ee : ees )
 			 */
 			resolveParameterAndReturnTypes();
 
+			if ( _variadic )
+			{
+				int last = parameterTypes.length - 1;
+				if ( 0 > last  ||  ! parameterTypes[last].isArray() )
+					msg( Kind.ERROR, func,
+						"VARIADIC function must have a last, non-output " +
+						"parameter that is an array");
+			}
+
 			recordImplicitTags();
 
 			recordExplicitTags(_provides, _requires);
@@ -1880,17 +1891,26 @@ hunt:	for ( ExecutableElement ee : ees )
 
 		void appendParams( StringBuilder sb, boolean dflts)
 		{
-			sb.append(parameterInfo()
-				.map(
-					i ->
-					{
-						String name = null == i.st ? null : i.st.name();
-						if ( null == name )
-							name = i.ve.getSimpleName().toString();
-						return "\n\t" + name + " " + i.dt.toString(dflts);
-					})
-				.collect(joining(","))
-			);
+			int count = parameterTypes.length;
+			for ( ParameterInfo i
+				: (Iterable<ParameterInfo>)parameterInfo()::iterator )
+			{
+				-- count;
+
+				String name = null == i.st ? null : i.st.name();
+				if ( null == name )
+					name = i.ve.getSimpleName().toString();
+
+				sb.append("\n\t");
+
+				if ( _variadic  &&  0 == count )
+					sb.append("VARIADIC ");
+
+				sb.append(name).append(' ').append(i.dt.toString(dflts));
+
+				if ( 0 < count )
+					sb.append(',');
+			}
 		}
 
 		void appendAS( StringBuilder sb)
@@ -2121,6 +2141,12 @@ hunt:	for ( ExecutableElement ee : ees )
 			if ( explicit )
 				msg( Kind.ERROR, e,
 					"The type of a UDT function may not be changed");
+		}
+
+		public void setVariadic( Object o, boolean explicit, Element e)
+		{
+			if ( explicit )
+				msg( Kind.ERROR, e,	"A UDT function is not variadic");
 		}
 
 		public void setRows( Object o, boolean explicit, Element e)

--- a/pljava-api/src/main/java/org/postgresql/pljava/annotation/processing/DDRProcessor.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/annotation/processing/DDRProcessor.java
@@ -2087,6 +2087,7 @@ hunt:	for ( ExecutableElement ee : ees )
 			_name = Identifier.Simple.fromJava(ui.name())
 				.concat("_", id.getSuffix()).toString();
 			_schema = ui.schema();
+			_variadic = false;
 			_cost = -1;
 			_rows = -1;
 			_onNullInput = OnNullInput.CALLED;
@@ -2146,7 +2147,7 @@ hunt:	for ( ExecutableElement ee : ees )
 		public void setVariadic( Object o, boolean explicit, Element e)
 		{
 			if ( explicit )
-				msg( Kind.ERROR, e,	"A UDT function is not variadic");
+				msg( Kind.ERROR, e,	"A UDT function is never variadic");
 		}
 
 		public void setRows( Object o, boolean explicit, Element e)

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/AnyTest.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/AnyTest.java
@@ -23,35 +23,6 @@ import static
 import org.postgresql.pljava.annotation.SQLAction;
 import org.postgresql.pljava.annotation.SQLType;
 
-/*
- * This SQLAction declares a function that refers to Java's own String.format
- * method, which is variadic, and tests its behavior.
- *
- * Its presence in this file is an artifact of history: it isn't much related
- * to the functions otherwise defined here, but once had an ordering dependency
- * with one of them because of a bug in the type system.
- */
-@SQLAction(
-	install = {
-		"CREATE FUNCTION javatest.format(" +
-		"  format pg_catalog.text," +
-		"  VARIADIC args pg_catalog.text[])" +
-		" RETURNS pg_catalog.text" +
-		" LANGUAGE java" +
-		" AS 'java.lang.String=" +
-		"     java.lang.String.format(java.lang.String,java.lang.Object[])'",
-
-		"SELECT" +
-		"  CASE" +
-		"   WHEN result OPERATOR(pg_catalog.=) 'Hello, world'" +
-		"   THEN javatest.logmessage('INFO', 'variadic call ok')" +
-		"   ELSE javatest.logmessage('WARNING', 'variadic call ng')" +
-		"  END" +
-		" FROM" +
-		"  javatest.format('Hello, %s', 'world') AS result"
-	},
-	remove = "DROP FUNCTION javatest.format(pg_catalog.text,pg_catalog.text[])"
-)
 /**
  * Provides example methods to illustrate the polymorphic types {@code any},
  * {@code anyarray}, and {@code anyelement}.

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/Variadic.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/Variadic.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2020 Tada AB and other contributors, as listed below.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Chapman Flack
+ */
+package org.postgresql.pljava.example.annotation;
+
+import static java.util.Arrays.stream;
+import java.util.Objects;
+
+import org.postgresql.pljava.annotation.Function;
+import static org.postgresql.pljava.annotation.Function.Effects.IMMUTABLE;
+import static
+	org.postgresql.pljava.annotation.Function.OnNullInput.RETURNS_NULL;
+import org.postgresql.pljava.annotation.SQLAction;
+import org.postgresql.pljava.annotation.SQLType;
+
+/*
+ * This SQLAction declares a function that refers to Java's own String.format
+ * method, which is variadic, and tests its behavior, as well as the locally-
+ * defined sumOfSquares and sumOfSquaresBoxed functions below.
+ */
+@SQLAction(
+	requires = { "sumOfSquares", "sumOfSquaresBoxed" },
+	install = {
+		"CREATE FUNCTION javatest.javaformat(" +
+		"  format pg_catalog.text," +
+		"  VARIADIC args pg_catalog.anyarray DEFAULT CAST(ARRAY[] AS text[]))" +
+		" RETURNS pg_catalog.text" +
+		" RETURNS NULL ON NULL INPUT" +
+		" LANGUAGE java" +
+		" AS 'java.lang.String=" +
+		"     java.lang.String.format(java.lang.String,java.lang.Object[])'",
+
+		"COMMENT ON FUNCTION javatest.javaformat(" +
+		" pg_catalog.text, VARIADIC pg_catalog.anyarray) IS '" +
+		"Invoke Java''s String.format with a format string and any number of " +
+		"arguments. This is not quite as general as the Java method implies, " +
+		"because, while the variadic argument is declared ''anyarray'' and " +
+		"its members can have any type, PostgreSQL requires all of them to " +
+		"have the same type in any given call. Furthermore, in the VARIADIC " +
+		"anyarray case, as here, the actual arguments must not all have " +
+		"''unknown'' type; if supplying bare literals, one must be cast to " +
+		"a type. PostgreSQL will not recognize a call of a variadic function " +
+		"unless at least one argument to populate the variadic parameter is " +
+		"supplied; to allow calls that don''t pass any, give the variadic " +
+		"parameter an empty-array default, as done here.'",
+
+		"SELECT" +
+		"  CASE" +
+		"   WHEN s.ok AND d.ok" +
+		"   THEN javatest.logmessage('INFO', 'variadic calls ok')" +
+		"   ELSE javatest.logmessage('WARNING', 'variadic calls ng')" +
+		"  END" +
+		" FROM" +
+		"  (SELECT" +
+		"    every(expect IS NOT DISTINCT FROM got)" +
+		"   FROM" +
+		"    (VALUES" +
+		"     (" +
+		"      'Hello, world'," +
+		"      javatest.javaformat('Hello, %s', 'world'::text)" +
+		"     )" +
+		"    ) AS t(expect, got)" +
+		"  ) AS s(ok)," +
+		"  (SELECT" +
+		"    every(expect IS NOT DISTINCT FROM got)" +
+		"   FROM" +
+		"    (VALUES" +
+		"     (14.0, javatest.sumOfSquares(1, 2, 3))," +
+		"     (14.0, javatest.sumOfSquares(1, 2, null, 3))," +
+		"     ( 0.0, javatest.sumOfSquares())," +
+		"     (14.0, javatest.sumOfSquaresBoxed(1, 2, 3))," +
+		"     (null, javatest.sumOfSquaresBoxed(1, 2, null, 3))" +
+		"    ) AS t(expect, got)" +
+		"  ) AS d(ok)"
+	},
+
+	remove = "DROP FUNCTION javatest.javaformat(pg_catalog.text,anyarray)"
+)
+/**
+ * Provides example methods to illustrate variadic functions.
+ *<p>
+ * The key is the {@code @Function} annotation declaring the function variadic
+ * to PostgreSQL. The Java method parameter is declared as an ordinary array,
+ * not with Java's {@code ...} syntax; in fact, that would be impossible for a
+ * function with a composite return type (where the Java signature would have to
+ * include a {@code ResultSet} parameter after the variadic input parameter).
+ */
+public class Variadic {
+	/**
+	 * Compute a double-precision sum of squares, returning null if any input
+	 * value is null.
+	 *<p>
+	 * The {@code RETURNS_NULL} annotation does not mean the array collecting
+	 * the variadic arguments cannot have null entries; it only means PostgreSQL
+	 * will never call this function with null for the array itself.
+	 */
+	@Function(
+		schema = "javatest", effects = IMMUTABLE, onNullInput = RETURNS_NULL,
+		variadic = true, provides = "sumOfSquaresBoxed"
+	)
+	public static Double sumOfSquaresBoxed(Double[] vals)
+	{
+		if ( stream(vals).anyMatch(Objects::isNull) )
+			return null;
+
+		return
+			stream(vals).mapToDouble(Double::doubleValue).map(v -> v*v).sum();
+	}
+
+	/**
+	 * Compute a double-precision sum of squares, treating any null input
+	 * as zero.
+	 *<p>
+	 * The {@code RETURNS_NULL} annotation does not mean the array collecting
+	 * the variadic arguments cannot have null entries; it only means PostgreSQL
+	 * will never call this function with null for the array itself. Because
+	 * the Java parameter type here is primitive and cannot represent nulls,
+	 * PL/Java will have silently replaced any nulls in the input with zeros.
+	 *<p>
+	 * This version can be called with no arguments (returning zero, naturally),
+	 * because it is given an empty-array default.
+	 */
+	@Function(
+		schema = "javatest", effects = IMMUTABLE, onNullInput = RETURNS_NULL,
+		variadic = true, provides = "sumOfSquares"
+	)
+	public static double sumOfSquares(@SQLType(defaultValue={}) double[] vals)
+	{
+		return stream(vals).map(v -> v*v).sum();
+	}
+}

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/Variadic.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/Variadic.java
@@ -31,7 +31,8 @@ import org.postgresql.pljava.annotation.SQLType;
 	install = {
 		"CREATE FUNCTION javatest.javaformat(" +
 		"  format pg_catalog.text," +
-		"  VARIADIC args pg_catalog.anyarray DEFAULT CAST(ARRAY[] AS text[]))" +
+		"  VARIADIC args pg_catalog.anyarray" +
+		"  DEFAULT CAST(ARRAY[] AS pg_catalog.text[]))" +
 		" RETURNS pg_catalog.text" +
 		" RETURNS NULL ON NULL INPUT" +
 		" LANGUAGE java" +
@@ -60,7 +61,7 @@ import org.postgresql.pljava.annotation.SQLType;
 		"  END" +
 		" FROM" +
 		"  (SELECT" +
-		"    every(expect IS NOT DISTINCT FROM got)" +
+		"    pg_catalog.every(expect IS NOT DISTINCT FROM got)" +
 		"   FROM" +
 		"    (VALUES" +
 		"     (" +
@@ -70,7 +71,7 @@ import org.postgresql.pljava.annotation.SQLType;
 		"    ) AS t(expect, got)" +
 		"  ) AS s(ok)," +
 		"  (SELECT" +
-		"    every(expect IS NOT DISTINCT FROM got)" +
+		"    pg_catalog.every(expect IS NOT DISTINCT FROM got)" +
 		"   FROM" +
 		"    (VALUES" +
 		"     (14.0, javatest.sumOfSquares(1, 2, 3))," +

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/Variadic.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/Variadic.java
@@ -21,14 +21,24 @@ import static
 import org.postgresql.pljava.annotation.SQLAction;
 import org.postgresql.pljava.annotation.SQLType;
 
-/*
- * This SQLAction declares a function that refers to Java's own String.format
- * method, which is variadic, and tests its behavior, as well as the locally-
- * defined sumOfSquares and sumOfSquaresBoxed functions below.
+/**
+ * Provides example methods to illustrate variadic functions.
+ *<p>
+ * The key is the {@code @Function} annotation declaring the function variadic
+ * to PostgreSQL. The Java method parameter is declared as an ordinary array,
+ * not with Java's {@code ...} syntax; in fact, that would be impossible for a
+ * function with a composite return type (where the Java signature would have to
+ * include a {@code ResultSet} parameter after the variadic input parameter).
  */
 @SQLAction(
 	requires = { "sumOfSquares", "sumOfSquaresBoxed" },
 	install = {
+		/*
+		 * In addition to the two sumOfSquares functions that are defined in
+		 * this class using annotations, emit some direct SQL to declare a
+		 * javaformat function that refers directly to java.lang.String.format,
+		 * which is a function declared variadic in Java.
+		 */
 		"CREATE FUNCTION javatest.javaformat(" +
 		"  format pg_catalog.text," +
 		"  VARIADIC args pg_catalog.anyarray" +
@@ -53,6 +63,9 @@ import org.postgresql.pljava.annotation.SQLType;
 		"supplied; to allow calls that don''t pass any, give the variadic " +
 		"parameter an empty-array default, as done here.'",
 
+		/*
+		 * Test a bunch of variadic calls.
+		 */
 		"SELECT" +
 		"  CASE" +
 		"   WHEN s.ok AND d.ok" +
@@ -85,16 +98,9 @@ import org.postgresql.pljava.annotation.SQLType;
 
 	remove = "DROP FUNCTION javatest.javaformat(pg_catalog.text,anyarray)"
 )
-/**
- * Provides example methods to illustrate variadic functions.
- *<p>
- * The key is the {@code @Function} annotation declaring the function variadic
- * to PostgreSQL. The Java method parameter is declared as an ordinary array,
- * not with Java's {@code ...} syntax; in fact, that would be impossible for a
- * function with a composite return type (where the Java signature would have to
- * include a {@code ResultSet} parameter after the variadic input parameter).
- */
 public class Variadic {
+	private Variadic() { } // do not instantiate
+
 	/**
 	 * Compute a double-precision sum of squares, returning null if any input
 	 * value is null.
@@ -126,8 +132,11 @@ public class Variadic {
 	 * the Java parameter type here is primitive and cannot represent nulls,
 	 * PL/Java will have silently replaced any nulls in the input with zeros.
 	 *<p>
-	 * This version can be called with no arguments (returning zero, naturally),
-	 * because it is given an empty-array default.
+	 * This version also demonstrates using {@link SQLType @SQLType} to give
+	 * the variadic parameter an empty-array default, so PostgreSQL will allow
+	 * the function to be called with no corresponding arguments. Without that,
+	 * PostgreSQL won't recognize a call to the function unless at least one
+	 * argument corresponding to the variadic parameter is supplied.
 	 */
 	@Function(
 		schema = "javatest", effects = IMMUTABLE, onNullInput = RETURNS_NULL,


### PR DESCRIPTION
As it was discovered in 6745166 that PostgreSQL already will do most of the lifting needed to make variadic PL/Java functions work, and in c198a5e that the remaining blocking bug was fixed, add here a `variadic` element for the `@Function` annotation, teach the SQL generator the right output to produce for it, and add a new example demonstrating the feature.