### PR TITLE
Add an SQL_ASCII encoder/decoder

### DIFF
--- a/pljava-packaging/src/main/resources/pljava.policy
+++ b/pljava-packaging/src/main/resources/pljava.policy
@@ -55,6 +55,8 @@ grant {
 //
 grant codebase "${org.postgresql.pljava.codesource}" {
 	permission java.lang.RuntimePermission
+		"charsetProvider";
+	permission java.lang.RuntimePermission
 		"createClassLoader";
 	permission java.util.logging.LoggingPermission
 		"control";

--- a/pljava/src/main/java/module-info.java
+++ b/pljava/src/main/java/module-info.java
@@ -26,6 +26,9 @@ module org.postgresql.pljava.internal
 	provides java.net.spi.URLStreamHandlerProvider
 		with org.postgresql.pljava.sqlj.Handler;
 
+	provides java.nio.charset.spi.CharsetProvider
+		with org.postgresql.pljava.internal.SQL_ASCII.Provider;
+
 	provides java.sql.Driver with org.postgresql.pljava.jdbc.SPIDriver;
 
 	provides org.postgresql.pljava.Session

--- a/pljava/src/main/java/org/postgresql/pljava/internal/SQL_ASCII.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/SQL_ASCII.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright (c) 2020 Tada AB and other contributors, as listed below.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Chapman Flack
+ */
+package org.postgresql.pljava.internal;
+
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+
+import java.nio.charset.Charset;
+import java.nio.charset.CharsetDecoder;
+import java.nio.charset.CharsetEncoder;
+import java.nio.charset.CoderResult;
+import java.nio.charset.spi.CharsetProvider;
+import static java.nio.charset.StandardCharsets.US_ASCII;
+
+import static java.util.Collections.singletonList;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * An {@code SQL_ASCII}, a/k/a {@code X-PGSQL_ASCII}, "character set".
+ *<p>
+ * This is a principled Java take on the PostgreSQL definition of
+ * SQL_ASCII as an encoding where the seven-bit ASCII values are
+ * themselves and the remaining eight-bit values are who-knows-what.
+ * It isn't appropriate to just copy byte values with no conversion,
+ * as that would amount to saying we know the values correspond to
+ * LATIN-1, which would be lying. Java strings are by definition Unicode,
+ * so it's not ok to go stuffing code points in that do not mean what
+ * Unicode defines those code points to mean.
+ *<p>
+ * What this decoder does is decode the seven-bit ASCII values as
+ * themselves, and decode each eight-bit value into a pair of Unicode
+ * noncharacters, one from the range u+fdd8 to u+fddf, followed by one
+ * from u+fde0 to u+fdef, where the first one's four low bits are the
+ * four high bits of the original value, and the second has the low four.
+ * The encoder transparently reverses that.
+ *<p>
+ * Those noncharacter code points are permanently defined in Unicode
+ * to have no glyphs, no correspondence to specific characters, and
+ * no interesting properties. Implementing this charset allows PL/Java
+ * code to work usefully in a database with SQL_ASCII encoding, when the
+ * expectation is that whatever the code needs to recognize, act on, or
+ * edit will be in ASCII, and any non-ASCII content can be passed along
+ * uninterpreted and unchanged.
+ */
+class SQL_ASCII extends Charset
+{
+	static class Holder
+	{
+		static final List<Charset> s_list =
+			singletonList((Charset)new SQL_ASCII());
+	}
+
+
+	public static class Provider extends CharsetProvider
+	{
+		static final String s_canonName = "X-PGSQL_ASCII";
+		static final String[] s_aliases = { "SQL_ASCII" };
+
+		@Override
+		public Charset charsetForName(String charsetName)
+		{
+			if ( s_canonName.equalsIgnoreCase(charsetName) )
+				return Holder.s_list.get(0);
+			for ( String s : s_aliases )
+				if ( s.equalsIgnoreCase(charsetName) )
+					return Holder.s_list.get(0);
+			return null;
+		}
+
+		@Override
+		public Iterator<Charset> charsets()
+		{
+			return Holder.s_list.iterator();
+		}
+	}
+
+
+	private SQL_ASCII()
+	{
+		super(Provider.s_canonName, Provider.s_aliases);
+	}
+
+	@Override
+	public boolean contains(Charset cs)
+	{
+		return this.equals(cs)  ||  US_ASCII.equals(cs);
+	}
+
+	@Override
+	public CharsetDecoder newDecoder()
+	{
+		return new Decoder();
+	}
+
+	@Override
+	public CharsetEncoder newEncoder()
+	{
+		return new Encoder();
+	}
+
+
+	static class Decoder extends CharsetDecoder
+	{
+		Decoder()
+		{
+			super(Holder.s_list.get(0), 1.002f, 2.0f);
+		}
+
+		@Override
+		protected CoderResult decodeLoop(ByteBuffer in, CharBuffer out)
+		{
+			int ipos = in.position();
+			int opos = out.position();
+			int ilim = in.limit();
+			int olim = out.limit();
+
+			for ( ; ipos < ilim ; ++ ipos )
+			{
+				char b = (char)(0xff & in.get(ipos));
+
+				if ( b < 128 )
+				{
+					if ( opos == olim )
+					{
+						in.position(ipos);
+						out.position(opos);
+						return CoderResult.OVERFLOW;
+					}
+					out.put(opos++, b);
+				}
+				else
+				{
+					if ( opos + 1 >= olim )
+					{
+						in.position(ipos);
+						out.position(opos);
+						return CoderResult.OVERFLOW;
+					}
+					out.put(opos++, (char)(0xFDD0 | (b >> 4)));
+					out.put(opos++, (char)(0xFDE0 | (b & 0xf)));
+				}
+			}
+			in.position(ipos);
+			out.position(opos);
+			return CoderResult.UNDERFLOW;
+		}
+	}
+
+	static class Encoder extends CharsetEncoder
+	{
+		Encoder()
+		{
+			super(Holder.s_list.get(0), 0.998f, 1.0f);
+		}
+
+		@Override
+		protected CoderResult encodeLoop(CharBuffer in, ByteBuffer out)
+		{
+			int ipos = in.position();
+			int opos = out.position();
+			int ilim = in.limit();
+			int olim = out.limit();
+
+			for ( ; ipos < ilim ; ++ ipos )
+			{
+				if ( opos == olim )
+				{
+					in.position(ipos);
+					out.position(opos);
+					return CoderResult.OVERFLOW;
+				}
+
+				char c = in.get(ipos);
+
+				if ( '\uFDD8' <= c  &&  c < '\uFDE0' )
+				{
+					if ( ipos + 1 == ilim )
+						break;
+
+					char d = in.get(ipos + 1);
+
+					if ( '\uFDE0' > d  ||  d > '\uFDEF' )
+					{
+						in.position(ipos);
+						out.position(opos);
+						return CoderResult.malformedForLength(2);
+					}
+					c = (char)(( (c & 0xf) << 4 ) | (d & 0xf));
+					++ ipos;
+				}
+				else if ( c >= 128 )
+				{
+					in.position(ipos);
+					out.position(opos);
+					return CoderResult.unmappableForLength(1);
+				}
+				out.put(opos++, (byte)c);
+			}
+			in.position(ipos);
+			out.position(opos);
+			return CoderResult.UNDERFLOW;
+		}
+	}
+}

--- a/pljava/src/test/java/CharsetTest.java
+++ b/pljava/src/test/java/CharsetTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2020 Tada AB and other contributors, as listed below.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Chapman Flack
+ */
+package org.postgresql.pljava.internal;
+
+import junit.framework.TestCase;
+
+import static org.junit.Assert.*;
+import org.junit.Ignore;
+import static org.hamcrest.CoreMatchers.*;
+
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+
+import java.nio.charset.Charset;
+import static java.nio.charset.StandardCharsets.US_ASCII;
+
+import static java.util.regex.Pattern.matches;
+
+public class CharsetTest extends TestCase
+{
+	public CharsetTest(String name) { super(name); }
+
+	public void testSQL_ASCII() throws Exception
+	{
+		Charset sqa = Charset.forName("SQL_ASCII");
+		assertNotNull(sqa);
+
+		assertTrue(sqa.contains(sqa));
+		assertTrue(sqa.contains(US_ASCII));
+
+		ByteBuffer bb = ByteBuffer.allocate(256);
+
+		while ( bb.hasRemaining() )
+			bb.put((byte)bb.position());
+
+		bb.flip();
+
+		CharBuffer cb = sqa.decode(bb);
+
+		assertTrue(matches("[\\u0000-\\u007f]{128}+" +
+						   "(?:[\\ufdd8-\\ufddf][\\ufde0-\\ufdef]){128}+", cb));
+
+		cb.rewind();
+
+		ByteBuffer bb2 = sqa.encode(cb);
+		bb.rewind();
+
+		assertTrue(bb2.equals(bb));
+	}
+}

--- a/pom.xml
+++ b/pom.xml
@@ -199,6 +199,11 @@
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>3.0.0-M4</version>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-site-plugin</artifactId>
 				<version>3.9.1</version>
 				<dependencies>

--- a/src/site/markdown/use/variables.md
+++ b/src/site/markdown/use/variables.md
@@ -24,14 +24,11 @@ These PostgreSQL configuration variables can influence PL/Java's operation:
 `server_encoding`
 : Another non-PL/Java variable, this affects all text/character strings
     exchanged between PostgreSQL and Java. `UTF8` as the database and server
-    encoding is _strongly_ recommended. If a different encoding is used, it
+    encoding is strongly recommended. If a different encoding is used, it
     should be any of the available _fully defined_ character encodings. In
-    particular, the PostgreSQL pseudo-encoding `SQL_ASCII` (which means
-    "characters within ASCII are ASCII, others are no-one-knows-what") will
-    _not_ work well with PL/Java, raising exceptions whenever strings contain
-    non-ASCII characters. (PL/Java can still be used in such a database, but
-    the application code needs to know what it's doing and use the right
-    conversion functions where needed.)
+    particular, the PostgreSQL pseudo-encoding `SQL_ASCII` does not fully
+    define what any values outside ASCII represent; it is usable, but
+    [subject to limitations][sqlascii].
 
 `pljava.debug`
 : A boolean variable that, if set `on`, stops the process on first entry to
@@ -183,4 +180,4 @@ These PostgreSQL configuration variables can influence PL/Java's operation:
 [jow]: https://docs.oracle.com/javase/8/docs/technotes/tools/windows/java.html
 [jou]: https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html
 [vmop]: ../install/vmoptions.html
-
+[sqlascii]: charsets.html#Using_PLJava_with_server_encoding_SQL_ASCII


### PR DESCRIPTION
PostgreSQL's legacy `SQL_ASCII` encoding is difficult to use in Java because 128 of its code points have no defined mapping to Unicode, which Java uses. Add a Java `Charset` supporting the encoding names `X-PGSQL_ASCII` or `SQL_ASCII`, which maps the ASCII characters as expected, and reversibly encodes the others using Unicode permanently-undefined codepoints; Java code can then use assorted `String` methods, regular expressions, etc., which will generally match in the ASCII regions and, with some care, leave the non-ASCII parts unmolested.