### PR TITLE
Migrate a few examples to ResultSetProvider.Large

### DIFF
--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/UsingProperties.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/UsingProperties.java
@@ -31,7 +31,7 @@ import org.postgresql.pljava.SessionManager;
  * of PL/Java's {@code ObjectPool} facility.
  * @author Thomas Hallgren
  */
-public class UsingProperties implements ResultSetProvider, PooledObject {
+public class UsingProperties implements ResultSetProvider.Large, PooledObject {
 	private static Logger s_logger = Logger.getAnonymousLogger();
 
 	public static ResultSetProvider getProperties() throws SQLException {
@@ -71,7 +71,7 @@ public class UsingProperties implements ResultSetProvider, PooledObject {
 	}
 
 	@Override
-	public boolean assignRowValues(ResultSet receiver, int currentRow)
+	public boolean assignRowValues(ResultSet receiver, long currentRow)
 			throws SQLException {
 		if (m_propertyIterator == null || !m_propertyIterator.hasMoreElements()) {
 			s_logger.fine("no more rows, returning false");

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/UsingProperties.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/UsingProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2013 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2020 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -9,6 +9,7 @@
  * Contributors:
  *   Tada AB
  *   Purdue University
+ *   Chapman Flack
  */
 package org.postgresql.pljava.example.annotation;
 
@@ -32,7 +33,7 @@ import org.postgresql.pljava.ResultSetProvider;
  * interface.
  * @author Thomas Hallgren
  */
-public class UsingProperties implements ResultSetProvider
+public class UsingProperties implements ResultSetProvider.Large
 {
 	private static Logger s_logger = Logger.getAnonymousLogger();
 	private final Iterator m_propertyIterator;
@@ -56,7 +57,7 @@ public class UsingProperties implements ResultSetProvider
 		}
 	}
 
-	public boolean assignRowValues(ResultSet receiver, int currentRow)
+	public boolean assignRowValues(ResultSet receiver, long currentRow)
 			throws SQLException
 	{
 		if(!m_propertyIterator.hasNext())

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/saxon/S9.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/saxon/S9.java
@@ -230,7 +230,7 @@ import org.xml.sax.SAXException;
  *	 'let $e := PREMIER_NAME
  *	  return if ( empty($e) )then $DPREMIER else $e'
  *	]) AS (
- *	 id int, ordinality int, "COUNTRY_NAME" text, country_id text,
+ *	 id int, ordinality int8, "COUNTRY_NAME" text, country_id text,
  *	 size_sq_km float, size_other text, premier_name text
  *	);
  *</pre>
@@ -288,7 +288,7 @@ import org.xml.sax.SAXException;
  * XQuery regular-expression methods provided here.
  * @author Chapman Flack
  */
-public class S9 implements ResultSetProvider
+public class S9 implements ResultSetProvider.Large
 {
 	private S9(
 		XdmSequenceIterator<XdmItem> xsi,
@@ -803,8 +803,9 @@ public class S9 implements ResultSetProvider
 	 * columns in the column definition list that follows the SQL call to this
 	 * function. This array must not be null. It is allowed for one element (and
 	 * no more than one) to be null, marking the corresponding column to be
-	 * "FOR ORDINALITY" (the column must be of integer, or, ahem, "exact numeric
-	 * with scale zero", type).
+	 * "FOR ORDINALITY" (the column must be of "exact numeric with scale zero"
+	 * type; PostgreSQL supports 64-bit row counters, so {@code int8} is
+	 * recommended).
 	 * @param passing A row value whose columns will be supplied to the query
 	 * as parameters, just as described for
 	 * {@link #xq_ret_content xq_ret_content()}. If a context item is supplied,
@@ -1188,7 +1189,7 @@ public class S9 implements ResultSetProvider
 	 * be changed to match a future clarification of the spec.
 	 */
 	@Override
-	public boolean assignRowValues(ResultSet receive, int currentRow)
+	public boolean assignRowValues(ResultSet receive, long currentRow)
 	throws SQLException
 	{
 		if ( 0 == currentRow )
@@ -1308,7 +1309,7 @@ public class S9 implements ResultSetProvider
 
 			if ( null == xqe )
 			{
-				receive.updateInt( i, currentRow);
+				receive.updateLong( i, currentRow);
 				continue;
 			}
 


### PR DESCRIPTION
Not necessarily the ones most likely to need 64-bit row counts (at the moment, I think even Saxon has an internal limitation to 32-bit sequence lengths), but these are trivial to update, and at least serve to illustrate use of the interface.