### PR TITLE
Make permissions configurable

### DIFF
--- a/pljava-api/src/main/java/module-info.java
+++ b/pljava-api/src/main/java/module-info.java
@@ -18,7 +18,7 @@ module org.postgresql.pljava
 {
 	requires java.base;
 	requires transitive java.sql;
-	requires java.compiler;
+	requires transitive java.compiler;
 
 	exports org.postgresql.pljava;
 	exports org.postgresql.pljava.annotation;

--- a/pljava-api/src/main/java/org/postgresql/pljava/BasePrincipal.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/BasePrincipal.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2020 Tada AB and other contributors, as listed below.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Chapman Flack
+ */
+package org.postgresql.pljava;
+
+import java.io.InvalidObjectException;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectStreamException;
+import java.io.Serializable;
+
+import static java.lang.reflect.Modifier.isFinal;
+
+import static java.util.Objects.requireNonNull;
+
+import java.security.Principal;
+
+import org.postgresql.pljava.sqlgen.Lexicals.Identifier.Simple;
+
+/**
+ * Abstract base class for {@link Principal}s named by SQL simple identifiers.
+ *<p>
+ * Subclasses are expected to be either {@code abstract} or {@code final}.
+ */
+abstract class BasePrincipal implements Principal, Serializable
+{
+	private static final long serialVersionUID = -3577164744804938351L;
+
+	BasePrincipal(String name)
+	{
+		this(Simple.fromJava(name));
+	}
+
+	BasePrincipal(Simple name)
+	{
+		m_name = requireNonNull(name);
+		assert isFinal(getClass().getModifiers())
+				: "instantiating a non-final BasePrincipal subclass";
+	}
+
+	private void readObject(ObjectInputStream in)
+	throws IOException, ClassNotFoundException
+	{
+		in.defaultReadObject();
+		if ( null == m_name )
+			throw new InvalidObjectException(
+				"deserializing a BasePrincipal with null name");
+	}
+
+	private Simple m_name;
+
+	@Override
+	public boolean equals(Object other)
+	{
+		if ( getClass().isInstance(other) )
+			return m_name.equals(((BasePrincipal)other).m_name);
+		return false;
+	}
+
+	@Override
+	public String toString()
+	{
+		Class<? extends BasePrincipal> c = getClass();
+		return c.getCanonicalName()
+			.substring(1+c.getPackageName().length()) + ": " + getName();
+	}
+
+	@Override
+	public int hashCode()
+	{
+		return m_name.hashCode();
+	}
+
+	@Override
+	public String getName()
+	{
+		return m_name.toString();
+	}
+}

--- a/pljava-api/src/main/java/org/postgresql/pljava/PLPrincipal.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/PLPrincipal.java
@@ -20,6 +20,15 @@ import java.io.Serializable;
 import org.postgresql.pljava.annotation.Function.Trust;
 import org.postgresql.pljava.sqlgen.Lexicals.Identifier.Simple;
 
+/**
+ * Java {@code Principal} representing a PostgreSQL {@code PROCEDURAL LANGUAGE},
+ * which has a name (a simple identifier, not schema-qualified) and is either
+ * {@code Sandboxed} (declared with SQL {@code CREATE TRUSTED LANGUAGE} or
+ * {@code Unsandboxed}.
+ *<p>
+ * Only the subclasses, {@code Sandboxed} or {@code Unsandboxed} can be
+ * instantiated, or granted permissions in policy.
+ */
 public abstract class PLPrincipal extends BasePrincipal
 {
 	private static final long serialVersionUID = 4876111394761861189L;
@@ -45,21 +54,50 @@ public abstract class PLPrincipal extends BasePrincipal
 				+ c.getName());
 	}
 
+	/**
+	 * Returns either {@link Trust#SANDBOXED SANDBOXED} or
+	 * {@link Trust#UNSANDBOXED UNSANDBOXED}
+	 * according to PostgreSQL's catalog entry for the language.
+	 */
 	public abstract Trust trust();
 
+	/**
+	 * Java {@code Principal} representing a PostgreSQL
+	 * {@code PROCEDURAL LANGUAGE} that was declared with the {@code TRUSTED}
+	 * keyword and can be used to declare new functions by any role that has
+	 * been granted {@code USAGE} permission on it.
+	 *<p>
+	 * A Java security policy can grant permissions to this {@code Principal}
+	 * by class and wildcard name, or by class and the specific name given in
+	 * SQL to the language.
+	 */
 	public static final class Sandboxed extends PLPrincipal
 	{
 		private static final long serialVersionUID = 55704990613451177L;
 
+		/**
+		 * Construct an instance given its name in {@code String} form.
+		 *<p>
+		 * The name will be parsed as described for
+		 * {@link Simple#fromJava Identifier.Simple.fromJava}.
+		 */
 		public Sandboxed(String name)
 		{
 			super(name);
 		}
+
+		/**
+		 * Construct an instance given its name already as an
+		 * {@code Identifier.Simple}.
+		 */
 		public Sandboxed(Simple name)
 		{
 			super(name);
 		}
 
+		/**
+		 * Returns {@code SANDBOXED}.
+		 */
 		@Override
 		public Trust trust()
 		{
@@ -67,19 +105,43 @@ public abstract class PLPrincipal extends BasePrincipal
 		}
 	}
 
+	/**
+	 * Java {@code Principal} representing a PostgreSQL
+	 * {@code PROCEDURAL LANGUAGE} that was declared <em>without</em> the
+	 * {@code TRUSTED} keyword, and can be used to declare new functions only
+	 * by a PostgreSQL superuser.
+	 *<p>
+	 * A Java security policy can grant permissions to this {@code Principal}
+	 * by class and wildcard name, or by class and the specific name given in
+	 * SQL to the language.
+	 */
 	public static final class Unsandboxed extends PLPrincipal
 	{
 		private static final long serialVersionUID = 7487230786813048525L;
 
+		/**
+		 * Construct an instance given its name in {@code String} form.
+		 *<p>
+		 * The name will be parsed as described for
+		 * {@link Simple#fromJava Identifier.Simple.fromJava}.
+		 */
 		public Unsandboxed(String name)
 		{
 			super(name);
 		}
+
+		/**
+		 * Construct an instance given its name already as an
+		 * {@code Identifier.Simple}.
+		 */
 		public Unsandboxed(Simple name)
 		{
 			super(name);
 		}
 
+		/**
+		 * Returns {@code UNSANDBOXED}.
+		 */
 		@Override
 		public Trust trust()
 		{

--- a/pljava-api/src/main/java/org/postgresql/pljava/PLPrincipal.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/PLPrincipal.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2020 Tada AB and other contributors, as listed below.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Chapman Flack
+ */
+package org.postgresql.pljava;
+
+import java.io.InvalidObjectException;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectStreamException;
+import java.io.Serializable;
+
+import org.postgresql.pljava.annotation.Function.Trust;
+import org.postgresql.pljava.sqlgen.Lexicals.Identifier.Simple;
+
+public abstract class PLPrincipal extends BasePrincipal
+{
+	private static final long serialVersionUID = 4876111394761861189L;
+
+	PLPrincipal(String name)
+	{
+		super(name);
+	}
+
+	PLPrincipal(Simple name)
+	{
+		super(name);
+	}
+
+	private void readObject(ObjectInputStream in)
+	throws IOException, ClassNotFoundException
+	{
+		in.defaultReadObject();
+		Class<?> c = getClass();
+		if ( c != Sandboxed.class && c != Unsandboxed.class )
+			throw new InvalidObjectException(
+				"deserializing unknown PLPrincipal subclass: "
+				+ c.getName());
+	}
+
+	public abstract Trust trust();
+
+	public static final class Sandboxed extends PLPrincipal
+	{
+		private static final long serialVersionUID = 55704990613451177L;
+
+		public Sandboxed(String name)
+		{
+			super(name);
+		}
+		public Sandboxed(Simple name)
+		{
+			super(name);
+		}
+
+		@Override
+		public Trust trust()
+		{
+			return Trust.SANDBOXED;
+		}
+	}
+
+	public static final class Unsandboxed extends PLPrincipal
+	{
+		private static final long serialVersionUID = 7487230786813048525L;
+
+		public Unsandboxed(String name)
+		{
+			super(name);
+		}
+		public Unsandboxed(Simple name)
+		{
+			super(name);
+		}
+
+		@Override
+		public Trust trust()
+		{
+			return Trust.UNSANDBOXED;
+		}
+	}
+}

--- a/pljava-api/src/main/java/org/postgresql/pljava/ResultSetProvider.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/ResultSetProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2018 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2020 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -14,6 +14,7 @@ package org.postgresql.pljava;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.SQLNonTransientException;
 
 /**
  * An implementation of this interface is returned from functions and procedures
@@ -36,7 +37,7 @@ public interface ResultSetProvider
 	 * This method is called once for each row that should be returned from
 	 * a procedure that returns a set of rows. The receiver
 	 * is a {@code SingleRowWriter}
-	 * instance that is used for capturing the data for the row.
+	 * instance that is used to capture the data for the row.
 	 *<p>
 	 * If the return type is {@code RECORD} rather than a specific complex type,
 	 * SQL requires a column definition list to follow any use of the function
@@ -45,12 +46,32 @@ public interface ResultSetProvider
 	 * and types of the columns expected by the caller. (It can also be used in
 	 * the case of a specific complex type, but in that case the names and types
 	 * are probably already known.)
+	 *<p>
+	 * This default implementation calls
+	 * {@link #assignRowValues(ResultSet,int)}, or throws an
+	 * {@code SQLException} with SQLState 54000 (program limit exceeded) if
+	 * the row number exceeds {@code Integer.MAX_VALUE}.
 	 * @param receiver Receiver of values for the given row.
 	 * @param currentRow Row number, zero on the first call, incremented by one
 	 * on each subsequent call.
 	 * @return {@code true} if a new row was provided, {@code false}
 	 * if not (end of data).
 	 * @throws SQLException
+	 */
+	default boolean assignRowValues(ResultSet receiver, long currentRow)
+	throws SQLException
+	{
+		if ( currentRow <= Integer.MAX_VALUE )
+			return assignRowValues(receiver, (int)currentRow);
+		throw new SQLNonTransientException(
+			getClass().getCanonicalName() +
+			" implements only the assignRowValues method limited to" +
+			" Integer.MAX_VALUE rows; this result set is too large", "54000");
+	}
+
+	/**
+	 * Older version where <em>currentRow</em> is limited to the range
+	 * of {@code int}.
 	 */
 	boolean assignRowValues(ResultSet receiver, int currentRow)
 	throws SQLException;
@@ -61,4 +82,42 @@ public interface ResultSetProvider
 	 */
 	void close()
 	throws SQLException;
+
+	/**
+	 * Version of {@code ResultSetProvider} where the {@code assignRowValues}
+	 * method accepting a {@code long} row count must be implemented, and the
+	 * {@code int} version defaults to using it.
+	 */
+	interface Large extends ResultSetProvider
+	{
+		/**
+		 * This method is called once for each row that should be returned
+		 * from a procedure that returns a set of rows. The receiver is a
+		 * {@code SingleRowWriter} instance that is used to capture the data
+		 * for the row.
+		 *<p>
+		 * If the return type is {@code RECORD} rather than a specific complex
+		 * type, SQL requires a column definition list to follow any use of the
+		 * function in a query.
+		 * The {@link ResultSet#getMetaData() ResultSetMetaData}
+		 * of {@code receiver} can be used here to learn the number, names, and
+		 * types of the columns expected by the caller. (It can also be used in
+		 * the case of a specific complex type, but in that case the names and
+		 * types are probably already known.)
+		 * @param receiver Receiver of values for the given row.
+		 * @param currentRow Row number, zero on the first call, incremented by one
+		 * on each subsequent call.
+		 * @return {@code true} if a new row was provided, {@code false}
+		 * if not (end of data).
+		 * @throws SQLException
+		 */
+		boolean assignRowValues(ResultSet receiver, long currentRow)
+		throws SQLException;
+
+		default boolean assignRowValues(ResultSet receiver, int currentRow)
+		throws SQLException
+		{
+			return assignRowValues(receiver, (long)currentRow);
+		}
+	}
 }

--- a/pljava-api/src/main/java/org/postgresql/pljava/SavepointListener.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/SavepointListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2019 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2020 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -9,6 +9,7 @@
  * Contributors:
  *   Tada AB
  *   Purdue University
+ *   Chapman Flack
  */
 package org.postgresql.pljava;
 
@@ -16,10 +17,11 @@ import java.sql.SQLException;
 import java.sql.Savepoint;
 
 /**
- * Interface for a listener to be notified of the start and commit or abort of
- * savepoints. To receive such notifications, implement this interface, with
- * the three methods that will be called in those three cases, and pass an
- * instance to {@link Session#addSavepointListener}.
+ * Interface for a listener to be notified of the start and pre-commit, commit,
+ * or abort of savepoints. To receive such notifications, implement this
+ * interface, with the methods that will be called in the cases of interest,
+ * and pass an instance to {@link Session#addSavepointListener}. The default
+ * implementations of these methods do nothing.
  *<p>
  * It is possible for a listener method to be called with <em>savepoint</em>
  * null, or <em>parent</em> null, or both; that can happen if the application
@@ -35,12 +37,25 @@ import java.sql.Savepoint;
  */
 public interface SavepointListener
 {
-	void onAbort(Session session, Savepoint savepoint, Savepoint parent)
-	throws SQLException;
+	default void onAbort(Session session, Savepoint savepoint, Savepoint parent)
+	throws SQLException
+	{
+	}
 
-	void onCommit(Session session, Savepoint savepoint, Savepoint parent)
-	throws SQLException;
+	default void onCommit(
+		Session session, Savepoint savepoint, Savepoint parent)
+	throws SQLException
+	{
+	}
 
-	void onStart(Session session, Savepoint savepoint, Savepoint parent)
-	throws SQLException;
+	default void onStart(Session session, Savepoint savepoint, Savepoint parent)
+	throws SQLException
+	{
+	}
+
+	default void onPreCommit(
+		Session session, Savepoint savepoint, Savepoint parent)
+	throws SQLException
+	{
+	}
 }

--- a/pljava-api/src/main/java/org/postgresql/pljava/Session.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/Session.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2019 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2020 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -11,6 +11,8 @@
  *   Chapman Flack
  */
 package org.postgresql.pljava;
+
+import java.security.AccessControlContext; // linked from javadoc
 
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -34,17 +36,23 @@ import java.sql.SQLException;
 public interface Session
 {
 	/**
-	 * Adds the specified <code>listener</code> to the list of listeners that will
-	 * receive savepoint events. This method does nothing if the listener
-	 * was already added.
+	 * Adds the specified {@code listener} to the list of listeners that will
+	 * receive savepoint events. An {@link AccessControlContext} saved by this
+	 * method will be used when the listener is invoked. If the listener was
+	 * already registered, it remains registered just once, though the
+	 * {@code AccessControlContext} is updated and its order of invocation
+	 * relative to other listeners may change.
 	 * @param listener The listener to be added.
 	 */
 	void addSavepointListener(SavepointListener listener);
 
 	/**
-	 * Adds the specified <code>listener</code> to the list of listeners that will
-	 * receive transactional events. This method does nothing if the listener
-	 * was already added.
+	 * Adds the specified {@code listener} to the list of listeners that will
+	 * receive transaction events. An {@link AccessControlContext} saved by this
+	 * method will be used when the listener is invoked. If the listener was
+	 * already registered, it remains registered just once, though the
+	 * {@code AccessControlContext} is updated and its order of invocation
+	 * relative to other listeners may change.
 	 * @param listener The listener to be added.
 	 */
 	void addTransactionListener(TransactionListener listener);
@@ -162,17 +170,17 @@ public interface Session
 	void removeAttribute(String attributeName);
 
 	/**
-	 * Removes the specified <code>listener</code> from the list of listeners that will
-	 * receive savepoint events. This method does nothing unless the listener is
-	 * found.
+	 * Removes the specified {@code listener} from the list of listeners that
+	 * will receive savepoint events. This method does nothing unless
+	 * the listener is found.
 	 * @param listener The listener to be removed.
 	 */
 	void removeSavepointListener(SavepointListener listener);
 
 	/**
-	 * Removes the specified <code>listener</code> from the list of listeners that will
-	 * receive transactional events. This method does nothing unless the listener is
-	 * found.
+	 * Removes the specified {@code listener} from the list of listeners that
+	 * will receive transaction events. This method does nothing unless
+	 * the listener is found.
 	 * @param listener The listener to be removed.
 	 */
 	void removeTransactionListener(TransactionListener listener);

--- a/pljava-api/src/main/java/org/postgresql/pljava/TransactionListener.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/TransactionListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2015 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2020 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -9,16 +9,19 @@
  * Contributors:
  *   Tada AB
  *   Purdue University
+ *   Chapman Flack
  */
 package org.postgresql.pljava;
 
 import java.sql.SQLException;
 
 /**
- * Interface for a listener to be notified of prepare, and commit or abort, of
- * distributed transactions. To receive such notifications, implement this
- * interface, with the three methods that will be called in those three cases,
- * and pass an instance to {@link Session#addTransactionListener}.
+ * Interface for a listener to be notified of prepare, and commit, abort,
+ * or other phase transitions, of distributed transactions. To receive
+ * such notifications, implement this interface, with the methods that
+ * will be called in the cases of interest, and pass an instance to
+ * {@link Session#addTransactionListener}. The default implementations of these
+ * methods do nothing.
  *
  * <code>TransactionListener</code> exposes a
  * <a href=
@@ -29,9 +32,19 @@ import java.sql.SQLException;
  */
 public interface TransactionListener
 {
-	void onAbort(Session session) throws SQLException;
+	default void onAbort(Session session) throws SQLException { }
 
-	void onCommit(Session session) throws SQLException;
+	default void onCommit(Session session) throws SQLException { }
 
-	void onPrepare(Session session) throws SQLException;
+	default void onPrepare(Session session) throws SQLException { }
+
+	default void onPreCommit(Session session) throws SQLException { }
+
+	default void onPrePrepare(Session session) throws SQLException { }
+
+	default void onParallelCommit(Session session) throws SQLException { }
+
+	default void onParallelAbort(Session session) throws SQLException { }
+
+	default void onParallelPreCommit(Session session) throws SQLException { }
 }

--- a/pljava-api/src/main/java/org/postgresql/pljava/annotation/Function.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/annotation/Function.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2016 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2020 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -102,14 +102,14 @@ category</a>
 
 	/**
 	 * Estimated cost in units of cpu_operator_cost.
-	 *
+	 *<p>
 	 * If left unspecified (-1) the backend's default will apply.
 	 */
 	int cost() default -1;
 
 	/**
 	 * Estimated number of rows returned (only for functions returning set).
-	 *
+	 *<p>
 	 * If left unspecified (-1) the backend's default will apply.
 	 */
 	int rows() default -1;
@@ -137,7 +137,7 @@ category</a>
 	
 	/**
 	 * What the query optimizer is allowed to assume about this function.
-	 *
+	 *<p>
 	 * IMMUTABLE describes a pure function whose return will always be the same
 	 * for the same parameter values, with no side effects and no dependency on
 	 * anything in the environment. STABLE describes a function that has no
@@ -154,6 +154,23 @@ category</a>
 	 * in the "untrusted" language instance.
 	 */
 	Trust trust() default Trust.SANDBOXED;
+
+	/**
+	 * The name of the PostgreSQL procedural language to which this function
+	 * should be declared, as an alternative to specifying {@link #trust trust}.
+	 *<p>
+	 * Ordinarily, PL/Java installs two procedural languages, {@code java} and
+	 * {@code javau}, and a function is declared in one or the other by giving
+	 * {@code trust} the value {@code SANDBOXED} or {@code UNSANDBOXED},
+	 * respectively. It is possible to declare other named procedural languages
+	 * sharing PL/Java's handler functions, and assign customized permissions
+	 * to them in {@code pljava.policy}. A function can be declared in the
+	 * specific language named with this element.
+	 *<p>
+	 * It is an error to specify both {@code language} and {@code trust} in
+	 * the same annotation.
+	 */
+	String language() default "";
 
 	/** 
 	 * Whether the function is UNSAFE to use in any parallel query plan at all
@@ -195,7 +212,7 @@ category</a>
 	 * configuration_parameter FROM CURRENT. The latter will ensure that the
 	 * function executes with the same setting for configuration_parameter that
 	 * was in effect when the function was created.
-	 * 
+	 *<p>
 	 * Appeared in PostgreSQL 8.3.
 	 */
 	String[] settings() default {};

--- a/pljava-api/src/main/java/org/postgresql/pljava/annotation/processing/DDRProcessor.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/annotation/processing/DDRProcessor.java
@@ -3972,9 +3972,9 @@ restart:for ( ;; )
 
 	static final class Named extends DBType
 	{
-		private final Identifier.Qualified m_ident;
+		private final Identifier.Qualified<Identifier.Simple> m_ident;
 
-		Named(Identifier.Qualified ident)
+		Named(Identifier.Qualified<Identifier.Simple> ident)
 		{
 			m_ident = ident;
 		}
@@ -4234,19 +4234,22 @@ abstract class DependTag<T>
 		}
 	}
 
-	static final class Type extends Named<Identifier.Qualified>
+	static final class Type
+	extends Named<Identifier.Qualified<Identifier.Simple>>
 	{
-		Type(Identifier.Qualified value)
+		Type(Identifier.Qualified<Identifier.Simple> value)
 		{
 			super(requireNonNull(value));
 		}
 	}
 
-	static final class Function extends Named<Identifier.Qualified>
+	static final class Function
+	extends Named<Identifier.Qualified<Identifier.Simple>>
 	{
 		private DBType[] m_signature;
 
-		Function(Identifier.Qualified value, DBType[] signature)
+		Function(
+			Identifier.Qualified<Identifier.Simple> value, DBType[] signature)
 		{
 			super(requireNonNull(value));
 			m_signature = signature.clone();

--- a/pljava-api/src/main/java/org/postgresql/pljava/sqlgen/Lexicals.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/sqlgen/Lexicals.java
@@ -440,6 +440,8 @@ public abstract class Lexicals
 	 */
 	public static abstract class Identifier implements Serializable
 	{
+		private static final long serialVersionUID = 8963213648466350967L;
+
 		Identifier() { } // not API
 
 		/**
@@ -513,6 +515,8 @@ public abstract class Lexicals
 		public static abstract class Unqualified<T extends Unqualified<T>>
 		extends Identifier
 		{
+			private static final long serialVersionUID = -6580227110716782079L;
+
 			Unqualified() { } // not API
 
 			/**
@@ -535,6 +539,8 @@ public abstract class Lexicals
 		 */
 		public static class Simple extends Unqualified<Simple>
 		{
+			private static final long serialVersionUID = 8571819710429273206L;
+
 			protected final String m_nonFolded;
 
 			/**
@@ -843,6 +849,8 @@ public abstract class Lexicals
 		 */
 		static class Foldable extends Simple
 		{
+			private static final long serialVersionUID = 108336518899180185L;
+
 			private transient /*otherwise final*/ int m_hashCode;
 
 			private Foldable(String nonFolded)
@@ -918,6 +926,8 @@ public abstract class Lexicals
 		 */
 		static class Folding extends Foldable
 		{
+			private static final long serialVersionUID = -1222773531891296743L;
+
 			private transient /*otherwise final*/ String m_pgFolded;
 			private transient /*otherwise final*/ String m_isoFolded;
 
@@ -998,6 +1008,8 @@ public abstract class Lexicals
 		 */
 		public static class Pseudo extends Simple
 		{
+			private static final long serialVersionUID = 4760344682650087583L;
+
 			/**
 			 * Instance intended to represent {@code PUBLIC} when used as a
 			 * privilege grantee.
@@ -1042,6 +1054,8 @@ public abstract class Lexicals
 		 */
 		public static class Operator extends Unqualified<Operator>
 		{
+			private static final long serialVersionUID = -7230613628520513783L;
+
 			private final String m_name;
 
 			private Operator(String name)
@@ -1162,6 +1176,8 @@ public abstract class Lexicals
 		public static class Qualified<T extends Unqualified<T>>
 		extends Identifier
 		{
+			private static final long serialVersionUID = 4834510180698247396L;
+
 			private final Simple m_qualifier;
 			private final T m_local;
 

--- a/pljava-api/src/main/java/org/postgresql/pljava/sqlgen/Lexicals.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/sqlgen/Lexicals.java
@@ -1273,6 +1273,7 @@ public abstract class Lexicals
 			 * or null if not in a compilation context.
 			 * @return the Identifier.Qualified&lt;Simple&gt;
 			 */
+			@SuppressWarnings("fallthrough")
 			public static Qualified<Simple> nameFromJava(
 				String s, Messager msgr)
 			{
@@ -1483,7 +1484,7 @@ public abstract class Lexicals
 			{
 				if ( ! (other instanceof Qualified) )
 					return false;
-				Qualified oi = (Qualified)other;
+				Qualified<?> oi = (Qualified)other;
 
 				return (null == m_qualifier
 						? null == oi.m_qualifier

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/PreJSR310.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/PreJSR310.java
@@ -24,6 +24,7 @@ import java.util.TimeZone;
 
 import org.postgresql.pljava.annotation.Function;
 import org.postgresql.pljava.annotation.SQLAction;
+import org.postgresql.pljava.annotation.SQLActions;
 
 /**
  * Some tests of pre-JSR 310 date/time/timestamp conversions.
@@ -33,9 +34,17 @@ import org.postgresql.pljava.annotation.SQLAction;
  * This example relies on {@code implementor} tags reflecting the PostgreSQL
  * version, set up in the {@link ConditionalDDR} example.
  */
-@SQLAction(implementor="postgresql_ge_90300", // needs LATERAL
-	requires="issue199", install={
-	"SELECT javatest.issue199()"
+@SQLActions({
+	@SQLAction(provides="language java_tzset", install={
+		"SELECT sqlj.alias_java_language('java_tzset', true)"
+	}, remove={
+		"DROP LANGUAGE java_tzset"
+	}),
+
+	@SQLAction(implementor="postgresql_ge_90300", // needs LATERAL
+		requires="issue199", install={
+		"SELECT javatest.issue199()"
+	})
 })
 public class PreJSR310
 {
@@ -49,8 +58,15 @@ public class PreJSR310
 	 * are converted correctly in the Europe/Prague timezone. The actual issue
 	 * was by no means limited to that timezone, but this test reproducibly
 	 * detects it.
+	 *<p>
+	 * This function is defined in the 'alias' language {@code java_tzset}, for
+	 * which there is an entry in the default {@code pljava.policy} granting
+	 * permission to adjust the time zone, which is temporarily done here.
 	 */
-	@Function(schema="javatest", provides="issue199")
+	@Function(
+		schema="javatest", language="java_tzset",
+		requires="language java_tzset", provides="issue199"
+	)
 	public static void issue199() throws SQLException
 	{
 		TimeZone oldZone = TimeZone.getDefault();

--- a/pljava-packaging/build.xml
+++ b/pljava-packaging/build.xml
@@ -310,6 +310,9 @@ jos.close();
 			<utf8 dir="target/classes" prefix="pljava/sharedir/pljava/"
 				includes="*.sql"
 				excludes="pljava.sql pljava--.sql pljava--unpackaged--.sql"/>			
+			<!-- Java Default Policy Implementation and ... Syntax says UTF8 -->
+			<utf8 dir="target/classes" prefix="pljava/sysconfdir/"
+				includes="pljava.policy"/>
 <!-- If editing the script below, expand tabs to spaces (at 4 columns, and only
 	 for the lines of the script) before saving. Line-wrapped into the manifest,
 	 it looks horrible with tabs.

--- a/pljava-packaging/src/main/resources/pljava.policy
+++ b/pljava-packaging/src/main/resources/pljava.policy
@@ -1,7 +1,17 @@
+//
+// Security policy for PL/Java. These grants are intended to add to those
+// contained in the java.policy file of the standard Java installation.
+//
+
+
+//
+// This grant is unconditional. It adds these properties to the standard Java
+// list of system properties that any code may read.
+//
 grant {
 	// "standard" properties that can be read by anyone, by analogy to the
-	// ones so treated in Java itself
-
+	// ones so treated in Java itself.
+	//
 	permission java.util.PropertyPermission
 		"org.postgresql.version", "read";
 	permission java.util.PropertyPermission
@@ -15,19 +25,28 @@ grant {
 	permission java.util.PropertyPermission
 		"org.postgresql.server.encoding", "read";
 
-	// PostgreSQL allows SELECT current_database() or SHOW cluster_name anyway
-
+	// PostgreSQL allows SELECT current_database() or SHOW cluster_name anyway.
+	//
 	permission java.util.PropertyPermission
 		"org.postgresql.database", "read";
 	permission java.util.PropertyPermission
 		"org.postgresql.cluster", "read";
 
-	// SQL/JRT specifies this property
-
+	// SQL/JRT specifies this property.
+	//
 	permission java.util.PropertyPermission
 		"sqlj.defaultconnection", "read";
 };
 
+
+//
+// This grant is specific to the internal implementation of PL/Java itself,
+// which needs these permissions for its own operations.
+//
+// Historically, PL/Java has been able to read any file on the server filesystem
+// when a file: URL is passed to sqlj.install_jar or sqlj.replace_jar. Such a
+// broad grant is not necessary, and can be narrowed below if desired.
+//
 grant codebase "${org.postgresql.pljava.codesource}" {
 	permission java.lang.RuntimePermission
 		"createClassLoader";
@@ -38,39 +57,54 @@ grant codebase "${org.postgresql.pljava.codesource}" {
 
 	// This gives the PL/Java implementation code permission to read
 	// any file, which it only exercises on behalf of sqlj.install_jar()
-	// or sqlj.replace_jar() calls with a file: URL.
+	// or sqlj.replace_jar() when called with a file: URL.
+	//
 	// There would be nothing wrong with restricting this permission to
 	// a specific directory, if all jar files to be loaded will be found there,
 	// or replacing it with a URLPermission if they will be hosted on a remote
 	// server, etc.
+	//
 	permission java.io.FilePermission
 		"<<ALL FILES>>", "read";
 };
 
-// These grants apply to the supplied examples, if sqlj.install_jar is given the
-// exact name 'examples' as the desired jar name. (Otherwise, they will apply to
+
+//
+// This grant applies to the supplied examples, if sqlj.install_jar is given the
+// exact name 'examples' as the desired jar name. (Otherwise, it will apply to
 // any other jar that is installed with the name 'examples'. Beware!)
+//
 grant codebase "sqlj:examples" {
-	// the PreJSR310 test involves setting the time zone
+
+	// The PreJSR310 test involves setting the time zone.
+	//
 	permission java.util.PropertyPermission "user.timezone", "write";
 };
 
+
+//
+// This grant defines the mapping onto Java of PostgreSQL's "trusted language"
+// category. When PL/Java executes a function whose SQL declaration names
+// a language that was declared WITH the TRUSTED keyword, it will have these
+// permissions, if any (in addition to whatever others might be granted to all
+// code, or to its specific jar, etc.).
+//
+grant principal org.postgresql.pljava.PLPrincipal$Sandboxed * {
+};
+
+
+//
 // This grant defines the mapping onto Java of PostgreSQL's "untrusted language"
-// category. When PL/Java executes a function whose SQL declaration names a
-// language that was declared without the TRUSTED keyword, it will have these
+// category. When PL/Java executes a function whose SQL declaration names
+// a language that was declared WITHOUT the TRUSTED keyword, it will have these
 // permissions (in addition to whatever others might be granted to all code, or
 // to its specific jar, etc.).
 //
 grant principal org.postgresql.pljava.PLPrincipal$Unsandboxed * {
-	permission java.io.FilePermission
-		"<<ALL FILES>>", "read,write,delete,readlink";
-};
 
-// This grant defines the mapping onto Java of PostgreSQL's "trusted language"
-// category. When PL/Java executes a function whose SQL declaration names a
-// language that was declared WITH the TRUSTED keyword, it will have these
-// permissions (in addition to whatever others might be granted to all code, or
-// to its specific jar, etc.).
-//
-grant principal org.postgresql.pljava.PLPrincipal$Sandboxed * {
+	// Java does not circumvent operating system access controls; this grant
+	// will still be limited to what the OS allows a PostgreSQL backend process
+	// to do.
+	permission java.io.FilePermission
+		"<<ALL FILES>>", "read,readlink,write,delete";
 };

--- a/pljava-packaging/src/main/resources/pljava.policy
+++ b/pljava-packaging/src/main/resources/pljava.policy
@@ -33,6 +33,8 @@ grant codebase "${org.postgresql.pljava.codesource}" {
 		"createClassLoader";
 	permission java.util.logging.LoggingPermission
 		"control";
+	permission java.security.SecurityPermission
+		"createAccessControlContext";
 
 	// This gives the PL/Java implementation code permission to read
 	// any file, which it only exercises on behalf of sqlj.install_jar()
@@ -51,4 +53,24 @@ grant codebase "${org.postgresql.pljava.codesource}" {
 grant codebase "sqlj:examples" {
 	// the PreJSR310 test involves setting the time zone
 	permission java.util.PropertyPermission "user.timezone", "write";
+};
+
+// This grant defines the mapping onto Java of PostgreSQL's "untrusted language"
+// category. When PL/Java executes a function whose SQL declaration names a
+// language that was declared without the TRUSTED keyword, it will have these
+// permissions (in addition to whatever others might be granted to all code, or
+// to its specific jar, etc.).
+//
+grant principal org.postgresql.pljava.PLPrincipal$Unsandboxed * {
+	permission java.io.FilePermission
+		"<<ALL FILES>>", "read,write,delete,readlink";
+};
+
+// This grant defines the mapping onto Java of PostgreSQL's "trusted language"
+// category. When PL/Java executes a function whose SQL declaration names a
+// language that was declared WITH the TRUSTED keyword, it will have these
+// permissions (in addition to whatever others might be granted to all code, or
+// to its specific jar, etc.).
+//
+grant principal org.postgresql.pljava.PLPrincipal$Sandboxed * {
 };

--- a/pljava-packaging/src/main/resources/pljava.policy
+++ b/pljava-packaging/src/main/resources/pljava.policy
@@ -43,10 +43,6 @@ grant codebase "${org.postgresql.pljava.codesource}" {
 	// server, etc.
 	permission java.io.FilePermission
 		"<<ALL FILES>>", "read";
-
-	// Required here as well as for sqlj:examples, as both will be on the stack
-	// when the PreJSR310 example needs it.
-	permission java.util.PropertyPermission "user.timezone", "write";
 };
 
 // These grants apply to the supplied examples, if sqlj.install_jar is given the

--- a/pljava-packaging/src/main/resources/pljava.policy
+++ b/pljava-packaging/src/main/resources/pljava.policy
@@ -36,6 +36,12 @@ grant {
 	//
 	permission java.util.PropertyPermission
 		"sqlj.defaultconnection", "read";
+
+	// This property is read in the innards of Java 9 and 10, but they forgot
+	// to add a permission for it. Not needed for Java 11 and later.
+	//
+	permission java.util.PropertyPermission
+		"jdk.lang.ref.disableClearBeforeEnqueue", "read";
 };
 
 
@@ -70,19 +76,6 @@ grant codebase "${org.postgresql.pljava.codesource}" {
 
 
 //
-// This grant applies to the supplied examples, if sqlj.install_jar is given the
-// exact name 'examples' as the desired jar name. (Otherwise, it will apply to
-// any other jar that is installed with the name 'examples'. Beware!)
-//
-grant codebase "sqlj:examples" {
-
-	// The PreJSR310 test involves setting the time zone.
-	//
-	permission java.util.PropertyPermission "user.timezone", "write";
-};
-
-
-//
 // This grant defines the mapping onto Java of PostgreSQL's "trusted language"
 // category. When PL/Java executes a function whose SQL declaration names
 // a language that was declared WITH the TRUSTED keyword, it will have these
@@ -107,4 +100,18 @@ grant principal org.postgresql.pljava.PLPrincipal$Unsandboxed * {
 	// to do.
 	permission java.io.FilePermission
 		"<<ALL FILES>>", "read,readlink,write,delete";
+};
+
+
+//
+// This grant applies to a specific PL/Java sandboxed language named java_tzset
+// (if such a language exists) and grants functions created in that language
+// permission to adjust the time zone. There is an example method in the
+// org.postgresql.pljava.example.annotation.PreJSR310 class, which needs to
+// temporarily adjust the time zone for a test. That example also uses
+// sqlj.alias_java_language to create the java_tzset "language" when deployed,
+// and DROP LANGUAGE to remove it when undeployed.
+//
+grant principal org.postgresql.pljava.PLPrincipal$Sandboxed "java_tzset" {
+	permission java.util.PropertyPermission "user.timezone", "write";
 };

--- a/pljava-packaging/src/main/resources/pljava.policy
+++ b/pljava-packaging/src/main/resources/pljava.policy
@@ -1,0 +1,58 @@
+grant {
+	// "standard" properties that can be read by anyone, by analogy to the
+	// ones so treated in Java itself
+
+	permission java.util.PropertyPermission
+		"org.postgresql.version", "read";
+	permission java.util.PropertyPermission
+		"org.postgresql.pljava.version", "read";
+	permission java.util.PropertyPermission
+		"org.postgresql.pljava.native.version", "read";
+
+	permission java.util.PropertyPermission
+		"org.postgresql.pljava.udt.byteorder.*", "read";
+
+	permission java.util.PropertyPermission
+		"org.postgresql.server.encoding", "read";
+
+	// PostgreSQL allows SELECT current_database() or SHOW cluster_name anyway
+
+	permission java.util.PropertyPermission
+		"org.postgresql.database", "read";
+	permission java.util.PropertyPermission
+		"org.postgresql.cluster", "read";
+
+	// SQL/JRT specifies this property
+
+	permission java.util.PropertyPermission
+		"sqlj.defaultconnection", "read";
+};
+
+grant codebase "${org.postgresql.pljava.codesource}" {
+	permission java.lang.RuntimePermission
+		"createClassLoader";
+	permission java.util.logging.LoggingPermission
+		"control";
+
+	// This gives the PL/Java implementation code permission to read
+	// any file, which it only exercises on behalf of sqlj.install_jar()
+	// or sqlj.replace_jar() calls with a file: URL.
+	// There would be nothing wrong with restricting this permission to
+	// a specific directory, if all jar files to be loaded will be found there,
+	// or replacing it with a URLPermission if they will be hosted on a remote
+	// server, etc.
+	permission java.io.FilePermission
+		"<<ALL FILES>>", "read";
+
+	// Required here as well as for sqlj:examples, as both will be on the stack
+	// when the PreJSR310 example needs it.
+	permission java.util.PropertyPermission "user.timezone", "write";
+};
+
+// These grants apply to the supplied examples, if sqlj.install_jar is given the
+// exact name 'examples' as the desired jar name. (Otherwise, they will apply to
+// any other jar that is installed with the name 'examples'. Beware!)
+grant codebase "sqlj:examples" {
+	// the PreJSR310 test involves setting the time zone
+	permission java.util.PropertyPermission "user.timezone", "write";
+};

--- a/pljava-so/src/main/c/Backend.c
+++ b/pljava-so/src/main/c/Backend.c
@@ -1783,7 +1783,7 @@ static Datum internalCallHandler(bool trusted, PG_FUNCTION_ARGS)
 	PG_TRY();
 	{
 		Function function =
-			Function_getFunction(funcoid, forTrigger, false, true);
+			Function_getFunction(funcoid, trusted, forTrigger, false, true);
 		if(forTrigger)
 		{
 			/* Called as a trigger procedure
@@ -1841,7 +1841,7 @@ static Datum internalValidator(bool trusted, PG_FUNCTION_ARGS)
 	 * we decide we don't like this function, which would make the Oid we just
 	 * stashed for it invalid, and frustrate getting the load path later.
 	 */
-	if ( ! InstallHelper_isPLJavaFunction(funcoid) )
+	if ( ! InstallHelper_isPLJavaFunction(funcoid, NULL, NULL) )
 		elog(ERROR, "unexpected error validating PL/Java function");
 
 
@@ -1863,7 +1863,8 @@ static Datum internalValidator(bool trusted, PG_FUNCTION_ARGS)
 	Invocation_pushInvocation(&ctx);
 	PG_TRY();
 	{
-		Function_getFunction(funcoid, false, true, check_function_bodies);
+		Function_getFunction(
+			funcoid, trusted, false, true, check_function_bodies);
 		Invocation_popInvocation(false);
 	}
 	PG_CATCH();

--- a/pljava-so/src/main/c/Backend.c
+++ b/pljava-so/src/main/c/Backend.c
@@ -1002,6 +1002,11 @@ static void initPLJavaClasses(void)
 		"()Z",
 		Java_org_postgresql_pljava_internal_Backend__1isCreatingExtension
 		},
+		{
+		"_myLibraryPath",
+		"()Ljava/lang/String;",
+		Java_org_postgresql_pljava_internal_Backend__1myLibraryPath
+		},
 		{ 0, 0, 0 }
 	};
 
@@ -2065,6 +2070,41 @@ Java_org_postgresql_pljava_internal_Backend__1isCreatingExtension(JNIEnv *env, j
 	bool inExtension = false;
 	pljavaCheckExtension( &inExtension);
 	return inExtension ? JNI_TRUE : JNI_FALSE;
+}
+
+/*
+ * Class:     org_postgresql_pljava_internal_Backend
+ * Method:    _myLibraryPath
+ * Signature: ()Ljava/lang/String;
+ */
+JNIEXPORT jstring JNICALL
+Java_org_postgresql_pljava_internal_Backend__1myLibraryPath(JNIEnv *env, jclass cls)
+{
+	jstring result = NULL;
+
+	BEGIN_NATIVE
+
+	if ( NULL == pljavaLoadPath )
+	{
+		Oid funcoid = pljavaTrustedOid;
+
+		if ( InvalidOid == funcoid )
+			funcoid = pljavaUntrustedOid;
+		if ( InvalidOid == funcoid )
+			return NULL;
+
+		/*
+		 * Result not needed, but pljavaLoadPath is set as a side effect.
+		 */
+		InstallHelper_isPLJavaFunction(funcoid, NULL, NULL);
+	}
+
+	if ( NULL != pljavaLoadPath )
+		result = String_createJavaStringFromNTS(pljavaLoadPath);
+
+	END_NATIVE
+
+	return result;
 }
 
 /*

--- a/pljava-so/src/main/c/Backend.c
+++ b/pljava-so/src/main/c/Backend.c
@@ -964,6 +964,11 @@ static void initPLJavaClasses(void)
 		"()Z",
 		Java_org_postgresql_pljava_internal_Backend_00024EarlyNatives__1forbidOtherThreads
 		},
+		{
+		"_defineClass",
+		"(Ljava/lang/String;Ljava/lang/ClassLoader;[B)Ljava/lang/Class;",
+		Java_org_postgresql_pljava_internal_Backend_00024EarlyNatives__1defineClass
+		},
 		{ 0, 0, 0 }
 	};
 	jclass cls;
@@ -2004,4 +2009,31 @@ JNIEXPORT jboolean JNICALL
 Java_org_postgresql_pljava_internal_Backend_00024EarlyNatives__1forbidOtherThreads(JNIEnv *env, jclass cls)
 {
 	return (java_thread_pg_entry & 4) ? JNI_TRUE : JNI_FALSE;
+}
+
+/*
+ * Class:     org_postgresql_pljava_internal_Backend_EarlyNatives
+ * Method:    _defineClass
+ * Signature: (Ljava/lang/String;Ljava/lang/ClassLoader;[B)Ljava/lang/Class;
+ */
+JNIEXPORT jclass JNICALL
+Java_org_postgresql_pljava_internal_Backend_00024EarlyNatives__1defineClass(JNIEnv *env, jclass cls, jstring name, jobject loader, jbyteArray image)
+{
+	const char *utfName;
+	jbyte *bytes;
+	jsize nbytes;
+	jclass newcls;
+	static bool oneShot = false;
+
+	if ( oneShot )
+		return NULL;
+	oneShot = true;
+
+	utfName = (*env)->GetStringUTFChars(env, name, NULL);
+	bytes = (*env)->GetByteArrayElements(env, image, NULL);
+	nbytes = (*env)->GetArrayLength(env, image);
+	newcls = (*env)->DefineClass(env, utfName, loader, bytes, nbytes);
+	(*env)->ReleaseByteArrayElements(env, image, bytes, JNI_ABORT);
+	(*env)->ReleaseStringUTFChars(env, name, utfName);
+	return newcls;
 }

--- a/pljava-so/src/main/c/Function.c
+++ b/pljava-so/src/main/c/Function.c
@@ -554,7 +554,7 @@ Type Function_checkTypeBaseUDT(Oid typeId, Form_pg_type typeStruct)
 		pljava_Function_udtParseHandle, pljava_Function_udtReadHandle,
 		pljava_Function_udtWriteHandle, pljava_Function_udtToStringHandle
 	};
-	char *langName[4] = {};
+	char *langName[4] = { NULL, NULL, NULL, NULL };
 	bool trusted[4];
 	jobject handle[4];
 	int i;

--- a/pljava-so/src/main/c/Function.c
+++ b/pljava-so/src/main/c/Function.c
@@ -52,14 +52,9 @@
 
 #define COUNTCHECK(refs, prims) ((jshort)(((refs) << 8) | ((prims) & 0xff)))
 
-static jclass s_Loader_class;
-static jclass s_ClassLoader_class;
 static jclass s_Function_class;
 static jclass s_ParameterFrame_class;
 static jclass s_EntryPoints_class;
-static jmethodID s_Loader_getSchemaLoader;
-static jmethodID s_Loader_getTypeMap;
-static jmethodID s_ClassLoader_loadClass;
 static jmethodID s_Function_create;
 static jmethodID s_Function_getClassIfUDT;
 static jmethodID s_Function_udtReadHandle;
@@ -178,9 +173,6 @@ Function Function_INIT_WRITER = &s_initWriter;
 
 static HashMap s_funcMap = 0;
 
-static jclass s_Loader_class;
-static jmethodID s_Loader_getSchemaLoader;
-
 static void _Function_finalize(PgObject func)
 {
 	Function self = (Function)func;
@@ -235,13 +227,6 @@ void Function_initialize(void)
 		== sizeof (jvalue), "Function.java has wrong size for Java JNI jvalue");
 
 	s_funcMap = HashMap_create(59, TopMemoryContext);
-
-	s_Loader_class = JNI_newGlobalRef(PgObject_getJavaClass("org/postgresql/pljava/sqlj/Loader"));
-	s_Loader_getSchemaLoader = PgObject_getStaticJavaMethod(s_Loader_class, "getSchemaLoader", "(Ljava/lang/String;)Ljava/lang/ClassLoader;");
-	s_Loader_getTypeMap = PgObject_getStaticJavaMethod(s_Loader_class, "getTypeMap", "(Ljava/lang/String;)Ljava/util/Map;");
-
-	s_ClassLoader_class = JNI_newGlobalRef(PgObject_getJavaClass("java/lang/ClassLoader"));
-	s_ClassLoader_loadClass = PgObject_getJavaMethod(s_ClassLoader_class, "loadClass", "(Ljava/lang/String;)Ljava/lang/Class;");
 
 	cls = PgObject_getJavaClass(
 		"org/postgresql/pljava/internal/Function$EarlyNatives");

--- a/pljava-so/src/main/c/Function.c
+++ b/pljava-so/src/main/c/Function.c
@@ -66,7 +66,6 @@ static jmethodID s_Function_udtReadHandle;
 static jmethodID s_Function_udtParseHandle;
 static jmethodID s_ParameterFrame_push;
 static jmethodID s_ParameterFrame_pop;
-static jmethodID s_EntryPoints_refInvoke;
 static jmethodID s_EntryPoints_invoke;
 static jmethodID s_EntryPoints_udtWriteInvoke;
 static jmethodID s_EntryPoints_udtToStringInvoke;
@@ -148,9 +147,10 @@ struct Function_
 		jobject typeMap;
 
 		/**
-		 * MethodHandle to the resolved Java method implementing the function.
+		 * PrivilegedAction to the resolved Java method implementing
+		 * the function.
 		 */
-		jobject methodHandle;
+		jobject invoker;
 		} nonudt;
 		
 		struct
@@ -187,7 +187,7 @@ static void _Function_finalize(PgObject func)
 	JNI_deleteGlobalRef(self->clazz);
 	if(!self->isUDT)
 	{
-		JNI_deleteGlobalRef(self->func.nonudt.methodHandle);
+		JNI_deleteGlobalRef(self->func.nonudt.invoker);
 		if(self->func.nonudt.typeMap != 0)
 			JNI_deleteGlobalRef(self->func.nonudt.typeMap);
 		if(self->func.nonudt.paramTypes != 0)
@@ -259,7 +259,7 @@ void Function_initialize(void)
 		"org/postgresql/pljava/internal/Function"));
 	s_Function_create = PgObject_getStaticJavaMethod(s_Function_class, "create",
 		"(JLjava/sql/ResultSet;Ljava/lang/String;Ljava/lang/String;ZZZ)"
-		"Ljava/lang/invoke/MethodHandle;");
+		"Ljava/security/PrivilegedAction;");
 	s_Function_getClassIfUDT = PgObject_getStaticJavaMethod(s_Function_class,
 		"getClassIfUDT",
 		"(Ljava/sql/ResultSet;Ljava/lang/String;)"
@@ -267,11 +267,9 @@ void Function_initialize(void)
 
 	s_EntryPoints_class = JNI_newGlobalRef(PgObject_getJavaClass(
 		"org/postgresql/pljava/internal/EntryPoints"));
-	s_EntryPoints_refInvoke = PgObject_getStaticJavaMethod(
+	s_EntryPoints_invoke = PgObject_getStaticJavaMethod(
 		s_EntryPoints_class,
-		"refInvoke", "(Ljava/lang/invoke/MethodHandle;)Ljava/lang/Object;");
-	s_EntryPoints_invoke = PgObject_getStaticJavaMethod(s_EntryPoints_class,
-		"invoke", "(Ljava/lang/invoke/MethodHandle;)V");
+		"invoke", "(Ljava/security/PrivilegedAction;)Ljava/lang/Object;");
 
 	s_EntryPoints_udtWriteInvoke = PgObject_getStaticJavaMethod(
 		s_EntryPoints_class,
@@ -304,68 +302,68 @@ void Function_initialize(void)
 jobject pljava_Function_refInvoke(Function self)
 {
 	return JNI_callStaticObjectMethod(s_EntryPoints_class,
-		s_EntryPoints_refInvoke, self->func.nonudt.methodHandle);
+		s_EntryPoints_invoke, self->func.nonudt.invoker);
 }
 
 void pljava_Function_voidInvoke(Function self)
 {
-	JNI_callStaticVoidMethod(s_EntryPoints_class,
-		s_EntryPoints_invoke, self->func.nonudt.methodHandle);
+	JNI_callStaticObjectMethod(s_EntryPoints_class,
+		s_EntryPoints_invoke, self->func.nonudt.invoker);
 }
 
 jboolean pljava_Function_booleanInvoke(Function self)
 {
-	JNI_callStaticVoidMethod(s_EntryPoints_class,
-		s_EntryPoints_invoke, self->func.nonudt.methodHandle);
+	JNI_callStaticObjectMethod(s_EntryPoints_class,
+		s_EntryPoints_invoke, self->func.nonudt.invoker);
 	return s_primitiveParameters[0].z;
 }
 
 jbyte pljava_Function_byteInvoke(Function self)
 {
-	JNI_callStaticVoidMethod(s_EntryPoints_class,
-		s_EntryPoints_invoke, self->func.nonudt.methodHandle);
+	JNI_callStaticObjectMethod(s_EntryPoints_class,
+		s_EntryPoints_invoke, self->func.nonudt.invoker);
 	return s_primitiveParameters[0].b;
 }
 
 jshort pljava_Function_shortInvoke(Function self)
 {
-	JNI_callStaticVoidMethod(s_EntryPoints_class,
-		s_EntryPoints_invoke, self->func.nonudt.methodHandle);
+	JNI_callStaticObjectMethod(s_EntryPoints_class,
+		s_EntryPoints_invoke, self->func.nonudt.invoker);
 	return s_primitiveParameters[0].s;
 }
 
 jchar pljava_Function_charInvoke(Function self)
 {
-	JNI_callStaticVoidMethod(s_EntryPoints_class,
-		s_EntryPoints_invoke, self->func.nonudt.methodHandle);
+	JNI_callStaticObjectMethod(s_EntryPoints_class,
+		s_EntryPoints_invoke, self->func.nonudt.invoker);
 	return s_primitiveParameters[0].c;
 }
 
 jint pljava_Function_intInvoke(Function self)
 {
-	JNI_callStaticVoidMethod(s_EntryPoints_class,
-		s_EntryPoints_invoke, self->func.nonudt.methodHandle);
+	JNI_callStaticObjectMethod(s_EntryPoints_class,
+		s_EntryPoints_invoke, self->func.nonudt.invoker);
 	return s_primitiveParameters[0].i;
 }
 
 jfloat pljava_Function_floatInvoke(Function self)
 {
-	JNI_callStaticVoidMethod(s_EntryPoints_class,
-		s_EntryPoints_invoke, self->func.nonudt.methodHandle);
+	JNI_callStaticObjectMethod(s_EntryPoints_class,
+		s_EntryPoints_invoke, self->func.nonudt.invoker);
 	return s_primitiveParameters[0].f;
 }
 
 jlong pljava_Function_longInvoke(Function self)
 {
-	JNI_callStaticVoidMethod(s_EntryPoints_class,
-		s_EntryPoints_invoke, self->func.nonudt.methodHandle);
+	JNI_callStaticObjectMethod(s_EntryPoints_class,
+		s_EntryPoints_invoke, self->func.nonudt.invoker);
 	return s_primitiveParameters[0].j;
 }
 
 jdouble pljava_Function_doubleInvoke(Function self)
 {
-	JNI_callStaticVoidMethod(s_EntryPoints_class,
-		s_EntryPoints_invoke, self->func.nonudt.methodHandle);
+	JNI_callStaticObjectMethod(s_EntryPoints_class,
+		s_EntryPoints_invoke, self->func.nonudt.invoker);
 	return s_primitiveParameters[0].d;
 }
 
@@ -468,7 +466,7 @@ static Function Function_create(
 	jstring schemaName;
 	Ptr2Long p2l;
 	Datum d;
-	jobject handle;
+	jobject invoker;
 
 	d = heap_copy_tuple_as_datum(procTup, Type_getTupleDesc(s_pgproc_Type, 0));
 
@@ -481,7 +479,7 @@ static Function Function_create(
 
 	PG_TRY();
 	{
-		handle = JNI_callStaticObjectMethod(s_Function_class, s_Function_create,
+		invoker = JNI_callStaticObjectMethod(s_Function_class, s_Function_create,
 			p2l.longVal, Type_coerceDatum(s_pgproc_Type, d), lname,
 			schemaName,
 			forTrigger ? JNI_TRUE : JNI_FALSE,
@@ -526,10 +524,10 @@ static Function Function_create(
 	 * the Java code bailed early.
 	 */
 
-	if ( NULL != handle )
+	if ( NULL != invoker )
 	{
-		self->func.nonudt.methodHandle = JNI_newGlobalRef(handle);
-		JNI_deleteLocalRef(handle);
+		self->func.nonudt.invoker = JNI_newGlobalRef(invoker);
+		JNI_deleteLocalRef(invoker);
 	}
 	else if ( ! self->isUDT )
 	{

--- a/pljava-so/src/main/c/Function.c
+++ b/pljava-so/src/main/c/Function.c
@@ -426,6 +426,26 @@ static void reserveParameterFrame(jsize refArgCount, jsize primArgCount)
 	*s_countCheck = newCounts;
 }
 
+/*
+ * Invoke an Invocable that was obtained by invoking an Invocable for a
+ * set-returning-function that returns results in value-per-call style.
+ * Pass true for 'close' when no more results are wanted. Will always overwrite
+ * *result; check the boolean return value to determine whether that is a real
+ * result (true) or the end of results was reached (false).
+ */
+jboolean pljava_Function_vpcInvoke(
+	jobject invocable, jobject rowcollect, jlong call_cntr, jboolean close,
+	jobject *result)
+{
+	reserveParameterFrame(1, 2);
+	JNI_setObjectArrayElement(s_referenceParameters, 0, rowcollect);
+	s_primitiveParameters[0].j = call_cntr;
+	s_primitiveParameters[1].z = close;
+	*result = JNI_callStaticObjectMethod(s_EntryPoints_class,
+		s_EntryPoints_invoke, invocable);
+	return s_primitiveParameters[0].z;
+}
+
 void pljava_Function_udtWriteInvoke(
 	jobject invocable, jobject value, jobject stream)
 {

--- a/pljava-so/src/main/c/Function.c
+++ b/pljava-so/src/main/c/Function.c
@@ -437,6 +437,17 @@ jboolean pljava_Function_vpcInvoke(
 	jobject invocable, jobject rowcollect, jlong call_cntr, jboolean close,
 	jobject *result)
 {
+	/*
+	 * When retrieving the very first row, this call happens under the same
+	 * Invocation as the call to the user function itself that returned this
+	 * invocable (and may, rarely, have pushed a ParameterFrame). What does
+	 * the reservation below imply for ParameterFrame management?
+	 *
+	 * It's ok, because the user function's invocation will have cleared the
+	 * static area parameter counts; this reservation will therefore not see a
+	 * need to push a frame. If one was pushed for the user function itself, it
+	 * remains on top, to be popped when the Invocation is.
+	 */
 	reserveParameterFrame(1, 2);
 	JNI_setObjectArrayElement(s_referenceParameters, 0, rowcollect);
 	s_primitiveParameters[0].j = call_cntr;

--- a/pljava-so/src/main/c/InstallHelper.c
+++ b/pljava-so/src/main/c/InstallHelper.c
@@ -354,7 +354,7 @@ static void getExtensionLoadPath()
  *
  * If a string is returned, it has been palloc'd in the current context.
  */
-char *pljavaFnOidToLibPath(Oid fnOid)
+char *pljavaFnOidToLibPath(Oid fnOid, char **langName, bool *trusted)
 {
 	bool isnull;
 	HeapTuple procTup;
@@ -394,13 +394,15 @@ char *pljavaFnOidToLibPath(Oid fnOid)
 		elog(ERROR, "cache lookup failed for language %u", langId);
 	langStruct = (Form_pg_language) GETSTRUCT(langTup);
 	handlerOid = langStruct->lanplcallfoid;
-	ReleaseSysCache(langTup);
 	/*
 	 * PL/Java has certainly got a function call handler, so if this language
 	 * hasn't, PL/Java it's not.
 	 */
 	if ( InvalidOid == handlerOid )
+	{
+		ReleaseSysCache(langTup);
 		return NULL;
+	}
 
 	/*
 	 * Da capo al coda ... handlerOid is another function to be looked up.
@@ -413,7 +415,10 @@ char *pljavaFnOidToLibPath(Oid fnOid)
 	 * If the call handler's not a C function, this isn't PL/Java....
 	 */
 	if ( ClanguageId != procStruct->prolang )
+	{
+		ReleaseSysCache(langTup);
 		return NULL;
+	}
 
 	/*
 	 * Now that the handler is known to be a C function, it should have a
@@ -423,6 +428,11 @@ char *pljavaFnOidToLibPath(Oid fnOid)
 		SysCacheGetAttr(PROCOID, procTup, Anum_pg_proc_probin, &isnull);
 	if ( isnull )
 		elog(ERROR, "null probin for C function %u", handlerOid);
+	if ( NULL != langName )
+		*langName = pstrdup(NameStr(langStruct->lanname));
+	if ( NULL != trusted )
+		*trusted = langStruct->lanpltrusted;
+	ReleaseSysCache(langTup);
 	probinstring = /* TextDatumGetCString(probinattr); */
 		DatumGetCString(DirectFunctionCall1(textout, probinattr)); /*archaic*/
 	ReleaseSysCache(procTup);
@@ -443,13 +453,13 @@ bool InstallHelper_shouldDeferInit()
 	return IsBackgroundWorker || IsBinaryUpgrade;
 }
 
-bool InstallHelper_isPLJavaFunction(Oid fn)
+bool InstallHelper_isPLJavaFunction(Oid fn, char **langName, bool *trusted)
 {
 	char *itsPath;
 	char *pljPath;
 	bool result = false;
 
-	itsPath = pljavaFnOidToLibPath(fn);
+	itsPath = pljavaFnOidToLibPath(fn, langName, trusted);
 	if ( NULL == itsPath )
 		return false;
 
@@ -457,9 +467,9 @@ bool InstallHelper_isPLJavaFunction(Oid fn)
 	{
 		pljPath = NULL;
 		if ( InvalidOid != pljavaTrustedOid )
-			pljPath = pljavaFnOidToLibPath(pljavaTrustedOid);
+			pljPath = pljavaFnOidToLibPath(pljavaTrustedOid, NULL, NULL);
 		if ( NULL == pljPath && InvalidOid != pljavaUntrustedOid )
-			pljPath = pljavaFnOidToLibPath(pljavaUntrustedOid);
+			pljPath = pljavaFnOidToLibPath(pljavaUntrustedOid, NULL, NULL);
 		if ( NULL == pljPath )
 		{
 			elog(WARNING, "unable to determine PL/Java's load path");

--- a/pljava-so/src/main/c/InstallHelper.c
+++ b/pljava-so/src/main/c/InstallHelper.c
@@ -595,7 +595,7 @@ void InstallHelper_groundwork()
 {
 	Invocation ctx;
 	bool snapshot_set = false;
-	Invocation_pushInvocation(&ctx, false);
+	Invocation_pushInvocation(&ctx);
 	ctx.function = Function_INIT_WRITER;
 #if PG_VERSION_NUM >= 80400
 	if ( ! ActiveSnapshotSet() )

--- a/pljava-so/src/main/c/Invocation.c
+++ b/pljava-so/src/main/c/Invocation.c
@@ -29,6 +29,32 @@ static unsigned int s_callLevel = 0;
 
 Invocation* currentInvocation;
 
+/*
+ * Two features of the calling convention for PL/Java functions will be handled
+ * here in Invocation to keep wrappers in Function simple. A PL/Java function
+ * may use static primitive slot 0 to return a primitive value, so that will
+ * always be saved in an Invocation struct and restored on both normal and
+ * exceptional return paths, when the heavier-weight full pushing of a Java
+ * ParameterFrame has not occurred. Likewise, the heavy full push is skipped if
+ * either the current or the new frame limits are (0,0), which means for such
+ * cases the frame limits themselves must be saved and restored the same way.
+ */
+static jvalue *s_primSlot0;
+static jshort *s_frameLimits;
+
+/*
+ * To keep these values somewhat encapsulated, Function.c calls this function
+ * during its initialization to share them, rather than simply making them
+ * global.
+ */
+void pljava_Invocation_shareFrame(jvalue *slot0, jshort *limits)
+{
+	if ( 0 != s_primSlot0  ||  0 != s_frameLimits )
+		return;
+	s_primSlot0 = slot0;
+	s_frameLimits = limits;
+}
+
 extern void Invocation_initialize(void);
 void Invocation_initialize(void)
 {
@@ -106,7 +132,8 @@ void Invocation_pushBootContext(Invocation* ctx)
 	JNI_pushLocalFrame(LOCAL_FRAME_SIZE);
 	ctx->invocation      = 0;
 	ctx->function        = 0;
-	ctx->pushedFrame     = false;
+	ctx->frameLimits     = 0;
+	ctx->primSlot0.j     = 0L;
 	ctx->hasConnected    = false;
 	ctx->upperContext    = CurrentMemoryContext;
 	ctx->errorOccurred   = false;
@@ -131,7 +158,8 @@ void Invocation_pushInvocation(Invocation* ctx)
 	JNI_pushLocalFrame(LOCAL_FRAME_SIZE);
 	ctx->invocation      = 0;
 	ctx->function        = 0;
-	ctx->pushedFrame     = false;
+	ctx->frameLimits     = *s_frameLimits;
+	ctx->primSlot0       = *s_primSlot0;
 	ctx->hasConnected    = false;
 	ctx->upperContext    = CurrentMemoryContext;
 	ctx->errorOccurred   = false;
@@ -148,8 +176,19 @@ void Invocation_popInvocation(bool wasException)
 {
 	Invocation* ctx = currentInvocation->previous;
 
-	if ( currentInvocation->pushedFrame )
+	/*
+	 * If the more heavyweight parameter-frame push got done, undo it.
+	 */
+	if ( FRAME_LIMITS_PUSHED == currentInvocation->frameLimits )
 		pljava_Function_popFrame();
+	else
+	{
+		/*
+		 * The lighter-weight cleanup.
+		 */
+		*s_frameLimits = currentInvocation->frameLimits;
+		*s_primSlot0   = currentInvocation->primSlot0;
+	}
 
 	/*
 	 * If a Java Invocation instance was created and associated with this
@@ -179,6 +218,7 @@ void Invocation_popInvocation(bool wasException)
 		SPI_finish();
 
 	JNI_popLocalFrame(0);
+
 	if(ctx != 0)
 	{
 		MemoryContextSwitchTo(ctx->upperContext);

--- a/pljava-so/src/main/c/XactListener.c
+++ b/pljava-so/src/main/c/XactListener.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2019 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2020 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -17,27 +17,39 @@
 #include "access/xact.h"
 
 static jclass s_XactListener_class;
-static jmethodID s_XactListener_onAbort;
-static jmethodID s_XactListener_onCommit;
-static jmethodID s_XactListener_onPrepare;
+static jmethodID s_XactListener_invokeListeners;
 
 static void xactCB(XactEvent event, void* arg)
 {
+	/*
+	 * Upstream has, regrettably, not merely added events over the years, but
+	 * changed their order, so a mapping is needed. Use a switch with the known
+	 * cases enumerated, to improve the chance that a clever compiler will warn
+	 * if yet more have been added, and initialize 'mapped' to a value that the
+	 * Java code won't mistake for a real one.
+	 */
+#define CASE(c) \
+case XACT_EVENT_##c: \
+	mapped = org_postgresql_pljava_internal_XactListener_##c; \
+	break
+
+	jint mapped = -1;
 	switch(event)
 	{
-		case XACT_EVENT_ABORT:
-			JNI_callStaticVoidMethod(s_XactListener_class,
-				s_XactListener_onAbort);
-			break;
-		case XACT_EVENT_COMMIT:
-			JNI_callStaticVoidMethod(s_XactListener_class,
-				s_XactListener_onCommit);
-			break;
-		case XACT_EVENT_PREPARE:
-			JNI_callStaticVoidMethod(s_XactListener_class,
-				s_XactListener_onPrepare);
-			break;
+		CASE( COMMIT );
+		CASE( ABORT );
+		CASE( PREPARE );
+		CASE( PRE_COMMIT );
+		CASE( PRE_PREPARE );
+#if PG_VERSION_NUM >= 90500
+		CASE( PARALLEL_COMMIT );
+		CASE( PARALLEL_ABORT );
+		CASE( PARALLEL_PRE_COMMIT );
+#endif
 	}
+
+	JNI_callStaticVoidMethod(s_XactListener_class,
+		s_XactListener_invokeListeners, mapped);
 }
 
 extern void XactListener_initialize(void);
@@ -59,10 +71,10 @@ void XactListener_initialize(void)
 
 	PgObject_registerNatives("org/postgresql/pljava/internal/XactListener", methods);
 
-	s_XactListener_class = JNI_newGlobalRef(PgObject_getJavaClass("org/postgresql/pljava/internal/XactListener"));
-	s_XactListener_onAbort = PgObject_getStaticJavaMethod(s_XactListener_class, "onAbort", "()V");
-	s_XactListener_onCommit = PgObject_getStaticJavaMethod(s_XactListener_class, "onCommit", "()V");
-	s_XactListener_onPrepare = PgObject_getStaticJavaMethod(s_XactListener_class, "onPrepare", "()V");
+	s_XactListener_class = JNI_newGlobalRef(PgObject_getJavaClass(
+		"org/postgresql/pljava/internal/XactListener"));
+	s_XactListener_invokeListeners = PgObject_getStaticJavaMethod(
+		s_XactListener_class, "invokeListeners", "(I)V");
 }
 
 /*

--- a/pljava-so/src/main/c/type/Type.c
+++ b/pljava-so/src/main/c/type/Type.c
@@ -775,22 +775,26 @@ static jobject _Type_getSRFCollector(Type self, PG_FUNCTION_ARGS)
 	return 0;
 }
 
+static jobject testingStash;
+
 static bool _Type_hasNextSRF(Type self, jobject rowProducer, jobject rowCollector, jlong callCounter)
 {
-	return (JNI_callBooleanMethod(rowProducer, s_Iterator_hasNext) == JNI_TRUE);
+	return (JNI_TRUE == pljava_Function_vpcInvoke(
+		rowProducer, rowCollector, callCounter, JNI_FALSE, &testingStash));
 }
 
 static Datum _Type_nextSRF(Type self, jobject rowProducer, jobject rowCollector)
 {
-	/* XXX make an entry point */
-	jobject tmp = JNI_callObjectMethod(rowProducer, s_Iterator_next);
-	Datum result = Type_coerceObject(self, tmp);
-	JNI_deleteLocalRef(tmp);
+	/* XXX make an entry point
+	jobject tmp = JNI_callObjectMethod(rowProducer, s_Iterator_next); */
+	Datum result = Type_coerceObject(self, testingStash);
+	JNI_deleteLocalRef(testingStash);
 	return result;
 }
 
 static void _Type_closeSRF(Type self, jobject rowProducer)
 {
+	pljava_Function_vpcInvoke(rowProducer, NULL, 0, JNI_TRUE, &testingStash);
 }
 
 jobject Type_getSRFProducer(Type self, Function fn)

--- a/pljava-so/src/main/c/type/Type.c
+++ b/pljava-so/src/main/c/type/Type.c
@@ -684,7 +684,8 @@ Type Type_fromOid(Oid typeId, jobject typeMap)
 			if ( hasTupleDesc )
 				ReleaseTupleDesc(tupleDesc);
 			type = (Type)UDT_registerUDT(
-				typeClass, typeId, typeStruct, hasTupleDesc, false, NULL, NULL);
+				typeClass, typeId, typeStruct, hasTupleDesc, false,
+				NULL, NULL, NULL, NULL);
 			JNI_deleteLocalRef(typeClass);
 			goto finally;
 		}

--- a/pljava-so/src/main/c/type/UDT.c
+++ b/pljava-so/src/main/c/type/UDT.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2019 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2020 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -151,7 +151,7 @@ static Datum coerceScalarObject(UDT self, jobject value)
 		 * produce the human-used external representation, is being called here
 		 * to produce this UDT's internal representation.
 		 */
-		jstring jstr = pljava_Function_udtToStringInvoke(value);
+		jstring jstr = pljava_Function_udtToStringInvoke(self->toString, value);
 		char* tmp = String_createNTS(jstr);
 		result = CStringGetDatum(tmp);
 		JNI_deleteLocalRef(jstr);
@@ -176,7 +176,7 @@ static Datum coerceScalarObject(UDT self, jobject value)
 			enlargeStringInfo(&buffer, dataLen);
 
 		outputStream = SQLOutputToChunk_create(&buffer, isJavaBasedScalar);
-		pljava_Function_udtWriteInvoke(value, outputStream);
+		pljava_Function_udtWriteInvoke(self->writeSQL, value, outputStream);
 		SQLOutputToChunk_close(outputStream);
 
 		if(dataLen < 0)
@@ -223,7 +223,7 @@ static Datum coerceTupleObject(UDT self, jobject value)
 		TupleDesc tupleDesc = lookup_rowtype_tupdesc_noerror(typeId, -1, true);
 		jobject sqlOutput = SQLOutputToTuple_create(tupleDesc);
 		ReleaseTupleDesc(tupleDesc);
-		pljava_Function_udtWriteInvoke(value, sqlOutput);
+		pljava_Function_udtWriteInvoke(self->writeSQL, value, sqlOutput);
 		tuple = SQLOutputToTuple_getTuple(sqlOutput);
 		if(tuple != 0)
 			result = HeapTupleGetDatum(tuple);
@@ -355,7 +355,7 @@ Datum UDT_output(UDT udt, PG_FUNCTION_ARGS)
 		 * toString to get the external representation from the object.
 		 */
 		jobject value = _UDT_coerceDatum((Type)udt, PG_GETARG_DATUM(0)).l;
-		jstring jstr  = pljava_Function_udtToStringInvoke(value);
+		jstring jstr  = pljava_Function_udtToStringInvoke(udt->toString, value);
 
 		MemoryContext currCtx = Invocation_switchToUpperContext();
 		txt = String_createNTS(jstr);
@@ -429,7 +429,8 @@ bool UDT_isScalar(UDT udt)
 /* Make this datatype available to the postgres system.
  */
 UDT UDT_registerUDT(jclass clazz, Oid typeId, Form_pg_type pgType,
-	bool hasTupleDesc, bool isJavaBasedScalar, jobject parseMH, jobject readMH)
+	bool hasTupleDesc, bool isJavaBasedScalar, jobject parseMH, jobject readMH,
+	jobject writeMH, jobject toStringMH)
 {
 	jstring jcn;
 	MemoryContext currCtx;
@@ -527,19 +528,28 @@ UDT UDT_registerUDT(jclass clazz, Oid typeId, Form_pg_type pgType,
 		 */
 		if ( NULL == parseMH )
 			parseMH = pljava_Function_udtParseHandle(clazz);
+		if ( NULL == toStringMH )
+			toStringMH = pljava_Function_udtToStringHandle(clazz);
 		udt->parse = JNI_newGlobalRef(parseMH);
+		udt->toString = JNI_newGlobalRef(toStringMH);
 		JNI_deleteLocalRef(parseMH);
+		JNI_deleteLocalRef(toStringMH);
 	}
 	else
 	{
 		udt->parse = NULL;
+		udt->toString = NULL;
 	}
 
 	udt->hasTupleDesc = hasTupleDesc;
 	if ( NULL == readMH )
 		readMH = pljava_Function_udtReadHandle(clazz);
+	if ( NULL == writeMH )
+		writeMH = pljava_Function_udtWriteHandle(clazz);
 	udt->readSQL = JNI_newGlobalRef(readMH);
+	udt->writeSQL = JNI_newGlobalRef(writeMH);
 	JNI_deleteLocalRef(readMH);
+	JNI_deleteLocalRef(writeMH);
 	Type_registerType(className, (Type)udt);
 	return udt;
 }

--- a/pljava-so/src/main/include/pljava/Backend.h
+++ b/pljava-so/src/main/include/pljava/Backend.h
@@ -1,10 +1,15 @@
 /*
- * Copyright (c) 2004, 2005, 2006 TADA AB - Taby Sweden
- * Distributed under the terms shown in the file COPYRIGHT
- * found in the root folder of this project or at
- * http://eng.tada.se/osprojects/COPYRIGHT.html
+ * Copyright (c) 2004-2020 Tada AB and other contributors, as listed below.
  *
- * @author Thomas Hallgren
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Tada AB - Thomas Hallgren
+ *   PostgreSQL Global Development Group
+ *   Chapman Flack
  */
 #ifndef __pljava_Backend_h
 #define __pljava_Backend_h
@@ -24,8 +29,6 @@ extern "C" {
 #if PG_VERSION_NUM < 100000
 extern bool integerDateTimes;
 #endif
-
-void Backend_setJavaSecurity(bool trusted);
 
 int Backend_setJavaLogLevel(int logLevel);
 

--- a/pljava-so/src/main/include/pljava/Function.h
+++ b/pljava-so/src/main/include/pljava/Function.h
@@ -107,6 +107,10 @@ extern jfloat pljava_Function_floatInvoke(Function self);
 extern jlong pljava_Function_longInvoke(Function self);
 extern jdouble pljava_Function_doubleInvoke(Function self);
 
+extern jboolean pljava_Function_vpcInvoke(
+	jobject invocable, jobject rowcollect, jlong call_cntr, jboolean close,
+	jobject *result);
+
 extern void pljava_Function_udtWriteInvoke(
 	jobject invocable, jobject value, jobject stream);
 extern jstring pljava_Function_udtToStringInvoke(

--- a/pljava-so/src/main/include/pljava/Function.h
+++ b/pljava-so/src/main/include/pljava/Function.h
@@ -55,9 +55,15 @@ extern void Function_clearFunctionCache(void);
  * meaning.
  */
 extern Function Function_getFunction(
-	Oid funcOid, bool forTrigger, bool forValidator, bool checkBody);
+	Oid funcOid, bool trusted, bool forTrigger,
+	bool forValidator, bool checkBody);
 
-extern Type Function_checkTypeUDT(Oid typeId, Form_pg_type typeStruct);
+/*
+ * Determine whether the type represented by typeId is declared as a
+ * "Java-based scalar" a/k/a BaseUDT and, if so, return a freshly-registered
+ * UDT Type for it; otherwise return NULL.
+ */
+extern Type Function_checkTypeBaseUDT(Oid typeId, Form_pg_type typeStruct);
 
 /*
  * Invoke a trigger. Wrap the TriggerData in org.postgresql.pljava.TriggerData
@@ -127,10 +133,14 @@ extern jobject pljava_Function_udtReadInvoke(
 extern jobject pljava_Function_udtParseInvoke(
 	jobject invocable, jstring stringRep, jstring typeName);
 
-extern jobject pljava_Function_udtWriteHandle(jclass clazz);
-extern jobject pljava_Function_udtToStringHandle(jclass clazz);
-extern jobject pljava_Function_udtReadHandle(jclass clazz);
-extern jobject pljava_Function_udtParseHandle(jclass clazz);
+extern jobject pljava_Function_udtWriteHandle(
+	jclass clazz, char *langName, bool trusted);
+extern jobject pljava_Function_udtToStringHandle(
+	jclass clazz, char *langName, bool trusted);
+extern jobject pljava_Function_udtReadHandle(
+	jclass clazz, char *langName, bool trusted);
+extern jobject pljava_Function_udtParseHandle(
+	jclass clazz, char *langName, bool trusted);
 
 /*
  * Returns the Type Map that is associated with the function

--- a/pljava-so/src/main/include/pljava/Function.h
+++ b/pljava-so/src/main/include/pljava/Function.h
@@ -107,13 +107,17 @@ extern jfloat pljava_Function_floatInvoke(Function self);
 extern jlong pljava_Function_longInvoke(Function self);
 extern jdouble pljava_Function_doubleInvoke(Function self);
 
-extern void pljava_Function_udtWriteInvoke(jobject value, jobject stream);
-extern jstring pljava_Function_udtToStringInvoke(jobject value);
+extern void pljava_Function_udtWriteInvoke(
+	jobject invocable, jobject value, jobject stream);
+extern jstring pljava_Function_udtToStringInvoke(
+	jobject invocable, jobject value);
 extern jobject pljava_Function_udtReadInvoke(
-	jobject readMH, jobject stream, jstring typeName);
+	jobject invocable, jobject stream, jstring typeName);
 extern jobject pljava_Function_udtParseInvoke(
-	jobject parseMH, jstring stringRep, jstring typeName);
+	jobject invocable, jstring stringRep, jstring typeName);
 
+extern jobject pljava_Function_udtWriteHandle(jclass clazz);
+extern jobject pljava_Function_udtToStringHandle(jclass clazz);
 extern jobject pljava_Function_udtReadHandle(jclass clazz);
 extern jobject pljava_Function_udtParseHandle(jclass clazz);
 

--- a/pljava-so/src/main/include/pljava/Function.h
+++ b/pljava-so/src/main/include/pljava/Function.h
@@ -107,6 +107,13 @@ extern jfloat pljava_Function_floatInvoke(Function self);
 extern jlong pljava_Function_longInvoke(Function self);
 extern jdouble pljava_Function_doubleInvoke(Function self);
 
+/*
+ * Call the invocable that was returned by the invocation of a set-returning
+ * user function that observes the SFRM_ValuePerCall protocol. Call with
+ * close == JNI_FALSE to retrieve the next row if any, JNI_TRUE when done (which
+ * may be before all rows have been retrieved). Returns JNI_TRUE/JNI_FALSE to
+ * indicate whether a row was retrieved, AND puts a value (or null) in *result.
+ */
 extern jboolean pljava_Function_vpcInvoke(
 	jobject invocable, jobject rowcollect, jlong call_cntr, jboolean close,
 	jobject *result);

--- a/pljava-so/src/main/include/pljava/InstallHelper.h
+++ b/pljava-so/src/main/include/pljava/InstallHelper.h
@@ -64,12 +64,16 @@ extern bool pljavaLoadingAsExtension;
  * isPLJavaFunction can use the stashed information to determine whether an
  * arbitrary function Oid is a function built on PL/Java, without relying on
  * assumptions about the language name, etc.
+ *
+ * It can return the language name and/or trusted flag if non-null pointers
+ * are supplied, as it will be looking up the language anyway.
  */
-extern char *pljavaFnOidToLibPath(Oid fn);
+extern char *pljavaFnOidToLibPath(Oid fn, char **langName, bool *trusted);
 
 extern Oid pljavaTrustedOid, pljavaUntrustedOid;
 
-extern bool InstallHelper_isPLJavaFunction(Oid fn);
+extern bool InstallHelper_isPLJavaFunction(
+	Oid fn, char **langName, bool *trusted);
 
 /*
  * Return the name of the current database, from MyProcPort ... don't free it.

--- a/pljava-so/src/main/include/pljava/Invocation.h
+++ b/pljava-so/src/main/include/pljava/Invocation.h
@@ -52,10 +52,24 @@ struct Invocation_
 	bool          inExprContextCB;
 
 	/**
-	 * Whether nested invocation of a Function has required pushing a parameter
-	 * frame that will have to be popped when the Invocation is.
+	 * The saved limits reserved in Function.c's static parameter frame, as a
+	 * count of reference and primitive parameters combined in a short.
+	 * FRAME_LIMITS_PUSHED is an otherwise invalid value used to record that the
+	 * more heavyweight saving of the frame as a Java ParameterFrame instance
+	 * has occurred. Otherwise, this value (and the primitive slot 0 value
+	 * below) are simply restored when this Invocation is exited normally or
+	 * exceptionally.
 	 */
-	bool pushedFrame;
+	jshort frameLimits;
+#define FRAME_LIMITS_PUSHED ((jshort)-1)
+
+	/**
+	 * The saved value of the first primitive slot in Function's static
+	 * parameter frame. Unless frameLimits above is FRAME_LIMITS_PUSHED, this
+	 * value is simply restored when this Invocation is exited normally or
+	 * exceptionally.
+	 */
+	jvalue primSlot0;
 
 	/**
 	 * The currently executing Function.
@@ -112,6 +126,13 @@ extern jobject Invocation_getTypeMap(void);
  * is the context returned from this call.
  */
 extern MemoryContext Invocation_switchToUpperContext(void);
+
+/*
+ * Called only during Function's initialization to supply these values, making
+ * them cheap to access during pushInvocation/popInvocation, while still a bit
+ * more encapsulated than if they were made global.
+ */
+extern void pljava_Invocation_shareFrame(jvalue *slot0, jshort *limits);
 
 #ifdef __cplusplus
 }

--- a/pljava-so/src/main/include/pljava/Invocation.h
+++ b/pljava-so/src/main/include/pljava/Invocation.h
@@ -52,11 +52,6 @@ struct Invocation_
 	bool          inExprContextCB;
 
 	/**
-	 * Set to true if the executing function is trusted
-	 */
-	bool          trusted;
-
-	/**
 	 * Whether nested invocation of a Function has required pushing a parameter
 	 * frame that will have to be popped when the Invocation is.
 	 */
@@ -102,7 +97,7 @@ extern void Invocation_pushBootContext(Invocation* ctx);
 
 extern void Invocation_popBootContext(void);
 
-extern void Invocation_pushInvocation(Invocation* ctx, bool trusted);
+extern void Invocation_pushInvocation(Invocation* ctx);
 
 extern void Invocation_popInvocation(bool wasException);
 

--- a/pljava-so/src/main/include/pljava/type/Type.h
+++ b/pljava-so/src/main/include/pljava/type/Type.h
@@ -200,12 +200,6 @@ extern Oid Type_getOid(Type self);
 extern TupleDesc Type_getTupleDesc(Type self, PG_FUNCTION_ARGS);
 
 /*
- * Obtains the Java object that acts as the SRF producer. This instance will be
- * called once for each row that should be produced.
- */
-extern jobject Type_getSRFProducer(Type self, Function fn);
-
-/*
  * Obtains the optional Java object that will act as the value collector for
  * the SRF producer. The collector typically manifest itself as an OUT
  * parameter of type java.sql.ResultSet in calls to the SRF producer.
@@ -213,19 +207,10 @@ extern jobject Type_getSRFProducer(Type self, Function fn);
 extern jobject Type_getSRFCollector(Type self, PG_FUNCTION_ARGS);
 
 /*
- * Called to determine if the producer will produce another row.
+ * Return a Datum of the expected type, from the row collector (if any) and/or
+ * the value returned by the row producer.
  */
-extern bool Type_hasNextSRF(Type self, jobject producer, jobject collector, jlong counter);
-
-/*
- * Converts the next row into a Datum of the expected type.
- */
-extern Datum Type_nextSRF(Type self, jobject producer, jobject collector);
-
-/*
- * Called at the end of an SRF iteration.
- */
-extern void Type_closeSRF(Type self, jobject producer);
+extern Datum Type_datumFromSRF(Type self, jobject row, jobject rowCollector);
 
 /*
  * Function used when obtaining a type based on an Oid

--- a/pljava-so/src/main/include/pljava/type/Type_priv.h
+++ b/pljava-so/src/main/include/pljava/type/Type_priv.h
@@ -107,11 +107,8 @@ struct TypeClass_
 	 */
 	Datum (*invoke)(Type self, Function fn, PG_FUNCTION_ARGS);
 
-	jobject (*getSRFProducer)(Type self, Function fn);
 	jobject (*getSRFCollector)(Type self, PG_FUNCTION_ARGS);
-	bool (*hasNextSRF)(Type self, jobject producer, jobject collector, jlong counter);
-	Datum (*nextSRF)(Type self, jobject producer, jobject collector);
-	void (*closeSRF)(Type self, jobject producer);
+	Datum (*datumFromSRF)(Type self, jobject row, jobject collector);
 	const char* (*getJNISignature)(Type self);
 
 	/*

--- a/pljava-so/src/main/include/pljava/type/UDT.h
+++ b/pljava-so/src/main/include/pljava/type/UDT.h
@@ -1,8 +1,14 @@
 /*
- * Copyright (c) 2004, 2005, 2006 TADA AB - Taby Sweden
- * Distributed under the terms shown in the file COPYRIGHT
- * found in the root folder of this project or at
- * http://eng.tada.se/osprojects/COPYRIGHT.html
+ * Copyright (c) 2004-2020 Tada AB and other contributors, as listed below.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Tada AB
+ *   Chapman Flack
  *
  * @author Thomas Hallgren
  */
@@ -40,13 +46,15 @@ extern bool UDT_isScalar(UDT udt);
  * argument is only used in the scalar case. A readMH is needed for the scalar
  * or the composite case.
  *
- * If null is supplied for readMH, or for parseMH in the scalar case, an upcall
- * to Java will be made to obtain the handle. Handles can be passed as arguments
+ * Non-null values for {parse,read,write,toString}MH can be passed as arguments
  * here as a shortcut in case the registration is coming from Function.c and the
- * handles are already known.
+ * handles are already known (they are in fact Invocables, but were method
+ * handles before, and MH still suggests their purpose and makes shorter names).
+ * If passed as NULL and needed, upcalls will be made to obtain them.
  */
 extern UDT UDT_registerUDT(jclass clazz, Oid typeId, Form_pg_type pgType,
-	bool hasTupleDesc, bool isJavaBasedScalar, jobject parseMH, jobject readMH);
+	bool hasTupleDesc, bool isJavaBasedScalar, jobject parseMH, jobject readMH,
+	jobject writeMH, jobject toStringMH);
 
 typedef Datum (*UDTFunction)(UDT udt, PG_FUNCTION_ARGS);
 

--- a/pljava-so/src/main/include/pljava/type/UDT_priv.h
+++ b/pljava-so/src/main/include/pljava/type/UDT_priv.h
@@ -1,8 +1,14 @@
 /*
- * Copyright (c) 2004, 2005, 2006 TADA AB - Taby Sweden
- * Distributed under the terms shown in the file COPYRIGHT
- * found in the root folder of this project or at
- * http://eng.tada.se/osprojects/COPYRIGHT.html
+ * Copyright (c) 2004-2020 Tada AB and other contributors, as listed below.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Tada AB
+ *   Chapman Flack
  *
  * @author Thomas Hallgren
  */
@@ -33,6 +39,16 @@ struct UDT_
 	bool      hasTupleDesc;
 	jobject parse;
 	jobject readSQL;
+
+	/*
+	 * At first glance, one might not retain writeSQL and toString handles
+	 * per-UDT, as they are both inherited methods common to all UDTs and so
+	 * do not depend on the class of the receiver. What these jobjects hold,
+	 * though, is an Invocable, which carries an AccessControlContext, which is
+	 * chosen at resolution time per-UDT or per-function, so they must be here.
+	 */
+	jobject writeSQL;
+	jobject toString;
 };
 
 extern Datum _UDT_coerceObject(Type self, jobject jstr);

--- a/pljava/src/main/java/module-info.java
+++ b/pljava/src/main/java/module-info.java
@@ -23,6 +23,9 @@ module org.postgresql.pljava.internal
 
 	exports org.postgresql.pljava.elog to java.logging;
 
+	provides java.net.spi.URLStreamHandlerProvider
+		with org.postgresql.pljava.sqlj.Handler;
+
 	provides java.sql.Driver with org.postgresql.pljava.jdbc.SPIDriver;
 
 	provides org.postgresql.pljava.Session

--- a/pljava/src/main/java/org/postgresql/pljava/internal/Backend.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/Backend.java
@@ -297,25 +297,40 @@ public class Backend
 	}
 
 	/**
+	 * Returns the path of PL/Java's shared library.
+	 * @throws SQLException if for some reason it can't be determined.
+	 */
+	public static String myLibraryPath() throws SQLException
+	{
+		String result = doInPG(Backend::_myLibraryPath);
+
+		if ( null != result )
+			return result;
+
+		throw new SQLException("Unable to retrieve PL/Java's library path");
+	}
+
+	/**
 	 * Returns <code>true</code> if the backend is awaiting a return from a
 	 * call into the JVM. This method will only return <code>false</code>
 	 * when called from a thread other then the main thread and the main
 	 * thread has returned from the call into the JVM.
 	 */
-	public native static boolean isCallingJava();
+	public static native boolean isCallingJava();
 
 	/**
 	 * Returns the value of the GUC custom variable <code>
 	 * pljava.release_lingering_savepoints</code>.
 	 */
-	public native static boolean isReleaseLingeringSavepoints();
+	public static native boolean isReleaseLingeringSavepoints();
 
-	private native static String _getConfigOption(String key);
+	private static native String _getConfigOption(String key);
 
-	private native static int  _getStatementCacheSize();
-	private native static void _log(int logLevel, String str);
-	private native static void _clearFunctionCache();
-	private native static boolean _isCreatingExtension();
+	private static native int  _getStatementCacheSize();
+	private static native void _log(int logLevel, String str);
+	private static native void _clearFunctionCache();
+	private static native boolean _isCreatingExtension();
+	private static native String _myLibraryPath();
 
 	private static class EarlyNatives
 	{

--- a/pljava/src/main/java/org/postgresql/pljava/internal/Backend.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/Backend.java
@@ -247,11 +247,11 @@ public class Backend
 		return doInPG(() -> _getConfigOption(key));
 	}
 
-	public static List<Identifier> getListConfigOption(String key)
+	public static List<Identifier.Simple> getListConfigOption(String key)
 	throws SQLException
 	{
 		final Matcher m = s_gucList.matcher(getConfigOption(key));
-		ArrayList<Identifier> al = new ArrayList<>();
+		ArrayList<Identifier.Simple> al = new ArrayList<>();
 		while ( m.find() )
 		{
 			al.add(identifierFrom(m));

--- a/pljava/src/main/java/org/postgresql/pljava/internal/Checked.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/Checked.java
@@ -202,6 +202,18 @@ public interface Checked<WT, EX extends Throwable>
 		return t -> after.apply(first.apply(t));
 	}
 
+	static <T, U, E extends Throwable>
+		BiConsumer<T,U,E> composed(
+			BiConsumer<? super T, ? super U, ? extends E> first,
+			BiConsumer<? super T, ? super U, ? extends E> after)
+	{
+		return (t, u) ->
+		{
+			first.accept(t, u);
+			after.accept(t, u);
+		};
+	}
+
 	static <T, E extends Throwable>
 		Consumer<T,E> composed(
 			Consumer<? super T, ? extends E> first,
@@ -839,6 +851,35 @@ public interface Checked<WT, EX extends Throwable>
 	/*
 	 * Consumers that have checked-exception-less counterparts in the Java API.
 	 */
+
+	@FunctionalInterface
+	interface BiConsumer<T,U,E extends Throwable>
+	extends Checked<java.util.function.BiConsumer<T,U>, E>
+	{
+		void accept(T t, U u) throws E;
+
+		@Override
+		default java.util.function.BiConsumer<T,U> ederWrap()
+		{
+			return (t, u) ->
+			{
+				try
+				{
+					accept(t, u);
+				}
+				catch ( Throwable thw )
+				{
+					throw Checked.<RuntimeException>ederThrow(thw);
+				}
+			};
+		}
+
+		static <T, U, E extends Throwable> BiConsumer<T,U,E>
+		use(BiConsumer<T,U,E> o)
+		{
+			return o;
+		}
+	}
 
 	@FunctionalInterface
 	interface Consumer<T,E extends Throwable>

--- a/pljava/src/main/java/org/postgresql/pljava/internal/Checked.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/Checked.java
@@ -89,17 +89,57 @@ href='https://wiki.sei.cmu.edu/confluence/display/java/ERR06-J.+Do+not+throw+und
  * parameter, and some {@link #closing(AutoCloseable) closing} methods (inspired
  * by Python, for use with resources that do not already implement
  * {@code AutoCloseable}), are also provided.
+ *
+ * @param <WT> The type this functional interface can be wrapped as by
+ * ederWrap(), which may be a corresponding Java functional interface that does
+ * not allow checked exceptions.
+ * @param <EX> The checked exception type (or least upper bound of the checked
+ * exception types) that the body of this functional interface may throw.
  */
 public interface Checked<WT, EX extends Throwable>
 {
+	/**
+	 * Throw an exception, unsafely cast to a different exception type, chiefly
+	 * as used by Lukas Eder to fly a checked exception through a section of
+	 * code that does not accept it.
+	 *<p>
+	 * In PL/Java, this method is not intended to be called directly, but used
+	 * transparently within the {@link #in in(...)} construct, which re-exposes
+	 * the checked exception type {@code EX} to the compiler.
+	 * @param <E> The throwable type the argument t should be presented as.
+	 * @param t A throwable.
+	 * @throws E The argument t, represented to the compiler as of type E.
+	 */
 	@SuppressWarnings("unchecked")
 	static <E extends Throwable> E ederThrow(Throwable t) throws E
 	{
 		throw (E) t;
 	}
 
+	/**
+	 * Wraps this {@code Checked} functional interfaces as its
+	 * corresponding Java functional interface {@code WT}, which possibly
+	 * does not allow checked exceptions.
+	 *<p>
+	 * Checked exceptions of type {@code EX} may still, in reality, be thrown.
+	 * This method is not intended to be called directly; it is used
+	 * transparently by {@link #in in(...)}, which passes the wrapper type into
+	 * code that requires it, but re-exposes the original checked exception type
+	 * to the compiler.
+	 */
 	WT ederWrap();
 
+	/**
+	 * Passes this functional interface, wrapped as its wrapper type {@code WT},
+	 * into a code body that requires that wrapper type, while remembering for
+	 * the compiler the checked exception type that may, in fact, be thrown.
+	 *
+	 * @param <RX> Any exception type that the body, c, detectably can throw.
+	 * @param c A Consumer to which this instance, wrapped as its corresponding
+	 * functional interface WT, will be passed.
+	 * @throws EX whatever can be thrown by the body of this instance
+	 * @throws RX whatever can be thrown by the body c.
+	 */
 	default <RX extends Throwable>
 	void in(Consumer<? super WT, RX> c)
 	throws EX, RX
@@ -107,6 +147,16 @@ public interface Checked<WT, EX extends Throwable>
 		c.accept(ederWrap());
 	}
 
+	/**
+	 * Like {@link #in in(...)} but where the body returns a non-primitive type.
+	 *
+	 * @param <RT> Return type of the body f.
+	 * @param <RX> Any exception type that the body, f, detectably can throw.
+	 * @param f A ToDoubleFunction to which this instance, wrapped as its
+	 * corresponding functional interface WT, will be passed.
+	 * @throws EX whatever can be thrown by the body of this instance
+	 * @throws RX whatever can be thrown by the body f.
+	 */
 	default <RT, RX extends Throwable>
 	RT inReturning(Function<? super WT, RT, RX> f)
 	throws EX, RX
@@ -114,6 +164,15 @@ public interface Checked<WT, EX extends Throwable>
 		return f.apply(ederWrap());
 	}
 
+	/**
+	 * Like {@link #in in(...)} but where the body returns a {@code double}.
+	 *
+	 * @param <RX> Any exception type that the body, f, detectably can throw.
+	 * @param f A ToDoubleFunction to which this instance, wrapped as its
+	 * corresponding functional interface WT, will be passed.
+	 * @throws EX whatever can be thrown by the body of this instance
+	 * @throws RX whatever can be thrown by the body f.
+	 */
 	default <RX extends Throwable>
 	double inDoubleReturning(ToDoubleFunction<? super WT, RX> f)
 		throws EX, RX
@@ -121,6 +180,15 @@ public interface Checked<WT, EX extends Throwable>
 		return f.apply(ederWrap());
 	}
 
+	/**
+	 * Like {@link #in in(...)} but where the body returns an {@code int}.
+	 *
+	 * @param <RX> Any exception type that the body, f, detectably can throw.
+	 * @param f A ToIntFunction to which this instance, wrapped as its
+	 * corresponding functional interface WT, will be passed.
+	 * @throws EX whatever can be thrown by the body of this instance
+	 * @throws RX whatever can be thrown by the body f.
+	 */
 	default <RX extends Throwable>
 	int inIntReturning(ToIntFunction<? super WT, RX> f)
 	throws EX, RX
@@ -128,6 +196,15 @@ public interface Checked<WT, EX extends Throwable>
 		return f.apply(ederWrap());
 	}
 
+	/**
+	 * Like {@link #in in(...)} but where the body returns a {@code long}.
+	 *
+	 * @param <RX> Any exception type that the body, f, detectably can throw.
+	 * @param f A ToLongFunction to which this instance, wrapped as its
+	 * corresponding functional interface WT, will be passed.
+	 * @throws EX whatever can be thrown by the body of this instance
+	 * @throws RX whatever can be thrown by the body f.
+	 */
 	default <RX extends Throwable>
 	long inLongReturning(ToLongFunction<? super WT, RX> f)
 	throws EX, RX
@@ -135,6 +212,15 @@ public interface Checked<WT, EX extends Throwable>
 		return f.apply(ederWrap());
 	}
 
+	/**
+	 * Like {@link #in in(...)} but where the body returns a {@code boolean}.
+	 *
+	 * @param <RX> Any exception type that the body, f, detectably can throw.
+	 * @param f A Predicate to which this instance, wrapped as its
+	 * corresponding functional interface WT, will be passed.
+	 * @throws EX whatever can be thrown by the body of this instance
+	 * @throws RX whatever can be thrown by the body f.
+	 */
 	default <RX extends Throwable>
 	boolean inBooleanReturning(Predicate<? super WT, RX> f)
 		throws EX, RX
@@ -142,6 +228,20 @@ public interface Checked<WT, EX extends Throwable>
 		return f.test(ederWrap());
 	}
 
+
+	/**
+	 * Like {@link #in in(...)} but where the body returns a {@code byte}.
+	 *<p>
+	 * This method is provided for consistency of notation, even though it is
+	 * not strictly needed because Java has no checked-exception-less
+	 * counterpart of {@code ToByteFunction}.
+	 *
+	 * @param <RX> Any exception type that the body, f, detectably can throw.
+	 * @param f A ToByteFunction to which this instance, wrapped as its
+	 * corresponding functional interface WT, will be passed.
+	 * @throws EX whatever can be thrown by the body of this instance
+	 * @throws RX whatever can be thrown by the body f.
+	 */
 	default <RX extends Throwable>
 	byte inByteReturning(ToByteFunction<? super WT, RX> f)
 		throws EX, RX
@@ -149,6 +249,19 @@ public interface Checked<WT, EX extends Throwable>
 		return f.apply(ederWrap());
 	}
 
+	/**
+	 * Like {@link #in in(...)} but where the body returns a {@code short}.
+	 *<p>
+	 * This method is provided for consistency of notation, even though it is
+	 * not strictly needed because Java has no checked-exception-less
+	 * counterpart of {@code ToShortFunction}.
+	 *
+	 * @param <RX> Any exception type that the body, f, detectably can throw.
+	 * @param f A ToShortFunction to which this instance, wrapped as its
+	 * corresponding functional interface WT, will be passed.
+	 * @throws EX whatever can be thrown by the body of this instance
+	 * @throws RX whatever can be thrown by the body f.
+	 */
 	default <RX extends Throwable>
 	short inShortReturning(ToShortFunction<? super WT, RX> f)
 	throws EX, RX
@@ -156,6 +269,19 @@ public interface Checked<WT, EX extends Throwable>
 		return f.apply(ederWrap());
 	}
 
+	/**
+	 * Like {@link #in in(...)} but where the body returns a {@code char}.
+	 *<p>
+	 * This method is provided for consistency of notation, even though it is
+	 * not strictly needed because Java has no checked-exception-less
+	 * counterpart of {@code ToCharFunction}.
+	 *
+	 * @param <RX> Any exception type that the body, f, detectably can throw.
+	 * @param f A ToCharFunction to which this instance, wrapped as its
+	 * corresponding functional interface WT, will be passed.
+	 * @throws EX whatever can be thrown by the body of this instance
+	 * @throws RX whatever can be thrown by the body f.
+	 */
 	default <RX extends Throwable>
 	char inCharReturning(ToCharFunction<? super WT, RX> f)
 	throws EX, RX
@@ -163,6 +289,19 @@ public interface Checked<WT, EX extends Throwable>
 		return f.apply(ederWrap());
 	}
 
+	/**
+	 * Like {@link #in in(...)} but where the body returns a {@code float}.
+	 *<p>
+	 * This method is provided for consistency of notation, even though it is
+	 * not strictly needed because Java has no checked-exception-less
+	 * counterpart of {@code ToFloatFunction}.
+	 *
+	 * @param <RX> Any exception type that the body, f, detectably can throw.
+	 * @param f A ToFloatFunction to which this instance, wrapped as its
+	 * corresponding functional interface WT, will be passed.
+	 * @throws EX whatever can be thrown by the body of this instance
+	 * @throws RX whatever can be thrown by the body f.
+	 */
 	default <RX extends Throwable>
 	float inFloatReturning(ToFloatFunction<? super WT, RX> f)
 	throws EX, RX
@@ -174,6 +313,17 @@ public interface Checked<WT, EX extends Throwable>
 	 * Short-circuiting predicate combinators.
 	 */
 
+	/**
+	 * Returns a {@code Predicate} that is the short-circuiting {@code AND} of
+	 * two others.
+	 * @param <T> Greatest-lower-bound parameter type acceptable to first and
+	 * after, and the parameter type of the resulting predicate.
+	 * @param <E> Least upper bound of the exception types thrown by first and
+	 * after, representing the exception types thrown by the resulting
+	 * predicate.
+	 * @param first The predicate to be tested first.
+	 * @param after The predicate to be tested next.
+	 */
 	static <T, E extends Throwable>
 		Predicate<T,E> and(
 			Predicate<? super T, ? extends E> first,
@@ -182,6 +332,17 @@ public interface Checked<WT, EX extends Throwable>
 		return t -> first.test(t) && after.test(t);
 	}
 
+	/**
+	 * Returns a {@code Predicate} that is the short-circuiting {@code OR} of
+	 * two others.
+	 * @param <T> Greatest-lower-bound parameter type acceptable to first and
+	 * after, and the parameter type of the resulting predicate.
+	 * @param <E> Least upper bound of the exception types thrown by first and
+	 * after, representing the exception types thrown by the resulting
+	 * predicate.
+	 * @param first The predicate to be tested first.
+	 * @param after The predicate to be tested next.
+	 */
 	static <T, E extends Throwable>
 		Predicate<T,E> or(
 			Predicate<? super T, ? extends E> first,
@@ -194,6 +355,21 @@ public interface Checked<WT, EX extends Throwable>
 	 * composed() methods.
 	 */
 
+	/**
+	 * Returns a {@code Function} that is the composition of
+	 * two others.
+	 * @param <T> Parameter type of the resulting function, and acceptable as
+	 * parameter of first.
+	 * @param <V> Type subsuming the return type of first, and acceptable as
+	 * parameter of after.
+	 * @param <R> Return type of the composed function, subsuming the return
+	 * type of after.
+	 * @param <E> Least upper bound of the exception types thrown by first and
+	 * after, representing the exception types thrown by the resulting
+	 * function.
+	 * @param first The first function to be applied.
+	 * @param after The function applied to the result of first.
+	 */
 	static <T, R, V, E extends Throwable>
 		Function<T,R,E> composed(
 			Function<? super T, ? extends V, ? extends E> first,
@@ -202,6 +378,19 @@ public interface Checked<WT, EX extends Throwable>
 		return t -> after.apply(first.apply(t));
 	}
 
+	/**
+	 * Returns a {@code BiConsumer} that is the composition of
+	 * two others.
+	 * @param <T> First parameter type of the resulting BiConsumer, acceptable
+	 * as first parameter to both first and after.
+	 * @param <U> Second parameter type of the resulting BiConsumer, acceptable
+	 * as second parameter to both first and after.
+	 * @param <E> Least upper bound of the exception types thrown by first and
+	 * after, representing the exception types thrown by the resulting
+	 * biconsumer.
+	 * @param first The first consumer to be applied.
+	 * @param after The consumer next applied to the same inputs.
+	 */
 	static <T, U, E extends Throwable>
 		BiConsumer<T,U,E> composed(
 			BiConsumer<? super T, ? super U, ? extends E> first,
@@ -214,6 +403,17 @@ public interface Checked<WT, EX extends Throwable>
 		};
 	}
 
+	/**
+	 * Returns a {@code Consumer} that is the composition of
+	 * two others.
+	 * @param <T> Parameter type of the resulting Consumer, acceptable
+	 * as parameter to both first and after.
+	 * @param <E> Least upper bound of the exception types thrown by first and
+	 * after, representing the exception types thrown by the resulting
+	 * consumer.
+	 * @param first The first consumer to be applied.
+	 * @param after The consumer next applied to the same input.
+	 */
 	static <T, E extends Throwable>
 		Consumer<T,E> composed(
 			Consumer<? super T, ? extends E> first,
@@ -226,6 +426,15 @@ public interface Checked<WT, EX extends Throwable>
 		};
 	}
 
+	/**
+	 * Returns a {@code DoubleConsumer} that is the composition of
+	 * two others.
+	 * @param <E> Least upper bound of the exception types thrown by first and
+	 * after, representing the exception types thrown by the resulting
+	 * consumer.
+	 * @param first The first consumer to be applied.
+	 * @param after The consumer next applied to the same input.
+	 */
 	static <E extends Throwable>
 		DoubleConsumer<E> composed(
 			DoubleConsumer<? extends E> first,
@@ -238,6 +447,15 @@ public interface Checked<WT, EX extends Throwable>
 		};
 	}
 
+	/**
+	 * Returns an {@code IntConsumer} that is the composition of
+	 * two others.
+	 * @param <E> Least upper bound of the exception types thrown by first and
+	 * after, representing the exception types thrown by the resulting
+	 * consumer.
+	 * @param first The first consumer to be applied.
+	 * @param after The consumer next applied to the same input.
+	 */
 	static <E extends Throwable>
 		IntConsumer<E> composed(
 			IntConsumer<? extends E> first,
@@ -250,6 +468,15 @@ public interface Checked<WT, EX extends Throwable>
 		};
 	}
 
+	/**
+	 * Returns a {@code LongConsumer} that is the composition of
+	 * two others.
+	 * @param <E> Least upper bound of the exception types thrown by first and
+	 * after, representing the exception types thrown by the resulting
+	 * consumer.
+	 * @param first The first consumer to be applied.
+	 * @param after The consumer next applied to the same input.
+	 */
 	static <E extends Throwable>
 		LongConsumer<E> composed(
 			LongConsumer<? extends E> first,
@@ -306,6 +533,8 @@ public interface Checked<WT, EX extends Throwable>
 	 *    ...
 	 *  }
 	 *</pre>
+	 * @param <E> Least upper bound of exceptions that can be thrown by o
+	 * @param o Lambda or method reference to serve as the close operation.
 	 */
 	static <E extends Exception>
 		AutoCloseable<E> closing(AutoCloseable<E> o)
@@ -318,6 +547,10 @@ public interface Checked<WT, EX extends Throwable>
 	 * that can supply the payload and implements {@code AutoCloseable} using
 	 * the lambda; useful in a {@code try}-with-resources when the payload
 	 * itself does not implement {@code AutoCloseable}.
+	 * @param <T> Type of the payload.
+	 * @param <E> Least upper bound of exceptions that may be thrown at close.
+	 * @param payload Any object.
+	 * @param closer Lambda or method reference to serve as the close operation.
 	 */
 	static <T, E extends Exception>
 		Closing<T,E> closing(T payload, AutoCloseable<E> closer)
@@ -340,6 +573,13 @@ public interface Checked<WT, EX extends Throwable>
 	 * stream's {@code close} method is not declared to throw any. When used as
 	 * intended in a {@code try}-with-resources, any such surprise is bounded
 	 * by the scope of that statement.
+	 * @param <T> Type of the stream elements
+	 * @param <S> Type of the stream
+	 * @param <E> Least upper bound of exceptions that can be thrown by closer,
+	 * and the declared throwable type of the close method of the returned
+	 * Closing instance.
+	 * @param stream Stream to have closer added as an action on close.
+	 * @param closer Runnable to be executed when the returned stream is closed.
 	 */
 	static <T, S extends BaseStream<T,S>, E extends Exception>
 		Closing<S,E> closing(S stream, Runnable<E> closer)
@@ -413,10 +653,18 @@ public interface Checked<WT, EX extends Throwable>
 	 * Runnable.
 	 */
 
+	/**
+	 * Like {@link java.lang.Runnable} but with a body that can throw checked
+	 * exceptions.
+	 * @param <E> Exception type that can be thrown by the body.
+	 */
 	@FunctionalInterface
 	interface Runnable<E extends Throwable>
 	extends Checked<java.lang.Runnable, E>
 	{
+		/**
+		 * Execute the body of this {@code Runnable}.
+		 */
 		void run() throws E;
 
 		@Override
@@ -435,6 +683,15 @@ public interface Checked<WT, EX extends Throwable>
 			};
 		}
 
+		/**
+		 * Shapes a lambda or method reference into an instance of this
+		 * functional interface.
+		 *<p>
+		 * This is simply an identity function that can take the place of a
+		 * more unwieldy cast.
+		 * @param <E> Least upper bound of exception types o can throw.
+		 * @param o The implementing lambda or method reference.
+		 */
 		static <E extends Throwable> Runnable<E> use(Runnable<E> o)
 		{
 			return o;
@@ -445,10 +702,19 @@ public interface Checked<WT, EX extends Throwable>
 	 * Suppliers that have checked-exception-less counterparts in the Java API.
 	 */
 
+	/**
+	 * Like {@link java.util.function.Supplier} but with a body that can throw
+	 * checked exceptions.
+	 * @param <T> Type the supplier will supply.
+	 * @param <E> Exception type that can be thrown by the body.
+	 */
 	@FunctionalInterface
 	interface Supplier<T, E extends Throwable>
 	extends Checked<java.util.function.Supplier<T>, E>
 	{
+		/**
+		 * Get the supplied value.
+		 */
 		T get() throws E;
 
 		@Override
@@ -467,16 +733,33 @@ public interface Checked<WT, EX extends Throwable>
 			};
 		}
 
+		/**
+		 * Shapes a lambda or method reference into an instance of this
+		 * functional interface.
+		 *<p>
+		 * This is simply an identity function that can take the place of a
+		 * more unwieldy cast.
+		 * @param <E> Least upper bound of exception types o can throw.
+		 * @param o The implementing lambda or method reference.
+		 */
 		static <T, E extends Throwable> Supplier<T,E> use(Supplier<T,E> o)
 		{
 			return o;
 		}
 	}
 
+	/**
+	 * Like {@link java.util.function.BooleanSupplier} but with a body that can
+	 * throw checked exceptions.
+	 * @param <E> Exception type that can be thrown by the body.
+	 */
 	@FunctionalInterface
 	interface BooleanSupplier<E extends Throwable>
 	extends Checked<java.util.function.BooleanSupplier, E>
 	{
+		/**
+		 * Get the supplied value.
+		 */
 		boolean getAsBoolean() throws E;
 
 		@Override
@@ -495,6 +778,15 @@ public interface Checked<WT, EX extends Throwable>
 			};
 		}
 
+		/**
+		 * Shapes a lambda or method reference into an instance of this
+		 * functional interface.
+		 *<p>
+		 * This is simply an identity function that can take the place of a
+		 * more unwieldy cast.
+		 * @param <E> Least upper bound of exception types o can throw.
+		 * @param o The implementing lambda or method reference.
+		 */
 		static <E extends Throwable>
 		BooleanSupplier<E> use(BooleanSupplier<E> o)
 		{
@@ -502,10 +794,18 @@ public interface Checked<WT, EX extends Throwable>
 		}
 	}
 
+	/**
+	 * Like {@link java.util.function.DoubleSupplier} but with a body that can
+	 * throw checked exceptions.
+	 * @param <E> Exception type that can be thrown by the body.
+	 */
 	@FunctionalInterface
 	interface DoubleSupplier<E extends Throwable>
 	extends Checked<java.util.function.DoubleSupplier, E>
 	{
+		/**
+		 * Get the supplied value.
+		 */
 		double getAsDouble() throws E;
 
 		@Override
@@ -524,16 +824,33 @@ public interface Checked<WT, EX extends Throwable>
 			};
 		}
 
+		/**
+		 * Shapes a lambda or method reference into an instance of this
+		 * functional interface.
+		 *<p>
+		 * This is simply an identity function that can take the place of a
+		 * more unwieldy cast.
+		 * @param <E> Least upper bound of exception types o can throw.
+		 * @param o The implementing lambda or method reference.
+		 */
 		static <E extends Throwable> DoubleSupplier<E> use(DoubleSupplier<E> o)
 		{
 			return o;
 		}
 	}
 
+	/**
+	 * Like {@link java.util.function.IntSupplier} but with a body that can
+	 * throw checked exceptions.
+	 * @param <E> Exception type that can be thrown by the body.
+	 */
 	@FunctionalInterface
 	interface IntSupplier<E extends Throwable>
 	extends Checked<java.util.function.IntSupplier, E>
 	{
+		/**
+		 * Get the supplied value.
+		 */
 		int getAsInt() throws E;
 
 		@Override
@@ -552,16 +869,33 @@ public interface Checked<WT, EX extends Throwable>
 			};
 		}
 
+		/**
+		 * Shapes a lambda or method reference into an instance of this
+		 * functional interface.
+		 *<p>
+		 * This is simply an identity function that can take the place of a
+		 * more unwieldy cast.
+		 * @param <E> Least upper bound of exception types o can throw.
+		 * @param o The implementing lambda or method reference.
+		 */
 		static <E extends Throwable> IntSupplier<E> use(IntSupplier<E> o)
 		{
 			return o;
 		}
 	}
 
+	/**
+	 * Like {@link java.util.function.LongSupplier} but with a body that can
+	 * throw checked exceptions.
+	 * @param <E> Exception type that can be thrown by the body.
+	 */
 	@FunctionalInterface
 	interface LongSupplier<E extends Throwable>
 	extends Checked<java.util.function.LongSupplier, E>
 	{
+		/**
+		 * Get the supplied value.
+		 */
 		long getAsLong() throws E;
 
 		@Override
@@ -580,6 +914,15 @@ public interface Checked<WT, EX extends Throwable>
 			};
 		}
 
+		/**
+		 * Shapes a lambda or method reference into an instance of this
+		 * functional interface.
+		 *<p>
+		 * This is simply an identity function that can take the place of a
+		 * more unwieldy cast.
+		 * @param <E> Least upper bound of exception types o can throw.
+		 * @param o The implementing lambda or method reference.
+		 */
 		static <E extends Throwable> LongSupplier<E> use(LongSupplier<E> o)
 		{
 			return o;
@@ -590,48 +933,116 @@ public interface Checked<WT, EX extends Throwable>
 	 * Suppliers without checked-exception-less Java API counterparts.
 	 */
 
+	/**
+	 * A supplier of byte-valued results, with a body that can
+	 * throw checked exceptions.
+	 * @param <E> Exception type that can be thrown by the body.
+	 */
 	@FunctionalInterface
 	interface ByteSupplier<E extends Throwable>
 	extends Closing.Trivial<ByteSupplier<E>, E>
 	{
+		/**
+		 * Get the supplied value.
+		 */
 		byte getAsByte() throws E;
 
+		/**
+		 * Shapes a lambda or method reference into an instance of this
+		 * functional interface.
+		 *<p>
+		 * This is simply an identity function that can take the place of a
+		 * more unwieldy cast.
+		 * @param <E> Least upper bound of exception types o can throw.
+		 * @param o The implementing lambda or method reference.
+		 */
 		static <E extends Throwable> ByteSupplier<E> use(ByteSupplier<E> o)
 		{
 			return o;
 		}
 	}
 
+	/**
+	 * A supplier of short-valued results, with a body that can
+	 * throw checked exceptions.
+	 * @param <E> Exception type that can be thrown by the body.
+	 */
 	@FunctionalInterface
 	interface ShortSupplier<E extends Throwable>
 	extends Closing.Trivial<ShortSupplier<E>, E>
 	{
+		/**
+		 * Get the supplied value.
+		 */
 		short getAsShort() throws E;
 
+		/**
+		 * Shapes a lambda or method reference into an instance of this
+		 * functional interface.
+		 *<p>
+		 * This is simply an identity function that can take the place of a
+		 * more unwieldy cast.
+		 * @param <E> Least upper bound of exception types o can throw.
+		 * @param o The implementing lambda or method reference.
+		 */
 		static <E extends Throwable> ShortSupplier<E> use(ShortSupplier<E> o)
 		{
 			return o;
 		}
 	}
 
+	/**
+	 * A supplier of char-valued results, with a body that can
+	 * throw checked exceptions.
+	 * @param <E> Exception type that can be thrown by the body.
+	 */
 	@FunctionalInterface
 	interface CharSupplier<E extends Throwable>
 	extends Closing.Trivial<CharSupplier<E>, E>
 	{
+		/**
+		 * Get the supplied value.
+		 */
 		char getAsChar() throws E;
 
+		/**
+		 * Shapes a lambda or method reference into an instance of this
+		 * functional interface.
+		 *<p>
+		 * This is simply an identity function that can take the place of a
+		 * more unwieldy cast.
+		 * @param <E> Least upper bound of exception types o can throw.
+		 * @param o The implementing lambda or method reference.
+		 */
 		static <E extends Throwable> CharSupplier<E> use(CharSupplier<E> o)
 		{
 			return o;
 		}
 	}
 
+	/**
+	 * A supplier of float-valued results, with a body that can
+	 * throw checked exceptions.
+	 * @param <E> Exception type that can be thrown by the body.
+	 */
 	@FunctionalInterface
 	interface FloatSupplier<E extends Throwable>
 	extends Closing.Trivial<FloatSupplier<E>, E>
 	{
+		/**
+		 * Get the supplied value.
+		 */
 		float getAsFloat() throws E;
 
+		/**
+		 * Shapes a lambda or method reference into an instance of this
+		 * functional interface.
+		 *<p>
+		 * This is simply an identity function that can take the place of a
+		 * more unwieldy cast.
+		 * @param <E> Least upper bound of exception types o can throw.
+		 * @param o The implementing lambda or method reference.
+		 */
 		static <E extends Throwable> FloatSupplier<E> use(FloatSupplier<E> o)
 		{
 			return o;
@@ -642,10 +1053,20 @@ public interface Checked<WT, EX extends Throwable>
 	 * Functions that have checked-exception-less counterparts in the Java API.
 	 */
 
+	/**
+	 * Like {@link java.util.function.Function} but with a body that can throw
+	 * checked exceptions.
+	 * @param <T> Type of the function's parameter.
+	 * @param <R> Type of the function's result.
+	 * @param <E> Exception type that can be thrown by the body.
+	 */
 	@FunctionalInterface
 	interface Function<T,R,E extends Throwable>
 	extends Checked<java.util.function.Function<T,R>, E>
 	{
+		/**
+		 * Applies this function to the given argument.
+		 */
 		R apply(T t) throws E;
 
 		@Override
@@ -664,6 +1085,15 @@ public interface Checked<WT, EX extends Throwable>
 			};
 		}
 
+		/**
+		 * Shapes a lambda or method reference into an instance of this
+		 * functional interface.
+		 *<p>
+		 * This is simply an identity function that can take the place of a
+		 * more unwieldy cast.
+		 * @param <E> Least upper bound of exception types o can throw.
+		 * @param o The implementing lambda or method reference.
+		 */
 		static <T, R, E extends Throwable>
 		Function<T,R,E> use(Function<T,R,E> o)
 		{
@@ -671,10 +1101,19 @@ public interface Checked<WT, EX extends Throwable>
 		}
 	}
 
+	/**
+	 * Like {@link java.util.function.ToDoubleFunction} but with a body that can
+	 * throw checked exceptions.
+	 * @param <T> Type of the function's parameter.
+	 * @param <E> Exception type that can be thrown by the body.
+	 */
 	@FunctionalInterface
 	interface ToDoubleFunction<T,E extends Throwable>
 	extends Checked<java.util.function.ToDoubleFunction<T>, E>
 	{
+		/**
+		 * Applies this function to the given argument.
+		 */
 		double apply(T t) throws E;
 
 		@Override
@@ -693,6 +1132,15 @@ public interface Checked<WT, EX extends Throwable>
 			};
 		}
 
+		/**
+		 * Shapes a lambda or method reference into an instance of this
+		 * functional interface.
+		 *<p>
+		 * This is simply an identity function that can take the place of a
+		 * more unwieldy cast.
+		 * @param <E> Least upper bound of exception types o can throw.
+		 * @param o The implementing lambda or method reference.
+		 */
 		static <T, E extends Throwable>
 		ToDoubleFunction<T,E> use(ToDoubleFunction<T,E> o)
 		{
@@ -700,10 +1148,19 @@ public interface Checked<WT, EX extends Throwable>
 		}
 	}
 
+	/**
+	 * Like {@link java.util.function.ToIntFunction} but with a body that can
+	 * throw checked exceptions.
+	 * @param <T> Type of the function's parameter.
+	 * @param <E> Exception type that can be thrown by the body.
+	 */
 	@FunctionalInterface
 	interface ToIntFunction<T,E extends Throwable>
 	extends Checked<java.util.function.ToIntFunction<T>, E>
 	{
+		/**
+		 * Applies this function to the given argument.
+		 */
 		int apply(T t) throws E;
 
 		@Override
@@ -722,6 +1179,15 @@ public interface Checked<WT, EX extends Throwable>
 			};
 		}
 
+		/**
+		 * Shapes a lambda or method reference into an instance of this
+		 * functional interface.
+		 *<p>
+		 * This is simply an identity function that can take the place of a
+		 * more unwieldy cast.
+		 * @param <E> Least upper bound of exception types o can throw.
+		 * @param o The implementing lambda or method reference.
+		 */
 		static <T, E extends Throwable>
 		ToIntFunction<T,E> use(ToIntFunction<T,E> o)
 		{
@@ -729,10 +1195,19 @@ public interface Checked<WT, EX extends Throwable>
 		}
 	}
 
+	/**
+	 * Like {@link java.util.function.ToLongFunction} but with a body that can
+	 * throw checked exceptions.
+	 * @param <T> Type of the function's parameter.
+	 * @param <E> Exception type that can be thrown by the body.
+	 */
 	@FunctionalInterface
 	interface ToLongFunction<T,E extends Throwable>
 	extends Checked<java.util.function.ToLongFunction<T>, E>
 	{
+		/**
+		 * Applies this function to the given argument.
+		 */
 		long apply(T t) throws E;
 
 		@Override
@@ -751,6 +1226,15 @@ public interface Checked<WT, EX extends Throwable>
 			};
 		}
 
+		/**
+		 * Shapes a lambda or method reference into an instance of this
+		 * functional interface.
+		 *<p>
+		 * This is simply an identity function that can take the place of a
+		 * more unwieldy cast.
+		 * @param <E> Least upper bound of exception types o can throw.
+		 * @param o The implementing lambda or method reference.
+		 */
 		static <T, E extends Throwable>
 		ToLongFunction<T,E> use(ToLongFunction<T,E> o)
 		{
@@ -758,12 +1242,21 @@ public interface Checked<WT, EX extends Throwable>
 		}
 	}
 
+	/**
+	 * Like {@link java.util.function.Predicate} but with a body that can
+	 * throw checked exceptions.
+	 * @param <T> Type of the predicate's parameter.
+	 * @param <E> Exception type that can be thrown by the body.
+	 */
 	@FunctionalInterface
 	interface Predicate<T,E extends Throwable>
 	extends Checked<java.util.function.Predicate<T>, E>
 	{
 		boolean test(T t) throws E;
 
+		/**
+		 * Evaluates this predicate on the given argument.
+		 */
 		default Predicate<T,E> negate()
 		{
 			return t -> ! test(t);
@@ -785,6 +1278,15 @@ public interface Checked<WT, EX extends Throwable>
 			};
 		}
 
+		/**
+		 * Shapes a lambda or method reference into an instance of this
+		 * functional interface.
+		 *<p>
+		 * This is simply an identity function that can take the place of a
+		 * more unwieldy cast.
+		 * @param <E> Least upper bound of exception types o can throw.
+		 * @param o The implementing lambda or method reference.
+		 */
 		static <T, E extends Throwable>
 		Predicate<T,E> use(Predicate<T,E> o)
 		{
@@ -796,12 +1298,30 @@ public interface Checked<WT, EX extends Throwable>
 	 * Functions without checked-exception-less Java API counterparts.
 	 */
 
+	/**
+	 * Represents a function that produces a byte-valued result and can
+	 * throw checked exceptions.
+	 * @param <T> Type of the function's parameter.
+	 * @param <E> Exception type that can be thrown by the body.
+	 */
 	@FunctionalInterface
 	interface ToByteFunction<T,E extends Throwable>
 	extends Closing.Trivial<ToByteFunction<T,E>, E>
 	{
+		/**
+		 * Applies this function to the given argument.
+		 */
 		byte apply(T t) throws E;
 
+		/**
+		 * Shapes a lambda or method reference into an instance of this
+		 * functional interface.
+		 *<p>
+		 * This is simply an identity function that can take the place of a
+		 * more unwieldy cast.
+		 * @param <E> Least upper bound of exception types o can throw.
+		 * @param o The implementing lambda or method reference.
+		 */
 		static <T, E extends Throwable>
 		ToByteFunction<T,E> use(ToByteFunction<T,E> o)
 		{
@@ -809,12 +1329,30 @@ public interface Checked<WT, EX extends Throwable>
 		}
 	}
 
+	/**
+	 * Represents a function that produces a short-valued result and can
+	 * throw checked exceptions.
+	 * @param <T> Type of the function's parameter.
+	 * @param <E> Exception type that can be thrown by the body.
+	 */
 	@FunctionalInterface
 	interface ToShortFunction<T,E extends Throwable>
 	extends Closing.Trivial<ToShortFunction<T,E>, E>
 	{
+		/**
+		 * Applies this function to the given argument.
+		 */
 		short apply(T t) throws E;
 
+		/**
+		 * Shapes a lambda or method reference into an instance of this
+		 * functional interface.
+		 *<p>
+		 * This is simply an identity function that can take the place of a
+		 * more unwieldy cast.
+		 * @param <E> Least upper bound of exception types o can throw.
+		 * @param o The implementing lambda or method reference.
+		 */
 		static <T, E extends Throwable>
 		ToShortFunction<T,E> use(ToShortFunction<T,E> o)
 		{
@@ -822,12 +1360,30 @@ public interface Checked<WT, EX extends Throwable>
 		}
 	}
 
+	/**
+	 * Represents a function that produces a char-valued result and can
+	 * throw checked exceptions.
+	 * @param <T> Type of the function's parameter.
+	 * @param <E> Exception type that can be thrown by the body.
+	 */
 	@FunctionalInterface
 	interface ToCharFunction<T,E extends Throwable>
 	extends Closing.Trivial<ToCharFunction<T,E>, E>
 	{
+		/**
+		 * Applies this function to the given argument.
+		 */
 		char apply(T t) throws E;
 
+		/**
+		 * Shapes a lambda or method reference into an instance of this
+		 * functional interface.
+		 *<p>
+		 * This is simply an identity function that can take the place of a
+		 * more unwieldy cast.
+		 * @param <E> Least upper bound of exception types o can throw.
+		 * @param o The implementing lambda or method reference.
+		 */
 		static <T, E extends Throwable>
 		ToCharFunction<T,E> use(ToCharFunction<T,E> o)
 		{
@@ -835,12 +1391,30 @@ public interface Checked<WT, EX extends Throwable>
 		}
 	}
 
+	/**
+	 * Represents a function that produces a float-valued result and can
+	 * throw checked exceptions.
+	 * @param <T> Type of the function's parameter.
+	 * @param <E> Exception type that can be thrown by the body.
+	 */
 	@FunctionalInterface
 	interface ToFloatFunction<T,E extends Throwable>
 	extends Closing.Trivial<ToFloatFunction<T,E>, E>
 	{
+		/**
+		 * Applies this function to the given argument.
+		 */
 		float apply(T t) throws E;
 
+		/**
+		 * Shapes a lambda or method reference into an instance of this
+		 * functional interface.
+		 *<p>
+		 * This is simply an identity function that can take the place of a
+		 * more unwieldy cast.
+		 * @param <E> Least upper bound of exception types o can throw.
+		 * @param o The implementing lambda or method reference.
+		 */
 		static <T, E extends Throwable>
 		ToFloatFunction<T,E> use(ToFloatFunction<T,E> o)
 		{
@@ -852,10 +1426,20 @@ public interface Checked<WT, EX extends Throwable>
 	 * Consumers that have checked-exception-less counterparts in the Java API.
 	 */
 
+	/**
+	 * Like {@link java.util.function.BiConsumer} but with a body that can
+	 * throw checked exceptions.
+	 * @param <T> Type of the first argument to the operation.
+	 * @param <U> Type of the second argument to the operation.
+	 * @param <E> Exception type that can be thrown by the body.
+	 */
 	@FunctionalInterface
 	interface BiConsumer<T,U,E extends Throwable>
 	extends Checked<java.util.function.BiConsumer<T,U>, E>
 	{
+		/**
+		 * Performs this operation on the given arguments.
+		 */
 		void accept(T t, U u) throws E;
 
 		@Override
@@ -874,6 +1458,15 @@ public interface Checked<WT, EX extends Throwable>
 			};
 		}
 
+		/**
+		 * Shapes a lambda or method reference into an instance of this
+		 * functional interface.
+		 *<p>
+		 * This is simply an identity function that can take the place of a
+		 * more unwieldy cast.
+		 * @param <E> Least upper bound of exception types o can throw.
+		 * @param o The implementing lambda or method reference.
+		 */
 		static <T, U, E extends Throwable> BiConsumer<T,U,E>
 		use(BiConsumer<T,U,E> o)
 		{
@@ -881,10 +1474,19 @@ public interface Checked<WT, EX extends Throwable>
 		}
 	}
 
+	/**
+	 * Like {@link java.util.function.Consumer} but with a body that can
+	 * throw checked exceptions.
+	 * @param <T> Type of the input to the operation.
+	 * @param <E> Exception type that can be thrown by the body.
+	 */
 	@FunctionalInterface
 	interface Consumer<T,E extends Throwable>
 	extends Checked<java.util.function.Consumer<T>, E>
 	{
+		/**
+		 * Performs this operation on the given argument.
+		 */
 		void accept(T t) throws E;
 
 		@Override
@@ -903,16 +1505,33 @@ public interface Checked<WT, EX extends Throwable>
 			};
 		}
 
+		/**
+		 * Shapes a lambda or method reference into an instance of this
+		 * functional interface.
+		 *<p>
+		 * This is simply an identity function that can take the place of a
+		 * more unwieldy cast.
+		 * @param <E> Least upper bound of exception types o can throw.
+		 * @param o The implementing lambda or method reference.
+		 */
 		static <T, E extends Throwable> Consumer<T,E> use(Consumer<T,E> o)
 		{
 			return o;
 		}
 	}
 
+	/**
+	 * Like {@link java.util.function.DoubleConsumer} but with a body that can
+	 * throw checked exceptions.
+	 * @param <E> Exception type that can be thrown by the body.
+	 */
 	@FunctionalInterface
 	interface DoubleConsumer<E extends Throwable>
 	extends Checked<java.util.function.DoubleConsumer, E>
 	{
+		/**
+		 * Performs this operation on the given argument.
+		 */
 		void accept(double value) throws E;
 
 		@Override
@@ -931,16 +1550,33 @@ public interface Checked<WT, EX extends Throwable>
 			};
 		}
 
+		/**
+		 * Shapes a lambda or method reference into an instance of this
+		 * functional interface.
+		 *<p>
+		 * This is simply an identity function that can take the place of a
+		 * more unwieldy cast.
+		 * @param <E> Least upper bound of exception types o can throw.
+		 * @param o The implementing lambda or method reference.
+		 */
 		static <E extends Throwable> DoubleConsumer<E> use(DoubleConsumer<E> o)
 		{
 			return o;
 		}
 	}
 
+	/**
+	 * Like {@link java.util.function.IntConsumer} but with a body that can
+	 * throw checked exceptions.
+	 * @param <E> Exception type that can be thrown by the body.
+	 */
 	@FunctionalInterface
 	interface IntConsumer<E extends Throwable>
 	extends Checked<java.util.function.IntConsumer, E>
 	{
+		/**
+		 * Performs this operation on the given argument.
+		 */
 		void accept(int value) throws E;
 
 		@Override
@@ -959,16 +1595,33 @@ public interface Checked<WT, EX extends Throwable>
 			};
 		}
 
+		/**
+		 * Shapes a lambda or method reference into an instance of this
+		 * functional interface.
+		 *<p>
+		 * This is simply an identity function that can take the place of a
+		 * more unwieldy cast.
+		 * @param <E> Least upper bound of exception types o can throw.
+		 * @param o The implementing lambda or method reference.
+		 */
 		static <E extends Throwable> IntConsumer<E> use(IntConsumer<E> o)
 		{
 			return o;
 		}
 	}
 
+	/**
+	 * Like {@link java.util.function.LongConsumer} but with a body that can
+	 * throw checked exceptions.
+	 * @param <E> Exception type that can be thrown by the body.
+	 */
 	@FunctionalInterface
 	interface LongConsumer<E extends Throwable>
 	extends Checked<java.util.function.LongConsumer, E>
 	{
+		/**
+		 * Performs this operation on the given argument.
+		 */
 		void accept(long value) throws E;
 
 		@Override
@@ -987,6 +1640,15 @@ public interface Checked<WT, EX extends Throwable>
 			};
 		}
 
+		/**
+		 * Shapes a lambda or method reference into an instance of this
+		 * functional interface.
+		 *<p>
+		 * This is simply an identity function that can take the place of a
+		 * more unwieldy cast.
+		 * @param <E> Least upper bound of exception types o can throw.
+		 * @param o The implementing lambda or method reference.
+		 */
 		static <E extends Throwable> LongConsumer<E> use(LongConsumer<E> o)
 		{
 			return o;
@@ -997,12 +1659,29 @@ public interface Checked<WT, EX extends Throwable>
 	 * Consumers without checked-exception-less counterparts in the Java API.
 	 */
 
+	/**
+	 * Represents an operation that accepts a single boolean-valued argument
+	 * and can throw checked exceptions.
+	 * @param <E> Exception type that can be thrown by the body.
+	 */
 	@FunctionalInterface
 	interface BooleanConsumer<E extends Throwable>
 	extends Closing.Trivial<BooleanConsumer<E>, E>
 	{
+		/**
+		 * Performs this operation on the given argument.
+		 */
 		void accept(boolean value) throws E;
 
+		/**
+		 * Shapes a lambda or method reference into an instance of this
+		 * functional interface.
+		 *<p>
+		 * This is simply an identity function that can take the place of a
+		 * more unwieldy cast.
+		 * @param <E> Least upper bound of exception types o can throw.
+		 * @param o The implementing lambda or method reference.
+		 */
 		static <E extends Throwable>
 		BooleanConsumer<E> use(BooleanConsumer<E> o)
 		{
@@ -1010,48 +1689,116 @@ public interface Checked<WT, EX extends Throwable>
 		}
 	}
 
+	/**
+	 * Represents an operation that accepts a single byte-valued argument
+	 * and can throw checked exceptions.
+	 * @param <E> Exception type that can be thrown by the body.
+	 */
 	@FunctionalInterface
 	interface ByteConsumer<E extends Throwable>
 	extends Closing.Trivial<ByteConsumer<E>, E>
 	{
+		/**
+		 * Performs this operation on the given argument.
+		 */
 		void accept(byte value) throws E;
 
+		/**
+		 * Shapes a lambda or method reference into an instance of this
+		 * functional interface.
+		 *<p>
+		 * This is simply an identity function that can take the place of a
+		 * more unwieldy cast.
+		 * @param <E> Least upper bound of exception types o can throw.
+		 * @param o The implementing lambda or method reference.
+		 */
 		static <E extends Throwable> ByteConsumer<E> use(ByteConsumer<E> o)
 		{
 			return o;
 		}
 	}
 
+	/**
+	 * Represents an operation that accepts a single short-valued argument
+	 * and can throw checked exceptions.
+	 * @param <E> Exception type that can be thrown by the body.
+	 */
 	@FunctionalInterface
 	interface ShortConsumer<E extends Throwable>
 	extends Closing.Trivial<ShortConsumer<E>, E>
 	{
+		/**
+		 * Performs this operation on the given argument.
+		 */
 		void accept(short value) throws E;
 
+		/**
+		 * Shapes a lambda or method reference into an instance of this
+		 * functional interface.
+		 *<p>
+		 * This is simply an identity function that can take the place of a
+		 * more unwieldy cast.
+		 * @param <E> Least upper bound of exception types o can throw.
+		 * @param o The implementing lambda or method reference.
+		 */
 		static <E extends Throwable> ShortConsumer<E> use(ShortConsumer<E> o)
 		{
 			return o;
 		}
 	}
 
+	/**
+	 * Represents an operation that accepts a single char-valued argument
+	 * and can throw checked exceptions.
+	 * @param <E> Exception type that can be thrown by the body.
+	 */
 	@FunctionalInterface
 	interface CharConsumer<E extends Throwable>
 	extends Closing.Trivial<CharConsumer<E>, E>
 	{
+		/**
+		 * Performs this operation on the given argument.
+		 */
 		void accept(char value) throws E;
 
+		/**
+		 * Shapes a lambda or method reference into an instance of this
+		 * functional interface.
+		 *<p>
+		 * This is simply an identity function that can take the place of a
+		 * more unwieldy cast.
+		 * @param <E> Least upper bound of exception types o can throw.
+		 * @param o The implementing lambda or method reference.
+		 */
 		static <E extends Throwable> CharConsumer<E> use(CharConsumer<E> o)
 		{
 			return o;
 		}
 	}
 
+	/**
+	 * Represents an operation that accepts a single float-valued argument
+	 * and can throw checked exceptions.
+	 * @param <E> Exception type that can be thrown by the body.
+	 */
 	@FunctionalInterface
 	interface FloatConsumer<E extends Throwable>
 	extends Closing.Trivial<FloatConsumer<E>, E>
 	{
+		/**
+		 * Performs this operation on the given argument.
+		 */
 		void accept(float value) throws E;
 
+		/**
+		 * Shapes a lambda or method reference into an instance of this
+		 * functional interface.
+		 *<p>
+		 * This is simply an identity function that can take the place of a
+		 * more unwieldy cast.
+		 * @param <E> Least upper bound of exception types o can throw.
+		 * @param o The implementing lambda or method reference.
+		 */
 		static <E extends Throwable> FloatConsumer<E> use(FloatConsumer<E> o)
 		{
 			return o;
@@ -1068,8 +1815,25 @@ public interface Checked<WT, EX extends Throwable>
 	 * value-based classes, and they will behave.
 	 */
 
+	/**
+	 * Head of a family of {@link java.util.Optional Optional}-like types
+	 * covering the Java primitives that the {@code java.util.Optional...}
+	 * classes do not cover, and whose methods that expect functional interfaces
+	 * will accept the checked-exception versions declared here.
+	 *<p>
+	 * Each {@code Optional}<em>Foo</em> class here should be treated as if
+	 * it were a Java "value-based" class; that they might have this class as
+	 * an ancestor, or any superclass/subclass relationships at all, may change
+	 * and should not be relied on. It may be convenient to
+	 * {@code import static} the {@code ofNullable} methods of this class,
+	 * however, which even cover the {@code java.util}-supplied primitive
+	 * optionals.
+	 */
 	abstract class OptionalBase
 	{
+		/**
+		 * If a value is present, returns true, otherwise false.
+		 */
 		public boolean isPresent()
 		{
 			return false;
@@ -1098,48 +1862,80 @@ public interface Checked<WT, EX extends Throwable>
 			return getClass().getSimpleName() + ".empty";
 		}
 
+		/**
+		 * Return an {@code OptionalDouble} representing the argument, empty
+		 * if the argument is null.
+		 */
 		public static OptionalDouble ofNullable(Double value)
 		{
 			return null == value ?
 				OptionalDouble.empty() : OptionalDouble.of(value);
 		}
 
+		/**
+		 * Return an {@code OptionalInt} representing the argument, empty
+		 * if the argument is null.
+		 */
 		public static OptionalInt ofNullable(Integer value)
 		{
 			return null == value ?
 				OptionalInt.empty() : OptionalInt.of(value);
 		}
 
+		/**
+		 * Return an {@code OptionalLong} representing the argument, empty
+		 * if the argument is null.
+		 */
 		public static OptionalLong ofNullable(Long value)
 		{
 			return null == value ?
 				OptionalLong.empty() : OptionalLong.of(value);
 		}
 
+		/**
+		 * Return an {@code OptionalBoolean} representing the argument, empty
+		 * if the argument is null.
+		 */
 		public static OptionalBoolean ofNullable(Boolean value)
 		{
 			return null == value ?
 				OptionalBoolean.EMPTY : OptionalBoolean.of(value);
 		}
 
+		/**
+		 * Return an {@code OptionalByte} representing the argument, empty
+		 * if the argument is null.
+		 */
 		public static OptionalByte ofNullable(Byte value)
 		{
 			return null == value ?
 				OptionalByte.EMPTY : OptionalByte.of(value);
 		}
 
+		/**
+		 * Return an {@code OptionalShort} representing the argument, empty
+		 * if the argument is null.
+		 */
 		public static OptionalShort ofNullable(Short value)
 		{
 			return null == value ?
 				OptionalShort.EMPTY : OptionalShort.of(value);
 		}
 
+		/**
+		 * Return an {@code OptionalChar} representing the argument, empty
+		 * if the argument is null.
+		 */
 		public static OptionalChar ofNullable(Character value)
 		{
 			return null == value ?
 				OptionalChar.EMPTY : OptionalChar.of(value);
 		}
 
+		/**
+		 * Return an {@code OptionalFloat} representing the argument, empty
+		 * if the argument is null.
+		 */
 		public static OptionalFloat ofNullable(Float value)
 		{
 			return null == value ?
@@ -1147,10 +1943,27 @@ public interface Checked<WT, EX extends Throwable>
 		}
 	}
 
+	/**
+	 * A container object which may or may not contain a {@code boolean} value.
+	 */
 	class OptionalBoolean extends OptionalBase
 	{
+		/**
+		 * An empty {@code OptionalBoolean}, for convenience; not to be used in
+		 * identity-sensitive operations.
+		 */
 		public static final OptionalBoolean EMPTY = new OptionalBoolean();
+
+		/**
+		 * An {@code OptionalBoolean} containing {@code false}, for convenience;
+		 * not to be used in identity-sensitive operations.
+		 */
 		public static final OptionalBoolean FALSE = new False();
+
+		/**
+		 * An {@code OptionalBoolean} containing {@code true}, for convenience;
+		 * not to be used in identity-sensitive operations.
+		 */
 		public static final OptionalBoolean TRUE  = new True();
 
 		private OptionalBoolean()
@@ -1299,8 +2112,15 @@ public interface Checked<WT, EX extends Throwable>
 		}
 	}
 
+	/**
+	 * A container object which may or may not contain a {@code byte} value.
+	 */
 	class OptionalByte extends OptionalBase
 	{
+		/**
+		 * An empty {@code OptionalByte}, for convenience; not to be used in
+		 * identity-sensitive operations.
+		 */
 		public static final OptionalByte EMPTY = new OptionalByte();
 
 		private OptionalByte()
@@ -1430,8 +2250,15 @@ public interface Checked<WT, EX extends Throwable>
 		}
 	}
 
+	/**
+	 * A container object which may or may not contain a {@code short} value.
+	 */
 	class OptionalShort extends OptionalBase
 	{
+		/**
+		 * An empty {@code OptionalShort}, for convenience; not to be used in
+		 * identity-sensitive operations.
+		 */
 		public static final OptionalShort EMPTY = new OptionalShort();
 
 		private OptionalShort()
@@ -1562,8 +2389,15 @@ public interface Checked<WT, EX extends Throwable>
 		}
 	}
 
+	/**
+	 * A container object which may or may not contain a {@code char} value.
+	 */
 	class OptionalChar extends OptionalBase
 	{
+		/**
+		 * An empty {@code OptionalChar}, for convenience; not to be used in
+		 * identity-sensitive operations.
+		 */
 		public static final OptionalChar EMPTY = new OptionalChar();
 
 		private OptionalChar()
@@ -1693,8 +2527,15 @@ public interface Checked<WT, EX extends Throwable>
 		}
 	}
 
+	/**
+	 * A container object which may or may not contain a {@code float} value.
+	 */
 	class OptionalFloat extends OptionalBase
 	{
+		/**
+		 * An empty {@code OptionalFloat}, for convenience; not to be used in
+		 * identity-sensitive operations.
+		 */
 		public static final OptionalFloat EMPTY = new OptionalFloat();
 
 		private OptionalFloat()

--- a/pljava/src/main/java/org/postgresql/pljava/internal/EntryPoints.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/EntryPoints.java
@@ -12,27 +12,47 @@
 package org.postgresql.pljava.internal;
 
 import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodType;
+import static java.lang.invoke.MethodType.methodType;
+
+import static java.security.AccessController.doPrivileged;
+import java.security.PrivilegedAction;
 
 import java.sql.SQLData;
 import java.sql.SQLInput;
 import java.sql.SQLOutput;
 
+import static java.util.Objects.requireNonNull;
+
+import org.postgresql.pljava.internal.UncheckedException;
+import static org.postgresql.pljava.internal.UncheckedException.unchecked;
+
+/*
+ * PrivilegedAction is used here in preference to PrivilegedExceptionAction,
+ * because a PrivilegedActionException can only wrap an Exception, but method
+ * handle invocation is declared to throw any Throwable. So there needs to be
+ * wrapping done even with PrivilegedExceptionAction, and whatever is wrapped
+ * as a runtime exception will propagate up through PrivilegedAction just fine,
+ * leaving only one flavor of wrapping to deal with rather than two.
+ */
+
 /**
  * A class to consolidate entry points from C to PL/Java functions.
  *<p>
- * The methods in this class can be private, as they are invoked only from C
- * via JNI, not from Java.
+ * The *invoke methods in this class can be private, as they are invoked only
+ * from C via JNI, not from Java.
  *<p>
- * The primary entry points are {@code refInvoke} (for a target method returning
- * any reference type) and {@code invoke} (for a target method with any other
- * return type, including {@code void}). The supplied method handles, as
+ * The primary entry point is {@code invoke}. The supplied
+ * {@code PrivilegedAction}, as
  * obtained from {@code Function.create}, may have bound references to static
  * parameter areas, and will fetch the actual parameters from there to the
  * stack before invoking the (potentially reentrant) target method. Primitive
  * return values are then stored (after the potentially reentrant method has
  * returned) in the first slot of the static parameter area, to allow a single
- * {@code void}-returning {@code invoke} method to cover those cases, rather
- * than versions for every primitive return type.
+ * {@code Object}-returning {@code invoke} method to cover those cases, rather
+ * than versions for references, every primitive return type, and {@code void}.
+ * The {@code PrivilegedAction} is expected to return null for a {@code void}
+ * or primitive-typed target.
  *<p>
  * The remaining methods here are for user-defined type (UDT) support. For now,
  * those are not consolidated into the {@code invoke}/{@code refInvoke} pattern,
@@ -42,28 +62,73 @@ import java.sql.SQLOutput;
  */
 class EntryPoints
 {
+	private static final MethodType s_expectedType = methodType(Object.class);
+
 	/**
-	 * Entry point for any PL/Java function returning a reference type.
-	 * @param mh MethodHandle obtained from Function.create that will push the
-	 * actual parameters and call the target method.
-	 * @return The value returned by the target method.
+	 * Wrap a {@code MethodHandle} in a {@code PrivilegedAction} suitable for
+	 * passing directly to {@link #invoke invoke()}.
+	 *<p>
+	 * The supplied method handle must have type {@code ()Object}, and fetch any
+	 * parameter values needed by its target from bound-in references to the
+	 * static reference and primitive parameter areas. If its ultimate target
+	 * has {@code void} or a primitive return type, the handle must be
+	 * constructed to return null, storing any primitive value returned into
+	 * the first static primitive-parameter slot.
+	 *<p>
+	 * The invoker is a {@code PrivilegedAction} and therefore can throw only
+	 * unchecked exceptions, but can throw {@code UncheckedException},
+	 * which may wrap anything. The {@code invoke} method will unwrap it.
 	 */
-	private static Object refInvoke(MethodHandle mh) throws Throwable
+	static PrivilegedAction<Object> invoker(MethodHandle mh)
 	{
-		return mh.invokeExact();
+		if ( ! s_expectedType.equals(mh.type()) )
+			throw new IllegalArgumentException(
+				"invoker() requires a MethodHandle with type ()Object");
+
+		/*
+		 * The EntryPoints class is specially loaded early in PL/Java's startup
+		 * to have unrestricted permissions, so that PL/Java user code can be
+		 * granted permissions as desired in the policy and be able to use those
+		 * without fussing with doPrivileged or having to grant the same
+		 * permissions redundantly to PL/Java itself.
+		 *
+		 * Lambdas end up looking like distinct classes under the hood, but the
+		 * "class" of a lambda is given the same protection domain as its host
+		 * class, so the lambda created here shares the EntryPoints class's own
+		 * specialness, making the scheme Just Work.
+		 */
+		return () ->
+		{
+			try
+			{
+				return mh.invokeExact();
+			}
+			catch ( Throwable t )
+			{
+				throw unchecked(t);
+			}
+		};
 	}
 
 	/**
-	 * Entry point for a PL/Java function with any non-reference return type,
-	 * including {@code void}.
-	 * If the target method's return type is not {@code void}, the value will be
-	 * returned in the first slot of the static parameter area.
-	 * @param mh MethodHandle obtained from Function.create that will push the
-	 * actual parameters and call the target method.
+	 * Entry point for a general PL/Java function.
+	 * @param target PrivilegedAction obtained from Function.create that will
+	 * push the actual parameters and call the target method.
+	 * @return The value returned by the target method, or null if the method
+	 * has void type or returns a primitive (which will have been returned in
+	 * the first static primitive parameter slot).
 	 */
-	private static void invoke(MethodHandle mh) throws Throwable
+	private static Object invoke(PrivilegedAction<Object> target)
+	throws Throwable
 	{
-		mh.invokeExact();
+		try
+		{
+			return doPrivileged(target);
+		}
+		catch ( UncheckedException e )
+		{
+			throw e.unwrap();
+		}
 	}
 
 	/**

--- a/pljava/src/main/java/org/postgresql/pljava/internal/Function.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/Function.java
@@ -194,7 +194,7 @@ public class Function
 		if ( ! isMultiCall  &&  retTypeIsOutParameter )
 			++ rtIdx;
 
-		Class<?>[] pTypes = new Class[ rtIdx ];
+		Class<?>[] pTypes = new Class<?>[ rtIdx ];
 
 		for ( int i = 0 ; i < rtIdx ; ++ i )
 			pTypes[i] = loadClass(schemaLoader, jTypes[i]);
@@ -1112,7 +1112,7 @@ public class Function
 	 * The access control context of the {@code Invocable} returned here is used
 	 * at the corresponding entry point; the payload is not.
 	 */
-	private static Invocable udtWriteHandle(
+	private static Invocable<?> udtWriteHandle(
 		Class<? extends SQLData> clazz, String language, boolean trusted)
 	throws SQLException
 	{
@@ -1127,7 +1127,7 @@ public class Function
 	 * The access control context of the {@code Invocable} returned here is used
 	 * at the corresponding entry point; the payload is not.
 	 */
-	private static Invocable udtToStringHandle(
+	private static Invocable<?> udtToStringHandle(
 		Class<? extends SQLData> clazz, String language, boolean trusted)
 	throws SQLException
 	{
@@ -1149,7 +1149,7 @@ public class Function
 	 * assigned here will be in effect for both the constructor and the
 	 * {@code readSQL} call.
 	 */
-	private static Invocable udtReadHandle(
+	private static Invocable<?> udtReadHandle(
 		Class<? extends SQLData> clazz, String language, boolean trusted)
 	throws SQLException
 	{
@@ -1180,7 +1180,7 @@ public class Function
 	 * a NUL-terminated storage form, so it gets its own dedicated entry point
 	 * and does not use the static parameter area.
 	 */
-	private static Invocable udtParseHandle(
+	private static Invocable<?> udtParseHandle(
 		Class<? extends SQLData> clazz, String language, boolean trusted)
 	throws SQLException
 	{
@@ -1212,7 +1212,7 @@ public class Function
 	 * {@code Invocable} for invoking the method, or null in the
 	 * case of a UDT.
 	 */
-	public static Invocable create(
+	public static Invocable<?> create(
 		long wrappedPtr, ResultSet procTup, String langName, String schemaName,
 		boolean trusted, boolean calledAsTrigger,
 		boolean forValidator, boolean checkBody)
@@ -1253,7 +1253,7 @@ public class Function
 	 * @return an Invocable to invoke the implementing method, or
 	 * null in the case of a UDT
 	 */
-	private static Invocable init(
+	private static Invocable<?> init(
 		long wrappedPtr, Matcher info, ResultSet procTup,
 		Identifier.Simple schema, boolean calledAsTrigger, boolean forValidator,
 		String language, boolean trusted)
@@ -1836,7 +1836,7 @@ public class Function
 			}
 		}
 
-		Type resolve(TypeVariable v)
+		Type resolve(TypeVariable<?> v)
 		{
 			for ( int i = 0; i < formalTypeParams.length; ++ i )
 				if ( formalTypeParams[i].equals(v) )

--- a/pljava/src/main/java/org/postgresql/pljava/internal/InstallHelper.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/InstallHelper.java
@@ -129,6 +129,9 @@ public class InstallHelper
 			InstallHelper.class.getProtectionDomain().getCodeSource()
 				.getLocation().toString());
 
+		Security.setProperty( "policy.url.2",
+			"file:${org.postgresql.sysconfdir}/pljava.policy");
+
 		/*
 		 * Construct the strings announcing the versions in use.
 		 */

--- a/pljava/src/main/java/org/postgresql/pljava/internal/InstallHelper.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/InstallHelper.java
@@ -14,7 +14,10 @@ package org.postgresql.pljava.internal;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.IOException;
+import java.net.URL;
+import java.net.MalformedURLException;
 import java.nio.charset.Charset;
+import java.security.Security;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.DriverManager;
@@ -121,6 +124,11 @@ public class InstallHelper
 			System.clearProperty(encodingKey);
 		}
 
+		/* so it can be granted permissions in the pljava policy */
+		System.setProperty( "org.postgresql.pljava.codesource",
+			InstallHelper.class.getProtectionDomain().getCodeSource()
+				.getLocation().toString());
+
 		/*
 		 * Construct the strings announcing the versions in use.
 		 */
@@ -136,6 +144,19 @@ public class InstallHelper
 		String vmName = System.getProperty( "java.vm.name");
 		String vmVer = System.getProperty( "java.vm.version");
 		String vmInfo = System.getProperty( "java.vm.info");
+
+		try
+		{
+			new URL("sqlj:x"); // sqlj: scheme must exist before reading policy
+		}
+		catch ( MalformedURLException e )
+		{
+			throw new SecurityException(
+				"failed to create sqlj: URL scheme needed for security policy",
+				e);
+		}
+
+		System.setSecurityManager( new SecurityManager());
 
 		StringBuilder sb = new StringBuilder();
 		sb.append( "PL/Java native code (").append( nativeVer).append( ")\n");

--- a/pljava/src/main/java/org/postgresql/pljava/internal/ResultSetPicker.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/ResultSetPicker.java
@@ -1,8 +1,14 @@
 /*
- * Copyright (c) 2004, 2005, 2006 TADA AB - Taby Sweden
- * Distributed under the terms shown in the file COPYRIGHT
- * found in the root directory of this distribution or at
- * http://eng.tada.se/osprojects/COPYRIGHT.html
+ * Copyright (c) 2004-2020 Tada AB and other contributors, as listed below.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Tada AB - Thomas Hallgren
+ *   Chapman Flack
  */
 package org.postgresql.pljava.internal;
 
@@ -28,7 +34,7 @@ import org.postgresql.pljava.jdbc.SingleRowWriter;
  * should be declared to return {@code ResultSetProvider} and do this work
  * itself.
  */
-public class ResultSetPicker implements ResultSetProvider
+public class ResultSetPicker implements ResultSetProvider.Large
 {
 	private final ResultSetHandle m_resultSetHandle;
 	private final ResultSet m_resultSet;
@@ -40,7 +46,7 @@ public class ResultSetPicker implements ResultSetProvider
 		m_resultSet = resultSetHandle.getResultSet();
 	}
 
-	public boolean assignRowValues(ResultSet receiver, int currentRow)
+	public boolean assignRowValues(ResultSet receiver, long currentRow)
 	throws SQLException
 	{
 		if(m_resultSet == null || !m_resultSet.next())

--- a/pljava/src/main/java/org/postgresql/pljava/internal/Session.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/Session.java
@@ -24,6 +24,8 @@ import org.postgresql.pljava.ObjectPool;
 import org.postgresql.pljava.PooledObject;
 import org.postgresql.pljava.SavepointListener;
 import org.postgresql.pljava.TransactionListener;
+import org.postgresql.pljava.sqlgen.Lexicals.Identifier;
+
 import org.postgresql.pljava.jdbc.SQLUtils;
 
 import org.postgresql.pljava.elog.ELogHandler;
@@ -229,7 +231,7 @@ public class Session implements org.postgresql.pljava.Session
 	 * Currently used only in Commands.java. Not made visible API yet
 	 * because there <em>has</em> to be a more general way to do this.
 	 */
-	public String getOuterUserSchema()
+	public Identifier.Simple getOuterUserSchema()
 	throws SQLException
 	{
 		Statement stmt = SQLUtils.getDefaultConnection().createStatement();
@@ -246,7 +248,7 @@ public class Session implements org.postgresql.pljava.Session
 				changeSucceeded = true;
 				rs = stmt.executeQuery("SELECT current_schema()");
 				if ( rs.next() )
-					return rs.getString(1);
+					return Identifier.Simple.fromCatalog(rs.getString(1));
 				throw new SQLException("Unable to obtain current schema");
 			}
 			finally

--- a/pljava/src/main/java/org/postgresql/pljava/internal/SubXactListener.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/SubXactListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2019 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2020 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -12,58 +12,91 @@
  */
 package org.postgresql.pljava.internal;
 
-import static org.postgresql.pljava.internal.Backend.doInPG;
+import org.postgresql.pljava.SavepointListener;
+import org.postgresql.pljava.Session;
 
+import static org.postgresql.pljava.internal.Backend.doInPG;
+import org.postgresql.pljava.internal.EntryPoints.Invocable;
+import static org.postgresql.pljava.internal.Privilege.doPrivileged;
+
+import static java.security.AccessController.getContext;
+
+import java.sql.Savepoint;
 import java.sql.SQLException;
+
 import java.util.ArrayDeque;
 import java.util.Deque;
+import static java.util.Objects.requireNonNull;
 
-import org.postgresql.pljava.SavepointListener;
-
+import static java.util.stream.Collectors.toList;
 
 /**
- * Class that enables registrations using the PostgreSQL <code>RegisterSubXactCallback</code>
- * function.
+ * Class that enables registrations using the PostgreSQL
+ * {@code RegisterSubXactCallback} function.
  *
  * @author Thomas Hallgren
  */
 class SubXactListener
 {
-	private static final Deque<SavepointListener> s_listeners =
+	@FunctionalInterface
+	private interface Target
+	{
+		void accept(SavepointListener l, Session s, Savepoint sp, Savepoint p)
+		throws SQLException;
+	}
+
+	/*
+	 * A non-thread-safe Deque; will be made safe by doing all mutations on the
+	 * PG thread (even though actually calling into PG is necessary only when
+	 * the size changes from 0 to 1 or 1 to 0).
+	 */
+	private static final Deque<Invocable<SavepointListener>> s_listeners =
 		new ArrayDeque<>();
 
 	static void onAbort(PgSavepoint sp, PgSavepoint parent)
 	throws SQLException
 	{
-		// Take a snapshot. Handlers might unregister during event processing
-		for ( SavepointListener listener :
-			s_listeners.toArray(new SavepointListener[s_listeners.size()]) )
-			listener.onAbort(Backend.getSession(), sp, parent);
+		invokeListeners(SavepointListener::onAbort, sp, parent);
 	}
 
 	static void onCommit(PgSavepoint sp, PgSavepoint parent)
 	throws SQLException
 	{
-		for ( SavepointListener listener :
-			s_listeners.toArray(new SavepointListener[s_listeners.size()]) )
-			listener.onCommit(Backend.getSession(), sp, parent);
+		invokeListeners(SavepointListener::onCommit, sp, parent);
 	}
 
 	static void onStart(PgSavepoint sp, PgSavepoint parent)
 	throws SQLException
 	{
-		for ( SavepointListener listener :
-			s_listeners.toArray(new SavepointListener[s_listeners.size()]) )
-			listener.onStart(Backend.getSession(), sp, parent);
+		invokeListeners(SavepointListener::onStart, sp, parent);
+	}
+
+	private static void invokeListeners(
+		Target target, Savepoint sp, Savepoint parent)
+	throws SQLException
+	{
+		Session session = Backend.getSession();
+
+		// Take a snapshot. Handlers might unregister during event processing
+		for ( Invocable<SavepointListener> listener :
+			s_listeners.stream().collect(toList()) )
+		{
+			doPrivileged(() ->
+			{
+				target.accept(listener.payload, session, sp, parent);
+			}, listener.acc);
+		}
 	}
 
 	static void addListener(SavepointListener listener)
 	{
+		Invocable<SavepointListener> invocable =
+			new Invocable<>(requireNonNull(listener), getContext());
+
 		doInPG(() ->
 		{
-			if ( s_listeners.contains(listener) )
-				return;
-			s_listeners.push(listener);
+			s_listeners.removeIf(v -> v.payload.equals(listener));
+			s_listeners.push(invocable);
 			if( 1 == s_listeners.size() )
 				_register();
 		});
@@ -73,7 +106,7 @@ class SubXactListener
 	{
 		doInPG(() ->
 		{
-			if ( ! s_listeners.remove(listener) )
+			if ( ! s_listeners.removeIf(v -> v.payload.equals(listener)) )
 				return;
 			if ( 0 == s_listeners.size() )
 				_unregister();

--- a/pljava/src/main/java/org/postgresql/pljava/internal/XactListener.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/XactListener.java
@@ -24,6 +24,7 @@ import java.sql.SQLException;
 
 import java.util.ArrayDeque;
 import java.util.Deque;
+import java.util.List;
 import static java.util.Objects.requireNonNull;
 
 import static java.util.stream.Collectors.toList;
@@ -37,6 +38,33 @@ import static java.util.stream.Collectors.toList;
 class XactListener
 {
 	/*
+	 * These do not need to match the values of the PostgreSQL enum (which, over
+	 * the years, has had members not merely added but reordered). The C code
+	 * will map those to these.
+	 */
+	private static final int COMMIT              = 0;
+	private static final int ABORT               = 1;
+	private static final int PREPARE             = 2;
+	private static final int PRE_COMMIT          = 3;
+	private static final int PRE_PREPARE         = 4;
+	private static final int PARALLEL_COMMIT     = 5;
+	private static final int PARALLEL_ABORT      = 6;
+	private static final int PARALLEL_PRE_COMMIT = 7;
+
+	private static final
+	List<Checked.BiConsumer<TransactionListener,Session,SQLException>> s_refs =
+	List.of(
+		TransactionListener::onCommit,
+		TransactionListener::onAbort,
+		TransactionListener::onPrepare,
+		TransactionListener::onPreCommit,
+		TransactionListener::onPrePrepare,
+		TransactionListener::onParallelCommit,
+		TransactionListener::onParallelAbort,
+		TransactionListener::onParallelPreCommit
+	);
+
+	/*
 	 * A non-thread-safe Deque; will be made safe by doing all mutations on the
 	 * PG thread (even though actually calling into PG is necessary only when
 	 * the size changes from 0 to 1 or 1 to 0).
@@ -44,25 +72,11 @@ class XactListener
 	private static final Deque<Invocable<TransactionListener>> s_listeners =
 		new ArrayDeque<>();
 
-	static void onAbort() throws SQLException
-	{
-		invokeListeners(TransactionListener::onAbort);
-	}
-
-	static void onCommit() throws SQLException
-	{
-		invokeListeners(TransactionListener::onCommit);
-	}
-
-	static void onPrepare() throws SQLException
-	{
-		invokeListeners(TransactionListener::onPrepare);
-	}
-
-	private static void invokeListeners(
-		Checked.BiConsumer<TransactionListener,Session,SQLException> target)
+	private static void invokeListeners(int eventIndex)
 	throws SQLException
 	{
+		Checked.BiConsumer<TransactionListener,Session,SQLException> target =
+			s_refs.get(eventIndex);
 		Session session = Backend.getSession();
 
 		// Take a snapshot. Handlers might unregister during event processing

--- a/pljava/src/main/java/org/postgresql/pljava/management/DDRExecutor.java
+++ b/pljava/src/main/java/org/postgresql/pljava/management/DDRExecutor.java
@@ -98,7 +98,7 @@ public abstract class DDRExecutor
 		if ( null == name )
 			return PLAIN;
 
-		Iterable<Identifier> imps =
+		Iterable<Identifier.Simple> imps =
 			Backend.getListConfigOption( "pljava.implementors");
 
 		for ( Identifier i : imps )

--- a/pljava/src/main/java/org/postgresql/pljava/sqlj/Handler.java
+++ b/pljava/src/main/java/org/postgresql/pljava/sqlj/Handler.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2020 Tada AB and other contributors, as listed below.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Chapman Flack
+ */
+package org.postgresql.pljava.sqlj;
+
+import java.io.IOException;
+
+import java.net.URL;
+import java.net.URLConnection;
+import java.net.URLStreamHandler;
+import java.net.spi.URLStreamHandlerProvider;
+
+/**
+ * Provider for an {@code sqlj:jarname} URL stream handler.
+ *<p>
+ * This is only used to allow the security policy to grant permissions to jars
+ * by name. The handler is otherwise nonfunctional; its {@code openConnection}
+ * method throws an exception.
+ */
+public class Handler extends URLStreamHandlerProvider
+{
+	private static final Handler INSTANCE = new Handler();
+
+	public URLStreamHandlerProvider provider()
+	{
+		return INSTANCE;
+	}
+
+	@Override
+	public URLStreamHandler createURLStreamHandler(String protocol)
+	{
+		switch ( protocol )
+		{
+		case "sqlj":
+			return SQLJ.INSTANCE;
+		default:
+			return null;
+		}
+	}
+
+	static class SQLJ extends URLStreamHandler
+	{
+		static final SQLJ INSTANCE = new SQLJ();
+
+		@Override
+		protected URLConnection openConnection(URL u) throws IOException
+		{
+			throw new IOException(
+				"URL of sqlj: protocol can't really be opened");
+		}
+
+		@Override
+		protected void parseURL(URL u, String spec, int start, int limit)
+		{
+			if ( spec.length() > limit )
+				throw new IllegalArgumentException(
+					"sqlj: URL should not contain #");
+			if ( spec.length() == start )
+				throw new IllegalArgumentException(
+					"sqlj: URL should not have empty path part");
+			setURL(u, u.getProtocol(), null, -1, null, null,
+				spec.substring(start), null, null);
+		}
+	}
+}

--- a/pljava/src/main/java/org/postgresql/pljava/sqlj/Loader.java
+++ b/pljava/src/main/java/org/postgresql/pljava/sqlj/Loader.java
@@ -48,6 +48,7 @@ import static java.util.stream.Collectors.groupingBy;
 import org.postgresql.pljava.internal.Backend;
 import org.postgresql.pljava.internal.Checked;
 import org.postgresql.pljava.internal.Oid;
+import static org.postgresql.pljava.internal.Privilege.doPrivileged;
 import static org.postgresql.pljava.internal.UncheckedException.unchecked;
 
 import static org.postgresql.pljava.jdbc.SQLUtils.getDefaultConnection;
@@ -260,7 +261,8 @@ public class Loader extends ClassLoader
 			loader = schemaName.equals(PUBLIC_SCHEMA)
 				? parent : getSchemaLoader(PUBLIC_SCHEMA);
 		else
-			loader = new Loader(classImages, codeSources, parent);
+			loader = doPrivileged(() ->
+				new Loader(classImages, codeSources, parent));
 
 		s_schemaLoaders.put(schemaName, loader);
 		return loader;

--- a/src/site/markdown/examples/examples.md.vm
+++ b/src/site/markdown/examples/examples.md.vm
@@ -126,7 +126,7 @@ The Saxon example [documentation is here](../examples/saxon.html).
 
 [Saxon-HE]: http://www.saxonica.com/html/products/products.html
 
-$h2 Unable to find class or method (message when installing examples)
+$h2 Exception resolving class or method (message when installing examples)
 
 As described above, there are some optionally-built examples included
 in the source. For example, there are XML Query examples that are not built
@@ -135,10 +135,9 @@ by default because they depend on the Saxon jar.
 If your examples jar was built with the optional examples enabled, then
 PL/Java will normally validate that all of the functions it creates can be used.
 That validation will fail if a needed dependency, such as the Saxon jar, is
-not already installed and on the classpath. The error message can be puzzling,
-as it won't say the Saxon jar is missing, it will say it can't find a method
-that is clearly present in the examples jar. The explanation is that Java does
-not resolve the method, because a dependency is missing.
+not already installed and on the classpath. The error message will not directly
+say the Saxon jar is missing, but will say it failed to find a class (whose name
+will suggest it should be part of Saxon).
 
 There are two ways to proceed:
 

--- a/src/site/markdown/use/policy.md
+++ b/src/site/markdown/use/policy.md
@@ -215,8 +215,8 @@ grant principal org.postgresql.pljava.PLPrincipal$Sandboxed "java_tzset" {
 ```
 
 If the JSR-310 test example in PL/Java's examples jar is declared with
-`LANGUAGE java_tzset` rather than `LANGUAGE java`, it will be able to set
-the time zone and succeed.
+`LANGUAGE java_tzset` rather than `LANGUAGE java` (as, in fact, it is),
+it will be able to set the time zone and succeed.
 
 The [`SQLJ.ALIAS_JAVA_LANGUAGE`][sqljajl] function can be used to create such
 aliases conveniently.

--- a/src/site/markdown/use/policy.md
+++ b/src/site/markdown/use/policy.md
@@ -304,11 +304,8 @@ installation by declaring an SQL function that directly calls
 `java.lang.System.getProperty`.
 
 Such declarations are allowed, but will execute as if called from a protection
-domain with no permissions other than those the policy grants unconditionally.
-If the target method is in a Java runtime class that Java's bootstrap loader
-loads, it will also not be able to exercise permissions granted by principal
-(because a bootstrap class has no protection domain with which the per-principal
-permissions could be combined).
+domain with the same `Principal`s, if any, that PL/Java would normally supply,
+and no other permissions but those the policy grants unconditionally.
 
 _Note: many of the how-to articles that can be found on the
 web happen to demonstrate their `System.getProperty`-calling example functions

--- a/src/site/markdown/use/policy.md
+++ b/src/site/markdown/use/policy.md
@@ -218,6 +218,9 @@ If the JSR-310 test example in PL/Java's examples jar is declared with
 `LANGUAGE java_tzset` rather than `LANGUAGE java`, it will be able to set
 the time zone and succeed.
 
+The [`SQLJ.ALIAS_JAVA_LANGUAGE`][sqljajl] function can be used to create such
+aliases conveniently.
+
 When grants to specific named languages and grants with the wildcard are
 present, code will have all of the permissions granted to the specific
 language by name, in addition to all permissions that appear in grants to the
@@ -325,3 +328,4 @@ release, so relying on it is not recommended.
 [jdkperms]: https://docs.oracle.com/en/java/javase/14/security/permissions-jdk1.html#GUID-1E8E213A-D7F2-49F1-A2F0-EFB3397A8C95
 [confvar]: variables.html
 [dopriv]: https://docs.oracle.com/en/java/javase/14/security/java-se-platform-security-architecture.html#GUID-E8898CB5-65BB-4D1A-A574-8F7112FC353F
+[sqljajl]: ../pljava/apidocs/org.postgresql.pljava.internal/org/postgresql/pljava/management/Commands.html#alias_java_language

--- a/src/site/markdown/use/policy.md
+++ b/src/site/markdown/use/policy.md
@@ -1,0 +1,330 @@
+# Configuring permissions in PL/Java
+
+## `TRUSTED` (and untrusted) procedural languages
+
+PostgreSQL allows a procedural language to be installed with or without
+the designation `TRUSTED`. For a language designated `TRUSTED`, functions
+can be created in that language by any user (PostgreSQL role) with `USAGE`
+permission on that language, as configured with the SQL commands
+`GRANT USAGE ON LANGUAGE ...` and `REVOKE USAGE ON LANGUAGE ...`. For a
+language that is _not_ designated `TRUSTED`, only a database superuser
+may create functions that use it, no matter who has been granted `USAGE`
+on it.
+
+In either case, once any function has been created, that function may
+be executed by any user/role granted `EXECUTE` permission on the function
+itself; a language's `USAGE` privilege (plus superuser status, if the language
+is not `TRUSTED`) is only needed to create a function that uses the language.
+
+Because PL functions execute in the database server, a general-purpose
+programming language with no restrictions on access to its containing process
+or the server file system may be used for actions or access that PostgreSQL
+would normally not permit. A superuser can implement such a function using
+a non-`TRUSTED` PL, and design the function to enforce its own limits and
+be safe for use by whatever roles will be granted `EXECUTE` permission on it.
+
+A `TRUSTED` PL is expected to enforce appropriate restrictions so that
+non-superusers can be allowed to use it to create functions on their own,
+while still subject to PostgreSQL's normal protections.
+
+Both kinds have their uses, and many of the available PLs, including PL/Java,
+install two similarly-named 'languages' to permit both. Although either can be
+renamed, a normal installation of PL/Java will create the language `java` with
+the `TRUSTED` property, and `javaU` without it.
+
+*Note: like any SQL identifier, these language names are case-insensitive
+when not quoted, and are stored in lowercase in PostgreSQL. The spelling with
+capital `U` for untrusted is a common convention.*
+
+### `TRUSTED`/untrusted versus sandboxed/unsandboxed
+
+In various places in PL/Java's API, and in the sections below, the words
+'sandboxed' or 'unsandboxed' are used in place of the PostgreSQL `TRUSTED` or
+untrusted, respectively. That choice reflects a little trick of language some
+readers may notice when new to PostgreSQL: it is about equally easy to read
+'trusted'/'untrusted' in two opposite ways. (Is this language trusted because of
+how tightly I restrict it? Or do I restrict it less tightly because I trust it?
+Is it like a teenager with the car keys?) Old hands at PostgreSQL know which
+reading is correct, but because some users of PL/Java may be old hands at Java
+and newcomers to PostgreSQL, it seems safer for PL/Java to use terms that
+should give the right idea to readers in both groups.
+
+## Permissions available in sandboxed/unsandboxed PL/Java
+
+Most PLs that offer both variants, including PL/Java before 1.6, hardcode
+the differences between what a function in each language is allowed to do.
+The sandboxed language would apply a fixed set of limitations, such as
+forbidding access to the server's file system, and those limits were
+not adjustable.
+
+A needed function that would only access one, specific, known-safe file, or
+perhaps would need no file access but have to make a network connection to one
+known server, might _almost_ be written under those predetermined restrictions,
+but that wouldn't count. It would simply have to be created for the unsandboxed
+language instead, and written defensively against a much wider range of possible
+misuses or mistakes.
+
+Beginning with 1.6, PL/Java takes a more configurable approach. Using the Java
+[policy file syntax][pfsyn], any of the permissions known to the JDK can
+be granted to chosen Java code. The default policy file installed with PL/Java
+includes these lines:
+
+```
+grant principal org.postgresql.pljava.PLPrincipal$Sandboxed * {
+};
+
+grant principal org.postgresql.pljava.PLPrincipal$Unsandboxed * {
+    permission java.io.FilePermission
+        "<<ALL FILES>>", "read,write,delete,readlink";
+};
+```
+
+A few observations fall out. Whatever the names may suggest, neither alternative
+is truly "unsandboxed". Both are subject to the same Java policy, but can
+be granted different permissions within it.
+
+As distributed, the only difference between the two is access to the filesystem.
+The "sandboxed" case grants no additional permissions at all, and the
+"unsandboxed" case adds read, readlink, write, and delete permission for any
+file (still subject to the operating system permissions in effect for the
+PostgreSQL server process, which will be enforced independently of Java).
+
+The permissions granted for either case are freely configurable. Granting
+the more lenient or dangerous permissions to the "unsandboxed" language is
+conventional, and reflected in the way PostgreSQL is more restrictive about
+what roles can create functions in that language.
+
+The [permissions known to the JDK][jdkperms] are plentiful and fine-grained.
+New permissions can also be defined and required in custom code, and selectively
+granted in the policy like any other permission.
+
+The `PLPrincipal` indicating sandboxed/unsandboxed is only one of the conditions
+that can be referred to in a policy to control the permissions granted. Others
+are described below.
+
+## Sources of Java policy
+
+Java's standard `Policy` implementation will read from a sequence of policy
+files specified as URLs. The first is normally part of the Java installation,
+supplying permission grants necessary for trouble-free operation of the JVM
+itself, and a second will be read, if present, from a user's home directory.
+
+PL/Java, by default, uses the first Java-supplied URL, for the policy file
+installed with Java, followed by the file `pljava.policy` in the directory
+reported by `pg_config --sysconfdir`. A default version of that file is
+installed with PL/Java.
+
+The `pljava.policy` file, by default, is used _instead of_ any `.java.policy`
+file in the OS user's home directory that Java would normally load. There
+probably is no such file in the `postgres` user's home directory, and if
+for any reason there is one, it probably is not tailored to PL/Java.
+
+The [configuration variable][confvar] `pljava.policy_urls` can be
+used to name different, or additional, policy files.
+
+Permission grants are cumulative in Java's standard `Policy` implementation:
+there is no policy syntax to _deny_ a permission if it is conveyed by some other
+applicable grant in any of the files on the `policy_urls` list. If an
+application must restrict a permission that is granted unconditionally
+in the Java-supplied policy file, for example, the typical approach would be
+to copy that file, remove the grant of that permission, and alter
+`pljava.policy_urls` to read the modified file in place of the original.
+
+## Conditional and unconditional permission grants
+
+A `grant` in a policy can be unconditional, for example:
+
+```
+grant {
+    permission java.util.PropertyPermission
+        "sqlj.defaultconnection", "read";
+};
+```
+
+That grant (which is included in the default `pljava.policy`) allows any Java
+code to read that property.
+
+Conditional grants to `PLPrincipal$Sandboxed` and `PLPrincipal$Unsandboxed` were
+shown above.
+
+It is also possible to condition a grant on the codebase (represented as
+a URL) of the code being executed. If the `SQLJ.INSTALL_JAR` function is used
+to install PL/Java's examples jar under the name `examples`, this grant will
+allow the JSR-310 test example to work:
+
+```
+grant codebase "sqlj:examples" {
+    permission java.util.PropertyPermission "user.timezone", "write";
+};
+```
+
+The `sqlj` URL scheme is (trivially, and otherwise nonfunctionally) defined
+within PL/Java to allow forming a codebase URL from the name of an installed
+jar.
+
+### Grant conditions currently unsupported
+
+A reader familiar with Java security policy may consider granting permissions
+based on the signer identity of a cryptographically signed jar, or on a
+`Principal` representing the PostgreSQL role executing the current function.
+In this version of PL/Java, such grants are not yet supported.
+
+While it is not yet possible to grant permissions based on a principal
+representing the PostgreSQL session user or role, it is possible for
+a superuser, with `ALTER ROLE ... SET`, to set user-specific values of
+`pljava.policy_urls` that will load different, or additional, policy files.
+While that will only reflect the connected user at the start of the session
+and not any role changes during the session, it may be enough for some uses.
+
+### `PLPrincipal` with a language name
+
+The grants for sandboxed/unsandboxed shown above have a `*` wildcard after
+the principal class name. It is possible to replace the wildcard with the name
+of the language (as used in SQL with `CREATE LANGUAGE` and `CREATE FUNCTION`)
+in which a function is declared.
+
+A basic installation of PL/Java creates just two named languages, `java` and
+`javaU`, declared as `TRUSTED`/sandboxed and untrusted/unsandboxed,
+respectively. In such an installation, these grants would be effectively
+equivalent to those shown earlier:
+
+```
+grant principal org.postgresql.pljava.PLPrincipal$Sandboxed "java" {
+};
+
+grant principal org.postgresql.pljava.PLPrincipal$Unsandboxed "javaU" {
+
+    // Java does not circumvent operating system access controls;
+    // this grant will still be limited to what the OS allows a
+    // PostgreSQL backend process to do.
+    permission java.io.FilePermission
+        "<<ALL FILES>>", "read,readlink,write,delete";
+};
+```
+
+However, it is possible to use `CREATE LANGUAGE` to create any number of
+named languages that share PL/Java's handler entries and can be used to
+declare PL/Java functions. For example, suppose `CREATE TRUSTED LANGUAGE` is
+used to create another language entry with the name `java_tzset` and this
+grant is included in the policy:
+
+```
+grant principal org.postgresql.pljava.PLPrincipal$Sandboxed "java_tzset" {
+    permission java.util.PropertyPermission "user.timezone", "write";
+};
+```
+
+If the JSR-310 test example in PL/Java's examples jar is declared with
+`LANGUAGE java_tzset` rather than `LANGUAGE java`, it will be able to set
+the time zone and succeed.
+
+When grants to specific named languages and grants with the wildcard are
+present, code will have all of the permissions granted to the specific
+language by name, in addition to all permissions that appear in grants to the
+language class (`PLPrincipal$Sandboxed` or `PLPrincipal$Unsandboxed`, whichever
+applies) with a wildcard name.
+
+A grant is silently ignored unless the class and the name both match. If the
+`java_tzset` language were declared as above but a grant entry used the right
+name but the `PLPrincipal$Unsandboxed` class by mistake, that grant would be
+silently ignored.
+
+### Grants to a codebase compared with grants to a principal
+
+Whenever a Java operation requires a permission check, it could be on a call
+stack several levels deep, perhaps involving code from more than one codebase
+(or, more generally, "protection domain"). The Java rule is that the needed
+permission must be in effect, one way or another, for every protection domain
+on the call stack at the point where the permission is needed. In other words,
+the available permissions are the _intersection_, over all domains on the stack,
+of the permissions in effect for each domain. The rationale is that the proposed
+action must not only be something the currently executing method is allowed to
+do; there is a calling method causing this method to do it, so it must also be
+something the caller is allowed to do, and so on up the stack. (For one crucial
+exception to this rule, see [handling privileges][dopriv].)
+
+Permissions granted to a `Principal` are not so tightly bound to what specific
+code is executing; the same code may execute at different times on behalf of
+more than one principal. A principal often represents a user or role for whom
+the code is executing, though role principals are not implemented in this
+PL/Java release. The sandboxed/unsandboxed function distinction is represented
+as a kind of `Principal` because it, too, is a property of the thread of
+execution, from its entry at the SQL-declared function entry point and through
+any number of protection domains the thread may traverse. Any permissions
+granted by principal may be thought of as combined with any codebase-specific
+permissions in every domain present on the stack.
+
+### Entry points other than SQL-declared functions
+
+Not every entry into PL/Java is through an SQL-declared function with an
+associated language name or sandboxed/unsandboxed property. For those that are
+not, permission decisions are based on an "access control context"
+(essentially, the in-effect `Principal`s and initial protection domains)
+constructed as described here.
+
+#### Set-returning functions
+
+While a set-returning function _is_ declared as an SQL function, the
+initial call is followed by repeated calls to the returned iterator or 
+ResultSet provider or handle, and a final call to close the provider or handle.
+The access control context constructed for the initial call is saved, and reused
+while iterating and closing.
+
+#### Savepoint and transaction listeners
+
+Java code may register listeners for callbacks at lifecycle stages of savepoints
+or transactions. Each callback will execute in the access control context of
+the code that registered it, except that PL/Java's own domain will also be
+represented on the stack. Because effective permissions are an intersection
+over all domains on the stack, if any permission has been granted to the
+callback's codebase that is not also granted to PL/Java's own code, the
+callback code will be unable to exercise that permission except within
+a [`doPrivileged`][dopriv] block.
+
+#### Mapped UDT `readSQL`/`writeSQL` methods
+
+When a Java user-defined type is defined without fully integrating it into
+PostgreSQL's type system as a `BaseUDT`, its `readSQL` and `writeSQL` methods
+will not have corresponding SQL function declarations, but will be called
+directly as PL/Java converts values between PostgreSQL and Java form. Those
+calls will be made without any `PLPrincipal`, sandboxed or unsandboxed, so
+they will execute with only the permissions granted to their codebase or
+unconditionally.
+
+The conversion functions for a `BaseUDT` do have SQL function declarations, and
+will execute in a context constructed based on the declaration in the usual way.
+
+### SQL-declared functions not in PL/Java-managed jars
+
+It is possible to issue an SQL `CREATE FUNCTION` naming a method from a codebase
+that is not a PL/Java-managed `sqlj:` jar, such as a jar on the filesystem
+module path, or a method of the Java runtime itself. For example, many how-to
+articles can be found on the web that demonstrate a successful PL/Java
+installation by declaring an SQL function that directly calls
+`java.lang.System.getProperty`.
+
+Such declarations are allowed, but will execute as if called from a protection
+domain with no permissions other than those the policy grants unconditionally.
+If the target method is in a Java runtime class that Java's bootstrap loader
+loads, it will also not be able to exercise permissions granted by principal
+(because a bootstrap class has no protection domain with which the per-principal
+permissions could be combined).
+
+_Note: many of the how-to articles that can be found on the
+web happen to demonstrate their `System.getProperty`-calling example functions
+on some property that isn't readable under Java's default policy.
+Those examples should be changed to use a property that is normally readable,
+such as `java.version` or `org.postgresql.pljava.version`._
+
+## Forward compatibility
+
+The current implementation makes use of the Java classes
+`Subject` and `SubjectDomainCombiner` in the `javax.security.auth` package.
+That should be regarded as an implementation detail; it may change in a future
+release, so relying on it is not recommended.
+
+
+[pfsyn]: https://docs.oracle.com/en/java/javase/14/security/permissions-jdk1.html#GUID-7942E6F8-8AAB-4404-9FE9-E08DD6FFCFFA
+[jdkperms]: https://docs.oracle.com/en/java/javase/14/security/permissions-jdk1.html#GUID-1E8E213A-D7F2-49F1-A2F0-EFB3397A8C95
+[confvar]: variables.html
+[dopriv]: https://docs.oracle.com/en/java/javase/14/security/java-se-platform-security-architecture.html#GUID-E8898CB5-65BB-4D1A-A574-8F7112FC353F

--- a/src/site/markdown/use/use.md
+++ b/src/site/markdown/use/use.md
@@ -36,6 +36,12 @@ PL/Java's own.
 
 ## Special topics
 
+### Configuring permissions
+
+The permissions in effect for PL/Java functions can be tailored, independently
+for functions declared to the `TRUSTED` or untrusted language, as described
+[here](policy.html).
+
 ### Choices when mapping data types
 
 #### Date and time types

--- a/src/site/markdown/use/variables.md
+++ b/src/site/markdown/use/variables.md
@@ -107,6 +107,40 @@ These PostgreSQL configuration variables can influence PL/Java's operation:
     For more on PL/Java's "module path" and "class path", see
     [PL/Java and the Java Platform Module System](jpms.html).
 
+`pljava.policy_urls`
+: A list of URLs to Java security [policy files](policy.html) determining
+    the permissions available to PL/Java functions. Each URL should be
+    enclosed in double quotes; any double quote that is literally part of
+    the URL may be represented as two double quotes (in SQL style) or as
+    `%22` in the URL convention. Between double-quoted URLs, a comma is the
+    list delimiter.
+
+    The Java installation's `java.security` file usually defines two policy
+    file locations:
+
+    0. A systemwide policy from the Java vendor, sufficient for the Java runtime
+        itself to function as expected
+    0. A per-user location, where a policy file, if found, can add to the policy
+        from the systemwide file.
+
+    The list in `pljava.policy_urls` will modify the list from the Java
+    installation, by default after the first entry, keeping the Java-supplied
+    systemwide policy but replacing the customary per-user file (there
+    probably isn't one in the home of the `postgres` user, and if there is
+    it is probably not tailored for PL/Java).
+
+    Any entry in this list can start with _n_`=` (inside the quotes) for a
+    positive integer _n_, to specify which entry of Java's policy location list
+    it will replace (entry 1 is the systemwide policy, 2 the customary user
+    location). URLs not prefixed with _n_`=` will follow consecutively. If the
+    first entry is not so prefixed, `2=` is assumed.
+
+    A final entry of `=` (in the required double quotes) will prevent
+    use of any remaining entries in the Java site-configured list.
+
+    This setting defaults to
+    `"file:${org.postgresql.sysconfdir}/pljava.policy","="`
+
 `pljava.release_lingering_savepoints`
 : How the return from a PL/Java function will treat any savepoints created
     within it that have not been explicitly either released (the savepoint
@@ -149,3 +183,4 @@ These PostgreSQL configuration variables can influence PL/Java's operation:
 [jow]: https://docs.oracle.com/javase/8/docs/technotes/tools/windows/java.html
 [jou]: https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html
 [vmop]: ../install/vmoptions.html
+


### PR DESCRIPTION
The difference between what `java` and `javaU` functions could do was hardcoded, and sometimes less or more than was wanted; also, they could interfere with normal operation of the Java runtime itself, breaking its XSLT processor, for one example, and the profiling features of `visualvm`.

Java has a nice policy language for conditionally granting permissions, so integrate that.