### PR TITLE
Teach the SQL generator to declare PostgreSQL casts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -250,6 +250,22 @@ script: |
         // state 9: must be end of input
         (o,p,q) -> null == o
       );
+
+      /*
+       * Also confirm that the generated undeploy actions work.
+       */
+      succeeding &= stateMachine(
+        "remove jar void result",
+        null,
+
+        q(c, "SELECT sqlj.remove_jar('examples', true)")
+        .flatMap(Node::semiFlattenDiagnostics)
+        .peek(Node::peek),
+
+        (o,p,q) -> isDiagnostic(o, Set.of("error")) ? 1 : -2,
+        (o,p,q) -> isVoidResultSet(o, 1, 1) ? 3 : false,
+        (o,p,q) -> null == o
+      );
     }
   } catch ( Throwable t )
   {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -188,6 +188,22 @@ test_script:
             // state 9: must be end of input
             (o,p,q) -> null == o
           );
+
+          /*
+           * Also confirm that the generated undeploy actions work.
+           */
+          succeeding &= stateMachine(
+            "remove jar void result",
+            null,
+
+            q(c, "SELECT sqlj.remove_jar('examples', true)")
+            .flatMap(Node::semiFlattenDiagnostics)
+            .peek(Node::peek),
+
+            (o,p,q) -> isDiagnostic(o, Set.of("error")) ? 1 : -2,
+            (o,p,q) -> isVoidResultSet(o, 1, 1) ? 3 : false,
+            (o,p,q) -> null == o
+          );
         }
       } catch ( Throwable t )
       {

--- a/pljava-api/src/main/java/org/postgresql/pljava/annotation/Cast.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/annotation/Cast.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2020 Tada AB and other contributors, as listed below.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Chapman Flack
+ */
+package org.postgresql.pljava.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Declares a PostgreSQL {@code CAST}.
+ *<p>
+ * May annotate a Java method (which should also carry a
+ * {@link Function @Function} annotation, making it a PostgreSQL function),
+ * or a class or interface (just to have a place to put it when not directly
+ * associated with a method).
+ *<p>
+ * If not applied to a method, must supply {@code path=} specifying
+ * {@code BINARY} or {@code INOUT}.
+ *<p>
+ * The source and target types must be specified with {@code from} and
+ * {@code to}, unless the annotation appears on a method, in which case these
+ * default to the first parameter and return types of the function,
+ * respectively.
+ *<p>
+ * The cast will, by default, have to be applied explicitly, unless
+ * {@code application=ASSIGNMENT} or {@code application=IMPLICIT} is given.
+ *
+ * @author Chapman Flack
+ */
+@Documented
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Repeatable(Cast.Container.class)
+@Retention(RetentionPolicy.CLASS)
+public @interface Cast
+{
+	/**
+	 * When this cast can be applied: only in explicit form, when used in
+	 * assignment context, or implicitly whenever needed.
+	 */
+	enum Application { EXPLICIT, ASSIGNMENT, IMPLICIT };
+
+	/**
+	 * A known conversion path when a dedicated function is not supplied:
+	 * {@code BINARY} for two types that are known to have the same internal
+	 * representation, or {@code INOUT} to invoke the first type's text-output
+	 * function followed by the second type's text-input function.
+	 */
+	enum Path { BINARY, INOUT };
+
+	/**
+	 * The source type to be cast. Will default to the first parameter type of
+	 * the associated function, if known.
+	 *<p>
+	 * PostgreSQL will allow this type and the function's first parameter type
+	 * to differ, if there is an existing binary cast between them. That cannot
+	 * be checked at compile time, so a cast with a different type given here
+	 * might successfully compile but fail to deploy in PostgreSQL.
+	 */
+	String from() default "";
+
+	/**
+	 * The target type to cast to. Will default to the return type of
+	 * the associated function, if known.
+	 *<p>
+	 * PostgreSQL will allow this type and the function's return type
+	 * to differ, if there is an existing binary cast between them. That cannot
+	 * be checked at compile time, so a cast with a different type given here
+	 * might successfully compile but fail to deploy in PostgreSQL.
+	 */
+	String to() default "";
+
+	/**
+	 * A stock conversion path when a dedicated function is not supplied:
+	 * {@code BINARY} for two types that are known to have the same internal
+	 * representation, or {@code INOUT} to invoke the first type's text-output
+	 * function followed by the second type's text-input function.
+	 *<p>
+	 * To declare an {@code INOUT} cast, {@code with=INOUT} must appear
+	 * explicitly; the default value is treated as unspecified.
+	 */
+	Path path() default Path.INOUT;
+
+	/**
+	 * When this cast can be applied: only in explicit form, when used in
+	 * assignment context, or implicitly whenever needed.
+	 */
+	Application application() default Application.EXPLICIT;
+
+	/**
+	 * One or more arbitrary labels that will be considered 'provided' by the
+	 * object carrying this annotation. The deployment descriptor will be
+	 * generated in such an order that other objects that 'require' labels
+	 * 'provided' by this come later in the output for install actions, and
+	 * earlier for remove actions.
+	 */
+	String[] provides() default {};
+
+	/**
+	 * One or more arbitrary labels that will be considered 'required' by the
+	 * object carrying this annotation. The deployment descriptor will be
+	 * generated in such an order that other objects that 'provide' labels
+	 * 'required' by this come earlier in the output for install actions, and
+	 * later for remove actions.
+	 */
+	String[] requires() default {};
+
+	/**
+	 * The {@code <implementor name>} to be used around SQL code generated
+	 * for this cast. Defaults to {@code PostgreSQL}. Set explicitly to
+	 * {@code ""} to emit code not wrapped in an {@code <implementor block>}.
+	 */
+	String implementor() default "";
+
+	/**
+	 * A comment to be associated with the cast. If left to default, and the
+	 * annotated Java construct has a doc comment, its first sentence will be
+	 * used. If an empty string is explicitly given, no comment will be set.
+	 */
+	String comment() default "";
+
+	/**
+	 * @hidden container type allowing Cast to be repeatable.
+	 */
+	@Documented
+	@Target({ElementType.METHOD, ElementType.TYPE})
+	@Retention(RetentionPolicy.CLASS)
+	@interface Container
+	{
+		Cast[] value();
+	}
+}

--- a/pljava-api/src/main/java/org/postgresql/pljava/annotation/SQLAction.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/annotation/SQLAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2013 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2020 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -14,6 +14,7 @@ package org.postgresql.pljava.annotation;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -35,6 +36,7 @@ import java.lang.annotation.Target;
  */
 @Documented
 @Target({ElementType.PACKAGE,ElementType.TYPE})
+@Repeatable(SQLActions.class)
 @Retention(RetentionPolicy.CLASS)
 public @interface SQLAction
 {

--- a/pljava-api/src/main/java/org/postgresql/pljava/annotation/SQLActions.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/annotation/SQLActions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2013 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2020 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -21,7 +21,11 @@ import java.lang.annotation.Target;
 /**
  * Container for multiple {@link SQLAction} annotations (in case it is
  * convenient to hang more than one on a given program element).
- *
+ *<p>
+ * This container annotation is documented for historical reasons (it existed
+ * in PL/Java versions targeting earlier Java versions than 8). In new code, it
+ * would be more natural to simply hang more than one {@code SQLAction}
+ * annotation directly on a program element.
  * @author Thomas Hallgren - pre-Java6 version
  * @author Chapman Flack (Purdue Mathematics) - updated to Java6,
  * added SQLActions

--- a/pljava-api/src/test/java/LexicalsTest.java
+++ b/pljava-api/src/test/java/LexicalsTest.java
@@ -20,6 +20,7 @@ import junit.framework.TestCase;
 
 import static org.junit.Assert.*;
 import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import static
 	org.postgresql.pljava.sqlgen.Lexicals.ISO_AND_PG_IDENTIFIER_CAPTURING;

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/ConditionalDDR.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/ConditionalDDR.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015- Tada AB and other contributors, as listed below.
+ * Copyright (c) 2015-2020 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -68,7 +68,6 @@ import org.postgresql.pljava.annotation.SQLActions;
  * several statements setting PostgreSQL-version-based implementor tags that
  * are relied on by various other examples in this directory.
  */
-@SQLActions({
 	@SQLAction(provides={"LifeIsGood","LifeIsNotGood"}, install=
 		"SELECT CASE 42 WHEN 42 THEN " +
 		" set_config('pljava.implementors', 'LifeIsGood,' || " +
@@ -77,15 +76,15 @@ import org.postgresql.pljava.annotation.SQLActions;
 		" set_config('pljava.implementors', 'LifeIsNotGood,' || " +
 		"  current_setting('pljava.implementors'), true) " +
 		"END"
-	),
+	)
 
 	@SQLAction(implementor="LifeIsGood", install=
 		"SELECT javatest.logmessage('INFO', 'Looking good!')"
-	),
+	)
 
 	@SQLAction(implementor="LifeIsNotGood", install=
 		"SELECT javatest.logmessage('WARNING', 'This should not be executed')"
-	),
+	)
 
 	@SQLAction(provides="postgresql_ge_80300", install=
 		"SELECT CASE WHEN" +
@@ -93,7 +92,7 @@ import org.postgresql.pljava.annotation.SQLActions;
 		" THEN set_config('pljava.implementors', 'postgresql_ge_80300,' || " +
 		" current_setting('pljava.implementors'), true) " +
 		"END"
-	),
+	)
 
 	@SQLAction(provides="postgresql_ge_80400", install=
 		"SELECT CASE WHEN" +
@@ -101,7 +100,7 @@ import org.postgresql.pljava.annotation.SQLActions;
 		" THEN set_config('pljava.implementors', 'postgresql_ge_80400,' || " +
 		" current_setting('pljava.implementors'), true) " +
 		"END"
-	),
+	)
 
 	@SQLAction(provides="postgresql_ge_90000", install=
 		"SELECT CASE WHEN" +
@@ -109,7 +108,7 @@ import org.postgresql.pljava.annotation.SQLActions;
 		" THEN set_config('pljava.implementors', 'postgresql_ge_90000,' || " +
 		" current_setting('pljava.implementors'), true) " +
 		"END"
-	),
+	)
 
 	@SQLAction(provides="postgresql_ge_90100", install=
 		"SELECT CASE WHEN" +
@@ -117,7 +116,7 @@ import org.postgresql.pljava.annotation.SQLActions;
 		" THEN set_config('pljava.implementors', 'postgresql_ge_90100,' || " +
 		" current_setting('pljava.implementors'), true) " +
 		"END"
-	),
+	)
 
 	@SQLAction(provides="postgresql_ge_90300", install=
 		"SELECT CASE WHEN" +
@@ -125,7 +124,7 @@ import org.postgresql.pljava.annotation.SQLActions;
 		" THEN set_config('pljava.implementors', 'postgresql_ge_90300,' || " +
 		" current_setting('pljava.implementors'), true) " +
 		"END"
-	),
+	)
 
 	@SQLAction(provides="postgresql_ge_100000", install=
 		"SELECT CASE WHEN" +
@@ -133,6 +132,5 @@ import org.postgresql.pljava.annotation.SQLActions;
 		" THEN set_config('pljava.implementors', 'postgresql_ge_100000,' || " +
 		" current_setting('pljava.implementors'), true) " +
 		"END"
-	),
-})
+	)
 public class ConditionalDDR { }

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/ConditionalDDR.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/ConditionalDDR.java
@@ -68,69 +68,69 @@ import org.postgresql.pljava.annotation.SQLActions;
  * several statements setting PostgreSQL-version-based implementor tags that
  * are relied on by various other examples in this directory.
  */
-	@SQLAction(provides={"LifeIsGood","LifeIsNotGood"}, install=
-		"SELECT CASE 42 WHEN 42 THEN " +
-		" set_config('pljava.implementors', 'LifeIsGood,' || " +
-		"  current_setting('pljava.implementors'), true) " +
-		"ELSE " +
-		" set_config('pljava.implementors', 'LifeIsNotGood,' || " +
-		"  current_setting('pljava.implementors'), true) " +
-		"END"
-	)
+@SQLAction(provides={"LifeIsGood","LifeIsNotGood"}, install=
+	"SELECT CASE 42 WHEN 42 THEN " +
+	" set_config('pljava.implementors', 'LifeIsGood,' || " +
+	"  current_setting('pljava.implementors'), true) " +
+	"ELSE " +
+	" set_config('pljava.implementors', 'LifeIsNotGood,' || " +
+	"  current_setting('pljava.implementors'), true) " +
+	"END"
+)
 
-	@SQLAction(implementor="LifeIsGood", install=
-		"SELECT javatest.logmessage('INFO', 'Looking good!')"
-	)
+@SQLAction(implementor="LifeIsGood", install=
+	"SELECT javatest.logmessage('INFO', 'Looking good!')"
+)
 
-	@SQLAction(implementor="LifeIsNotGood", install=
-		"SELECT javatest.logmessage('WARNING', 'This should not be executed')"
-	)
+@SQLAction(implementor="LifeIsNotGood", install=
+	"SELECT javatest.logmessage('WARNING', 'This should not be executed')"
+)
 
-	@SQLAction(provides="postgresql_ge_80300", install=
-		"SELECT CASE WHEN" +
-		" 80300 <= CAST(current_setting('server_version_num') AS integer)" +
-		" THEN set_config('pljava.implementors', 'postgresql_ge_80300,' || " +
-		" current_setting('pljava.implementors'), true) " +
-		"END"
-	)
+@SQLAction(provides="postgresql_ge_80300", install=
+	"SELECT CASE WHEN" +
+	" 80300 <= CAST(current_setting('server_version_num') AS integer)" +
+	" THEN set_config('pljava.implementors', 'postgresql_ge_80300,' || " +
+	" current_setting('pljava.implementors'), true) " +
+	"END"
+)
 
-	@SQLAction(provides="postgresql_ge_80400", install=
-		"SELECT CASE WHEN" +
-		" 80400 <= CAST(current_setting('server_version_num') AS integer)" +
-		" THEN set_config('pljava.implementors', 'postgresql_ge_80400,' || " +
-		" current_setting('pljava.implementors'), true) " +
-		"END"
-	)
+@SQLAction(provides="postgresql_ge_80400", install=
+	"SELECT CASE WHEN" +
+	" 80400 <= CAST(current_setting('server_version_num') AS integer)" +
+	" THEN set_config('pljava.implementors', 'postgresql_ge_80400,' || " +
+	" current_setting('pljava.implementors'), true) " +
+	"END"
+)
 
-	@SQLAction(provides="postgresql_ge_90000", install=
-		"SELECT CASE WHEN" +
-		" 90000 <= CAST(current_setting('server_version_num') AS integer)" +
-		" THEN set_config('pljava.implementors', 'postgresql_ge_90000,' || " +
-		" current_setting('pljava.implementors'), true) " +
-		"END"
-	)
+@SQLAction(provides="postgresql_ge_90000", install=
+	"SELECT CASE WHEN" +
+	" 90000 <= CAST(current_setting('server_version_num') AS integer)" +
+	" THEN set_config('pljava.implementors', 'postgresql_ge_90000,' || " +
+	" current_setting('pljava.implementors'), true) " +
+	"END"
+)
 
-	@SQLAction(provides="postgresql_ge_90100", install=
-		"SELECT CASE WHEN" +
-		" 90100 <= CAST(current_setting('server_version_num') AS integer)" +
-		" THEN set_config('pljava.implementors', 'postgresql_ge_90100,' || " +
-		" current_setting('pljava.implementors'), true) " +
-		"END"
-	)
+@SQLAction(provides="postgresql_ge_90100", install=
+	"SELECT CASE WHEN" +
+	" 90100 <= CAST(current_setting('server_version_num') AS integer)" +
+	" THEN set_config('pljava.implementors', 'postgresql_ge_90100,' || " +
+	" current_setting('pljava.implementors'), true) " +
+	"END"
+)
 
-	@SQLAction(provides="postgresql_ge_90300", install=
-		"SELECT CASE WHEN" +
-		" 90300 <= CAST(current_setting('server_version_num') AS integer)" +
-		" THEN set_config('pljava.implementors', 'postgresql_ge_90300,' || " +
-		" current_setting('pljava.implementors'), true) " +
-		"END"
-	)
+@SQLAction(provides="postgresql_ge_90300", install=
+	"SELECT CASE WHEN" +
+	" 90300 <= CAST(current_setting('server_version_num') AS integer)" +
+	" THEN set_config('pljava.implementors', 'postgresql_ge_90300,' || " +
+	" current_setting('pljava.implementors'), true) " +
+	"END"
+)
 
-	@SQLAction(provides="postgresql_ge_100000", install=
-		"SELECT CASE WHEN" +
-		" 100000 <= CAST(current_setting('server_version_num') AS integer)" +
-		" THEN set_config('pljava.implementors', 'postgresql_ge_100000,' || " +
-		" current_setting('pljava.implementors'), true) " +
-		"END"
-	)
+@SQLAction(provides="postgresql_ge_100000", install=
+	"SELECT CASE WHEN" +
+	" 100000 <= CAST(current_setting('server_version_num') AS integer)" +
+	" THEN set_config('pljava.implementors', 'postgresql_ge_100000,' || " +
+	" current_setting('pljava.implementors'), true) " +
+	"END"
+)
 public class ConditionalDDR { }

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/ConditionalDDR.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/ConditionalDDR.java
@@ -12,7 +12,6 @@
 package org.postgresql.pljava.example.annotation;
 
 import org.postgresql.pljava.annotation.SQLAction;
-import org.postgresql.pljava.annotation.SQLActions;
 
 /**
  * Test of a very simple form of conditional execution in the deployment

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/Enumeration.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/Enumeration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015- Tada AB and other contributors, as listed below.
+ * Copyright (c) 2015-2020 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -27,11 +27,10 @@ import org.postgresql.pljava.annotation.Function;
  * version, set up in the {@link ConditionalDDR} example. PostgreSQL before 8.3
  * did not have enum types.
  */
-@SQLActions({
 	@SQLAction(provides="mood type", implementor="postgresql_ge_80300",
 		install="CREATE TYPE mood AS ENUM ('sad', 'ok', 'happy')",
 		remove="DROP TYPE mood"
-	),
+	)
 	@SQLAction(implementor="postgresql_ge_80300",
 		requires={"textToMood", "moodToText", "textsToMoods", "moodsToTexts"},
 		install={
@@ -41,7 +40,6 @@ import org.postgresql.pljava.annotation.Function;
 			"SELECT moodsToTexts(array['happy','happy','sad','ok']::mood[])"
 		}
 	)
-})
 public class Enumeration
 {
 	@Function(requires="mood type", provides="textToMood", type="mood",

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/Enumeration.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/Enumeration.java
@@ -27,19 +27,19 @@ import org.postgresql.pljava.annotation.Function;
  * version, set up in the {@link ConditionalDDR} example. PostgreSQL before 8.3
  * did not have enum types.
  */
-	@SQLAction(provides="mood type", implementor="postgresql_ge_80300",
-		install="CREATE TYPE mood AS ENUM ('sad', 'ok', 'happy')",
-		remove="DROP TYPE mood"
-	)
-	@SQLAction(implementor="postgresql_ge_80300",
-		requires={"textToMood", "moodToText", "textsToMoods", "moodsToTexts"},
-		install={
-			"SELECT textToMood('happy')",
-			"SELECT moodToText('happy'::mood)",
-			"SELECT textsToMoods(array['happy','happy','sad','ok'])",
-			"SELECT moodsToTexts(array['happy','happy','sad','ok']::mood[])"
-		}
-	)
+@SQLAction(provides="mood type", implementor="postgresql_ge_80300",
+	install="CREATE TYPE mood AS ENUM ('sad', 'ok', 'happy')",
+	remove="DROP TYPE mood"
+)
+@SQLAction(implementor="postgresql_ge_80300",
+	requires={"textToMood", "moodToText", "textsToMoods", "moodsToTexts"},
+	install={
+		"SELECT textToMood('happy')",
+		"SELECT moodToText('happy'::mood)",
+		"SELECT textsToMoods(array['happy','happy','sad','ok'])",
+		"SELECT moodsToTexts(array['happy','happy','sad','ok']::mood[])"
+	}
+)
 public class Enumeration
 {
 	@Function(requires="mood type", provides="textToMood", type="mood",

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/Enumeration.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/Enumeration.java
@@ -15,7 +15,6 @@ import java.util.Iterator;
 import java.util.Arrays;
 
 import org.postgresql.pljava.annotation.SQLAction;
-import org.postgresql.pljava.annotation.SQLActions;
 import org.postgresql.pljava.annotation.SQLType;
 import org.postgresql.pljava.annotation.Function;
 

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/JDBC42_21.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/JDBC42_21.java
@@ -27,101 +27,101 @@ import org.postgresql.pljava.example.annotation.ConditionalDDR; // for javadoc
  * Relies on PostgreSQL-version-specific implementor tags set up in the
  * {@link ConditionalDDR} example.
  */
-	@SQLAction(
-		implementor="postgresql_ge_90300",requires="TypeRoundTripper.roundTrip",
-		install={
-		" SELECT" +
-		"  CASE WHEN every(orig = roundtripped)" +
-		"  THEN javatest.logmessage('INFO', 'java.time.LocalDate passes')" +
-		"  ELSE javatest.logmessage('WARNING', 'java.time.LocalDate fails')" +
-		"  END" +
-		" FROM" +
-		"  (VALUES" +
-		"   (date '2017-08-21')," +
-		"   (date '1970-03-07')," +
-		"   (date '1919-05-29')" +
-		"  ) AS p(orig)," +
-		"  javatest.roundtrip(p, 'java.time.LocalDate')" +
-		"  AS r(roundtripped date)",
+@SQLAction(
+	implementor="postgresql_ge_90300",requires="TypeRoundTripper.roundTrip",
+	install={
+	" SELECT" +
+	"  CASE WHEN every(orig = roundtripped)" +
+	"  THEN javatest.logmessage('INFO', 'java.time.LocalDate passes')" +
+	"  ELSE javatest.logmessage('WARNING', 'java.time.LocalDate fails')" +
+	"  END" +
+	" FROM" +
+	"  (VALUES" +
+	"   (date '2017-08-21')," +
+	"   (date '1970-03-07')," +
+	"   (date '1919-05-29')" +
+	"  ) AS p(orig)," +
+	"  javatest.roundtrip(p, 'java.time.LocalDate')" +
+	"  AS r(roundtripped date)",
 
-		" SELECT" +
-		"  CASE WHEN every(orig = roundtripped)" +
-		"  THEN javatest.logmessage('INFO', 'java.time.LocalTime passes')" +
-		"  ELSE javatest.logmessage('WARNING', 'java.time.LocalTime fails')" +
-		"  END" +
-		" FROM" +
-		"  (SELECT current_time::time) AS p(orig)," +
-		"  javatest.roundtrip(p, 'java.time.LocalTime')" +
-		"  AS r(roundtripped time)",
+	" SELECT" +
+	"  CASE WHEN every(orig = roundtripped)" +
+	"  THEN javatest.logmessage('INFO', 'java.time.LocalTime passes')" +
+	"  ELSE javatest.logmessage('WARNING', 'java.time.LocalTime fails')" +
+	"  END" +
+	" FROM" +
+	"  (SELECT current_time::time) AS p(orig)," +
+	"  javatest.roundtrip(p, 'java.time.LocalTime')" +
+	"  AS r(roundtripped time)",
 
-		" SELECT" +
-		"  CASE WHEN every(orig = roundtripped)" +
-		"  THEN javatest.logmessage('INFO', 'java.time.OffsetTime passes')" +
-		"  ELSE javatest.logmessage('WARNING', 'java.time.OffsetTime fails')" +
-		"  END" +
-		" FROM" +
-		"  (SELECT current_time::timetz) AS p(orig)," +
-		"  javatest.roundtrip(p, 'java.time.OffsetTime')" +
-		"  AS r(roundtripped timetz)",
+	" SELECT" +
+	"  CASE WHEN every(orig = roundtripped)" +
+	"  THEN javatest.logmessage('INFO', 'java.time.OffsetTime passes')" +
+	"  ELSE javatest.logmessage('WARNING', 'java.time.OffsetTime fails')" +
+	"  END" +
+	" FROM" +
+	"  (SELECT current_time::timetz) AS p(orig)," +
+	"  javatest.roundtrip(p, 'java.time.OffsetTime')" +
+	"  AS r(roundtripped timetz)",
 
-		" SELECT" +
-		"  CASE WHEN every(orig = roundtripped)" +
-		"  THEN javatest.logmessage('INFO', 'java.time.LocalDateTime passes')" +
-		"  ELSE javatest.logmessage('WARNING','java.time.LocalDateTime fails')"+
-		"  END" +
-		" FROM" +
-		"  (SELECT 'on' = current_setting('integer_datetimes')) AS ck(idt)," +
-		"  LATERAL (" +
-		"   SELECT" +
-		"    value" +
-		"   FROM" +
-		"	 (VALUES" +
-		"	  (true, timestamp '2017-08-21 18:25:29.900005')," +
-		"	  (true, timestamp '1970-03-07 17:37:49.300009')," +
-		"	  (true, timestamp '1919-05-29 13:08:33.600001')," +
-		"	  (idt,  timestamp  'infinity')," +
-		"	  (idt,  timestamp '-infinity')" +
-		"	 ) AS vs(cond, value)" +
-		"   WHERE cond" +
-		"  ) AS p(orig)," +
-		"  javatest.roundtrip(p, 'java.time.LocalDateTime')" +
-		"  AS r(roundtripped timestamp)",
+	" SELECT" +
+	"  CASE WHEN every(orig = roundtripped)" +
+	"  THEN javatest.logmessage('INFO', 'java.time.LocalDateTime passes')" +
+	"  ELSE javatest.logmessage('WARNING','java.time.LocalDateTime fails')"+
+	"  END" +
+	" FROM" +
+	"  (SELECT 'on' = current_setting('integer_datetimes')) AS ck(idt)," +
+	"  LATERAL (" +
+	"   SELECT" +
+	"    value" +
+	"   FROM" +
+	"	 (VALUES" +
+	"	  (true, timestamp '2017-08-21 18:25:29.900005')," +
+	"	  (true, timestamp '1970-03-07 17:37:49.300009')," +
+	"	  (true, timestamp '1919-05-29 13:08:33.600001')," +
+	"	  (idt,  timestamp  'infinity')," +
+	"	  (idt,  timestamp '-infinity')" +
+	"	 ) AS vs(cond, value)" +
+	"   WHERE cond" +
+	"  ) AS p(orig)," +
+	"  javatest.roundtrip(p, 'java.time.LocalDateTime')" +
+	"  AS r(roundtripped timestamp)",
 
-		" SELECT" +
-		"  CASE WHEN every(orig = roundtripped)" +
-		"  THEN javatest.logmessage('INFO', 'java.time.OffsetDateTime passes')"+
-		"  ELSE javatest.logmessage(" +
-		"         'WARNING','java.time.OffsetDateTime fails')"+
-		"  END" +
-		" FROM" +
-		"  (SELECT 'on' = current_setting('integer_datetimes')) AS ck(idt)," +
-		"  LATERAL (" +
-		"   SELECT" +
-		"    value" +
-		"   FROM" +
-		"	 (VALUES" +
-		"	  (true, timestamptz '2017-08-21 18:25:29.900005Z')," +
-		"	  (true, timestamptz '1970-03-07 17:37:49.300009Z')," +
-		"	  (true, timestamptz '1919-05-29 13:08:33.600001Z')," +
-		"	  (idt,  timestamptz  'infinity')," +
-		"	  (idt,  timestamptz '-infinity')" +
-		"	 ) AS vs(cond, value)" +
-		"   WHERE cond" +
-		"  ) AS p(orig)," +
-		"  javatest.roundtrip(p, 'java.time.OffsetDateTime')" +
-		"  AS r(roundtripped timestamptz)",
+	" SELECT" +
+	"  CASE WHEN every(orig = roundtripped)" +
+	"  THEN javatest.logmessage('INFO', 'java.time.OffsetDateTime passes')"+
+	"  ELSE javatest.logmessage(" +
+	"         'WARNING','java.time.OffsetDateTime fails')"+
+	"  END" +
+	" FROM" +
+	"  (SELECT 'on' = current_setting('integer_datetimes')) AS ck(idt)," +
+	"  LATERAL (" +
+	"   SELECT" +
+	"    value" +
+	"   FROM" +
+	"	 (VALUES" +
+	"	  (true, timestamptz '2017-08-21 18:25:29.900005Z')," +
+	"	  (true, timestamptz '1970-03-07 17:37:49.300009Z')," +
+	"	  (true, timestamptz '1919-05-29 13:08:33.600001Z')," +
+	"	  (idt,  timestamptz  'infinity')," +
+	"	  (idt,  timestamptz '-infinity')" +
+	"	 ) AS vs(cond, value)" +
+	"   WHERE cond" +
+	"  ) AS p(orig)," +
+	"  javatest.roundtrip(p, 'java.time.OffsetDateTime')" +
+	"  AS r(roundtripped timestamptz)",
 
-		" SELECT" +
-		"  CASE WHEN every(orig = roundtripped)" +
-		"  THEN javatest.logmessage('INFO', 'OffsetTime as stmt param passes')"+
-		"  ELSE javatest.logmessage(" +
-		"         'WARNING','java.time.OffsetTime as stmt param fails')"+
-		"  END" +
-		" FROM" +
-		"  (SELECT current_time::timetz) AS p(orig)," +
-		"  javatest.roundtrip(p, 'java.time.OffsetTime', true)" +
-		"  AS r(roundtripped timetz)"
-	})
+	" SELECT" +
+	"  CASE WHEN every(orig = roundtripped)" +
+	"  THEN javatest.logmessage('INFO', 'OffsetTime as stmt param passes')"+
+	"  ELSE javatest.logmessage(" +
+	"         'WARNING','java.time.OffsetTime as stmt param fails')"+
+	"  END" +
+	" FROM" +
+	"  (SELECT current_time::timetz) AS p(orig)," +
+	"  javatest.roundtrip(p, 'java.time.OffsetTime', true)" +
+	"  AS r(roundtripped timetz)"
+})
 public class JDBC42_21
 {
 	/**

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/JDBC42_21.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/JDBC42_21.java
@@ -27,7 +27,6 @@ import org.postgresql.pljava.example.annotation.ConditionalDDR; // for javadoc
  * Relies on PostgreSQL-version-specific implementor tags set up in the
  * {@link ConditionalDDR} example.
  */
-@SQLActions({
 	@SQLAction(
 		implementor="postgresql_ge_90300",requires="TypeRoundTripper.roundTrip",
 		install={
@@ -123,7 +122,6 @@ import org.postgresql.pljava.example.annotation.ConditionalDDR; // for javadoc
 		"  javatest.roundtrip(p, 'java.time.OffsetTime', true)" +
 		"  AS r(roundtripped timetz)"
 	})
-})
 public class JDBC42_21
 {
 	/**

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/JDBC42_21.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/JDBC42_21.java
@@ -13,7 +13,6 @@ package org.postgresql.pljava.example.annotation;
 
 import org.postgresql.pljava.annotation.Function;
 import org.postgresql.pljava.annotation.SQLAction;
-import org.postgresql.pljava.annotation.SQLActions;
 
 import org.postgresql.pljava.example.annotation.ConditionalDDR; // for javadoc
 

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/PassXML.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/PassXML.java
@@ -105,13 +105,12 @@ import org.w3c.dom.bootstrap.DOMImplementationRegistry;
  * Everything mentioning the type XML here needs a conditional implementor tag
  * in case of being loaded into a PostgreSQL instance built without that type.
  */
-@SQLActions({
 	@SQLAction(provides="postgresql_xml", install=
 		"SELECT CASE (SELECT 1 FROM pg_type WHERE typname = 'xml') WHEN 1" +
 		" THEN set_config('pljava.implementors', 'postgresql_xml,' || " +
 		" current_setting('pljava.implementors'), true) " +
 		"END"
-	),
+	)
 
 	@SQLAction(implementor="postgresql_ge_80400",
 		provides="postgresql_xml_ge84",
@@ -120,7 +119,7 @@ import org.w3c.dom.bootstrap.DOMImplementationRegistry;
 		" THEN set_config('pljava.implementors', 'postgresql_xml_ge84,' || " +
 		" current_setting('pljava.implementors'), true) " +
 		"END"
-	),
+	)
 
 	@SQLAction(implementor="postgresql_xml_ge84", requires="echoXMLParameter",
 		install=
@@ -145,7 +144,7 @@ import org.w3c.dom.bootstrap.DOMImplementationRegistry;
 		" END " +
 		"FROM" +
 		" r"
-	),
+	)
 
 	@SQLAction(implementor="postgresql_xml_ge84", requires="proxiedXMLEcho",
 		install=
@@ -169,7 +168,7 @@ import org.w3c.dom.bootstrap.DOMImplementationRegistry;
 		" END " +
 		"FROM" +
 		" r"
-	),
+	)
 
 	@SQLAction(implementor="postgresql_xml_ge84", requires="lowLevelXMLEcho",
 		install={
@@ -211,7 +210,7 @@ import org.w3c.dom.bootstrap.DOMImplementationRegistry;
 		"FROM" +
 		" r"
 		}
-	),
+	)
 
 	@SQLAction(implementor="postgresql_xml",
 			   requires={"prepareXMLTransform", "transformXML"},
@@ -250,7 +249,6 @@ import org.w3c.dom.bootstrap.DOMImplementationRegistry;
 			" END"
 		}
 	)
-})
 @MappedUDT(schema="javatest", name="onexml", structure="c1 xml",
 		   implementor="postgresql_xml",
            comment="A composite type mapped by the PassXML example class")

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/PassXML.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/PassXML.java
@@ -67,7 +67,6 @@ import org.postgresql.pljava.Adjusting;
 import org.postgresql.pljava.annotation.Function;
 import org.postgresql.pljava.annotation.MappedUDT;
 import org.postgresql.pljava.annotation.SQLAction;
-import org.postgresql.pljava.annotation.SQLActions;
 import org.postgresql.pljava.annotation.SQLType;
 
 import static org.postgresql.pljava.example.LoggerTest.logMessage;

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/PreJSR310.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/PreJSR310.java
@@ -34,16 +34,16 @@ import org.postgresql.pljava.annotation.SQLActions;
  * This example relies on {@code implementor} tags reflecting the PostgreSQL
  * version, set up in the {@link ConditionalDDR} example.
  */
-	@SQLAction(provides="language java_tzset", install={
-		"SELECT sqlj.alias_java_language('java_tzset', true)"
-	}, remove={
-		"DROP LANGUAGE java_tzset"
-	})
+@SQLAction(provides="language java_tzset", install={
+	"SELECT sqlj.alias_java_language('java_tzset', true)"
+}, remove={
+	"DROP LANGUAGE java_tzset"
+})
 
-	@SQLAction(implementor="postgresql_ge_90300", // needs LATERAL
-		requires="issue199", install={
-		"SELECT javatest.issue199()"
-	})
+@SQLAction(implementor="postgresql_ge_90300", // needs LATERAL
+	requires="issue199", install={
+	"SELECT javatest.issue199()"
+})
 public class PreJSR310
 {
 	private static final String TZPRAGUE = "Europe/Prague";

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/PreJSR310.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/PreJSR310.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018- Tada AB and other contributors, as listed below.
+ * Copyright (c) 2018-2020 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -34,18 +34,16 @@ import org.postgresql.pljava.annotation.SQLActions;
  * This example relies on {@code implementor} tags reflecting the PostgreSQL
  * version, set up in the {@link ConditionalDDR} example.
  */
-@SQLActions({
 	@SQLAction(provides="language java_tzset", install={
 		"SELECT sqlj.alias_java_language('java_tzset', true)"
 	}, remove={
 		"DROP LANGUAGE java_tzset"
-	}),
+	})
 
 	@SQLAction(implementor="postgresql_ge_90300", // needs LATERAL
 		requires="issue199", install={
 		"SELECT javatest.issue199()"
 	})
-})
 public class PreJSR310
 {
 	private static final String TZPRAGUE = "Europe/Prague";

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/PreJSR310.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/PreJSR310.java
@@ -24,7 +24,6 @@ import java.util.TimeZone;
 
 import org.postgresql.pljava.annotation.Function;
 import org.postgresql.pljava.annotation.SQLAction;
-import org.postgresql.pljava.annotation.SQLActions;
 
 /**
  * Some tests of pre-JSR 310 date/time/timestamp conversions.

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/RecordParameterDefaults.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/RecordParameterDefaults.java
@@ -20,7 +20,6 @@ import static java.util.Arrays.fill;
 import org.postgresql.pljava.ResultSetProvider;
 import org.postgresql.pljava.annotation.Function;
 import org.postgresql.pljava.annotation.SQLAction;
-import org.postgresql.pljava.annotation.SQLActions;
 import org.postgresql.pljava.annotation.SQLType;
 
 /**

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/RecordParameterDefaults.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/RecordParameterDefaults.java
@@ -33,17 +33,17 @@ import org.postgresql.pljava.annotation.SQLType;
  * This example relies on {@code implementor} tags reflecting the PostgreSQL
  * version, set up in the {@link ConditionalDDR} example.
  */
-	@SQLAction(
-		provides = "paramtypeinfo type", // created in Triggers.java
-		install = {
-			"CREATE TYPE javatest.paramtypeinfo AS (" +
-			" name text, pgtypename text, javaclass text, tostring text" +
-			")"
-		},
-		remove = {
-			"DROP TYPE javatest.paramtypeinfo"
-		}
-	)
+@SQLAction(
+	provides = "paramtypeinfo type", // created in Triggers.java
+	install = {
+		"CREATE TYPE javatest.paramtypeinfo AS (" +
+		" name text, pgtypename text, javaclass text, tostring text" +
+		")"
+	},
+	remove = {
+		"DROP TYPE javatest.paramtypeinfo"
+	}
+)
 public class RecordParameterDefaults implements ResultSetProvider
 {
 	/**

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/RecordParameterDefaults.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/RecordParameterDefaults.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018- Tada AB and other contributors, as listed below.
+ * Copyright (c) 2018-2020 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -33,7 +33,6 @@ import org.postgresql.pljava.annotation.SQLType;
  * This example relies on {@code implementor} tags reflecting the PostgreSQL
  * version, set up in the {@link ConditionalDDR} example.
  */
-@SQLActions({
 	@SQLAction(
 		provides = "paramtypeinfo type", // created in Triggers.java
 		install = {
@@ -45,7 +44,6 @@ import org.postgresql.pljava.annotation.SQLType;
 			"DROP TYPE javatest.paramtypeinfo"
 		}
 	)
-})
 public class RecordParameterDefaults implements ResultSetProvider
 {
 	/**

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/SPIActions.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/SPIActions.java
@@ -38,28 +38,28 @@ import org.postgresql.pljava.annotation.SQLActions;
  *
  * @author Thomas Hallgren
  */
-	@SQLAction(provides = "employees tables", install = {
-		"CREATE TABLE javatest.employees1" +
-		" (" +
-		" id     int PRIMARY KEY," +
-		" name   varchar(200)," +
-		" salary int" +
-		" )",
+@SQLAction(provides = "employees tables", install = {
+	"CREATE TABLE javatest.employees1" +
+	" (" +
+	" id     int PRIMARY KEY," +
+	" name   varchar(200)," +
+	" salary int" +
+	" )",
 
-		"CREATE TABLE javatest.employees2" +
-		" (" +
-		" id		int PRIMARY KEY," +
-		" name	varchar(200)," +
-		" salary	int," +
-		" transferDay date," +
-		" transferTime time" +
-		" )"
-		}, remove = {
-		"DROP TABLE javatest.employees2",
-		"DROP TABLE javatest.employees1"
-	}
-	)
-	@SQLAction(requires = "issue228", install = "SELECT javatest.issue228()")
+	"CREATE TABLE javatest.employees2" +
+	" (" +
+	" id		int PRIMARY KEY," +
+	" name	varchar(200)," +
+	" salary	int," +
+	" transferDay date," +
+	" transferTime time" +
+	" )"
+	}, remove = {
+	"DROP TABLE javatest.employees2",
+	"DROP TABLE javatest.employees1"
+}
+)
+@SQLAction(requires = "issue228", install = "SELECT javatest.issue228()")
 public class SPIActions {
 	private static final String SP_CHECKSTATE = "sp.checkState";
 

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/SPIActions.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/SPIActions.java
@@ -31,7 +31,6 @@ import org.postgresql.pljava.TransactionListener;
 import org.postgresql.pljava.annotation.Function;
 import static org.postgresql.pljava.annotation.Function.Effects.*;
 import org.postgresql.pljava.annotation.SQLAction;
-import org.postgresql.pljava.annotation.SQLActions;
 
 /**
  * Some methods used for testing the SPI JDBC driver.

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/SPIActions.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/SPIActions.java
@@ -38,7 +38,6 @@ import org.postgresql.pljava.annotation.SQLActions;
  *
  * @author Thomas Hallgren
  */
-@SQLActions({
 	@SQLAction(provides = "employees tables", install = {
 		"CREATE TABLE javatest.employees1" +
 		" (" +
@@ -59,9 +58,8 @@ import org.postgresql.pljava.annotation.SQLActions;
 		"DROP TABLE javatest.employees2",
 		"DROP TABLE javatest.employees1"
 	}
-	),
+	)
 	@SQLAction(requires = "issue228", install = "SELECT javatest.issue228()")
-})
 public class SPIActions {
 	private static final String SP_CHECKSTATE = "sp.checkState";
 

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/Triggers.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/Triggers.java
@@ -42,39 +42,39 @@ import static org.postgresql.pljava.example.LoggerTest.logMessage;
  * version, set up in the {@link ConditionalDDR} example. Constraint triggers
  * appear in PG 9.1, transition tables in PG 10.
  */
-	@SQLAction(
-		provides = "foobar tables",
-		install = {
-			"CREATE TABLE javatest.foobar_1 ( username text, stuff text )",
-			"CREATE TABLE javatest.foobar_2 ( username text, value numeric )"
-		},
-		remove = {
-			"DROP TABLE javatest.foobar_2",
-			"DROP TABLE javatest.foobar_1"
-		}
-	)
-	@SQLAction(
-		requires = "constraint triggers",
-		install = "INSERT INTO javatest.foobar_2(value) VALUES (45)"
-	)
-	@SQLAction(
-		requires = "foobar triggers",
-		provides = "foobar2_42",
-		install = "INSERT INTO javatest.foobar_2(value) VALUES (42)"
-	)
-	@SQLAction(
-		requires = { "transition triggers", "foobar2_42" },
-		install = "UPDATE javatest.foobar_2 SET value = 43 WHERE value = 42"
-	)
-	/*
-	 * Note for another day: this would seem an excellent place to add a
-	 * regression test for github issue #134 (make sure invocations of a
-	 * trigger do not fail with SPI_ERROR_UNCONNECTED). However, any test
-	 * here that runs from the deployment descriptor will be running when
-	 * SPI is already connected, so a regression would not be caught.
-	 * A proper test for it will have to wait for a proper testing harness
-	 * invoking tests from outside PL/Java itself.
-	 */
+@SQLAction(
+	provides = "foobar tables",
+	install = {
+		"CREATE TABLE javatest.foobar_1 ( username text, stuff text )",
+		"CREATE TABLE javatest.foobar_2 ( username text, value numeric )"
+	},
+	remove = {
+		"DROP TABLE javatest.foobar_2",
+		"DROP TABLE javatest.foobar_1"
+	}
+)
+@SQLAction(
+	requires = "constraint triggers",
+	install = "INSERT INTO javatest.foobar_2(value) VALUES (45)"
+)
+@SQLAction(
+	requires = "foobar triggers",
+	provides = "foobar2_42",
+	install = "INSERT INTO javatest.foobar_2(value) VALUES (42)"
+)
+@SQLAction(
+	requires = { "transition triggers", "foobar2_42" },
+	install = "UPDATE javatest.foobar_2 SET value = 43 WHERE value = 42"
+)
+/*
+ * Note for another day: this would seem an excellent place to add a
+ * regression test for github issue #134 (make sure invocations of a
+ * trigger do not fail with SPI_ERROR_UNCONNECTED). However, any test
+ * here that runs from the deployment descriptor will be running when
+ * SPI is already connected, so a regression would not be caught.
+ * A proper test for it will have to wait for a proper testing harness
+ * invoking tests from outside PL/Java itself.
+ */
 public class Triggers
 {
 	/**

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/Triggers.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/Triggers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2013 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2020 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -9,6 +9,7 @@
  * Contributors:
  *   Tada AB
  *   Purdue University
+ *   Chapman Flack
  */
 package org.postgresql.pljava.example.annotation;
 
@@ -41,7 +42,6 @@ import static org.postgresql.pljava.example.LoggerTest.logMessage;
  * version, set up in the {@link ConditionalDDR} example. Constraint triggers
  * appear in PG 9.1, transition tables in PG 10.
  */
-@SQLActions({
 	@SQLAction(
 		provides = "foobar tables",
 		install = {
@@ -52,16 +52,16 @@ import static org.postgresql.pljava.example.LoggerTest.logMessage;
 			"DROP TABLE javatest.foobar_2",
 			"DROP TABLE javatest.foobar_1"
 		}
-	),
+	)
 	@SQLAction(
 		requires = "constraint triggers",
 		install = "INSERT INTO javatest.foobar_2(value) VALUES (45)"
-	),
+	)
 	@SQLAction(
 		requires = "foobar triggers",
 		provides = "foobar2_42",
 		install = "INSERT INTO javatest.foobar_2(value) VALUES (42)"
-	),
+	)
 	@SQLAction(
 		requires = { "transition triggers", "foobar2_42" },
 		install = "UPDATE javatest.foobar_2 SET value = 43 WHERE value = 42"
@@ -75,7 +75,6 @@ import static org.postgresql.pljava.example.LoggerTest.logMessage;
 	 * A proper test for it will have to wait for a proper testing harness
 	 * invoking tests from outside PL/Java itself.
 	 */
-})
 public class Triggers
 {
 	/**

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/Triggers.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/Triggers.java
@@ -23,7 +23,6 @@ import java.sql.Statement;
 import org.postgresql.pljava.TriggerData;
 import org.postgresql.pljava.annotation.Function;
 import org.postgresql.pljava.annotation.SQLAction;
-import org.postgresql.pljava.annotation.SQLActions;
 import org.postgresql.pljava.annotation.Trigger;
 import static org.postgresql.pljava.annotation.Trigger.Called.*;
 import static org.postgresql.pljava.annotation.Trigger.Constraint.*;

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/UnicodeRoundTripTest.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/UnicodeRoundTripTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2015-2020 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -39,7 +39,6 @@ import org.postgresql.pljava.annotation.Function;
  * This example relies on {@code implementor} tags reflecting the PostgreSQL
  * version, set up in the {@link ConditionalDDR} example, and also sets its own.
  */
-@SQLActions({
 	@SQLAction(provides="postgresql_unicodetest",
 		implementor="postgresql_ge_90000", install=
 		"SELECT CASE" +
@@ -47,7 +46,7 @@ import org.postgresql.pljava.annotation.Function;
 		" THEN set_config('pljava.implementors', 'postgresql_unicodetest,' ||" +
 		" current_setting('pljava.implementors'), true) " +
 		"END"
-	),
+	)
 	@SQLAction(requires="unicodetest fn",
 	implementor="postgresql_unicodetest",
 	install=
@@ -88,7 +87,7 @@ import org.postgresql.pljava.annotation.Function;
 "        'all Unicode codepoint ranges roundtripped successfully.') " +
 "    end " +
 "    from test_summary"
-	),
+	)
 	@SQLAction(
 		install=
 			"CREATE TYPE unicodetestrow AS " +
@@ -96,7 +95,6 @@ import org.postgresql.pljava.annotation.Function;
 		remove="DROP TYPE unicodetestrow",
 		provides="unicodetestrow type"
 	)
-})
 public class UnicodeRoundTripTest {
 	/**
 	 * This function takes a string and an array of ints constructed in PG,

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/UnicodeRoundTripTest.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/UnicodeRoundTripTest.java
@@ -39,17 +39,17 @@ import org.postgresql.pljava.annotation.Function;
  * This example relies on {@code implementor} tags reflecting the PostgreSQL
  * version, set up in the {@link ConditionalDDR} example, and also sets its own.
  */
-	@SQLAction(provides="postgresql_unicodetest",
-		implementor="postgresql_ge_90000", install=
-		"SELECT CASE" +
-		" WHEN 'UTF8' = current_setting('server_encoding')" +
-		" THEN set_config('pljava.implementors', 'postgresql_unicodetest,' ||" +
-		" current_setting('pljava.implementors'), true) " +
-		"END"
-	)
-	@SQLAction(requires="unicodetest fn",
-	implementor="postgresql_unicodetest",
-	install=
+@SQLAction(provides="postgresql_unicodetest",
+	implementor="postgresql_ge_90000", install=
+	"SELECT CASE" +
+	" WHEN 'UTF8' = current_setting('server_encoding')" +
+	" THEN set_config('pljava.implementors', 'postgresql_unicodetest,' ||" +
+	" current_setting('pljava.implementors'), true) " +
+	"END"
+)
+@SQLAction(requires="unicodetest fn",
+implementor="postgresql_unicodetest",
+install=
 "   with " +
 "    usable_codepoints ( cp ) as ( " +
 "     select generate_series(1,x'd7ff'::int) " +
@@ -87,14 +87,14 @@ import org.postgresql.pljava.annotation.Function;
 "        'all Unicode codepoint ranges roundtripped successfully.') " +
 "    end " +
 "    from test_summary"
-	)
-	@SQLAction(
-		install=
-			"CREATE TYPE unicodetestrow AS " +
-			"(matched boolean, cparray integer[], s text)",
-		remove="DROP TYPE unicodetestrow",
-		provides="unicodetestrow type"
-	)
+)
+@SQLAction(
+	install=
+		"CREATE TYPE unicodetestrow AS " +
+		"(matched boolean, cparray integer[], s text)",
+	remove="DROP TYPE unicodetestrow",
+	provides="unicodetestrow type"
+)
 public class UnicodeRoundTripTest {
 	/**
 	 * This function takes a string and an array of ints constructed in PG,

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/UnicodeRoundTripTest.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/UnicodeRoundTripTest.java
@@ -15,7 +15,6 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 
 import org.postgresql.pljava.annotation.SQLAction;
-import org.postgresql.pljava.annotation.SQLActions;
 import org.postgresql.pljava.annotation.Function;
 
 /**

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/XMLRenderedTypes.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/XMLRenderedTypes.java
@@ -30,14 +30,14 @@ import static org.postgresql.pljava.example.LoggerTest.logMessage;
  * in case of being loaded into a PostgreSQL instance built without that type.
  * The {@code pg_node_tree} type appears in 9.1.
  */
-	@SQLAction(implementor="postgresql_ge_90100",
-		provides="postgresql_xml_ge91",
-		install=
-		"SELECT CASE (SELECT 1 FROM pg_type WHERE typname = 'xml') WHEN 1" +
-		" THEN set_config('pljava.implementors', 'postgresql_xml_ge91,' || " +
-		" current_setting('pljava.implementors'), true) " +
-		"END"
-	)
+@SQLAction(implementor="postgresql_ge_90100",
+	provides="postgresql_xml_ge91",
+	install=
+	"SELECT CASE (SELECT 1 FROM pg_type WHERE typname = 'xml') WHEN 1" +
+	" THEN set_config('pljava.implementors', 'postgresql_xml_ge91,' || " +
+	" current_setting('pljava.implementors'), true) " +
+	"END"
+)
 public class XMLRenderedTypes
 {
 	@Function(schema="javatest", implementor="postgresql_xml_ge91")

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/XMLRenderedTypes.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/XMLRenderedTypes.java
@@ -17,7 +17,6 @@ import java.sql.SQLException;
 
 import org.postgresql.pljava.annotation.Function;
 import org.postgresql.pljava.annotation.SQLAction;
-import org.postgresql.pljava.annotation.SQLActions;
 import org.postgresql.pljava.annotation.SQLType;
 
 import static org.postgresql.pljava.example.LoggerTest.logMessage;

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/XMLRenderedTypes.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/XMLRenderedTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2019-2020 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -30,7 +30,6 @@ import static org.postgresql.pljava.example.LoggerTest.logMessage;
  * in case of being loaded into a PostgreSQL instance built without that type.
  * The {@code pg_node_tree} type appears in 9.1.
  */
-@SQLActions({
 	@SQLAction(implementor="postgresql_ge_90100",
 		provides="postgresql_xml_ge91",
 		install=
@@ -39,7 +38,6 @@ import static org.postgresql.pljava.example.LoggerTest.logMessage;
 		" current_setting('pljava.implementors'), true) " +
 		"END"
 	)
-})
 public class XMLRenderedTypes
 {
 	@Function(schema="javatest", implementor="postgresql_xml_ge91")


### PR DESCRIPTION
Recent work on the SQL generator added enough implicit-dependency-tracking infrastructure that it is now fairly straightforward to implement a `@Cast` annotation (and possibly others in the future, such as for aggregates and operators).

Effect of this patch can be seen in further simplification of Bear Giles's UDT example in jcflack/pljava-udt-type-extension@7987f29.

Until now, the only (ersatz) "repeatable" annotation was `@SQLAction`, which appeared in PL/Java 1.5 supporting Java earlier than 8, so in order to 'repeat' it, it had to be wrapped inside `@SQLActions`.

As PL/Java 1.6 supports only Java versions with real repeatable annotations, also declare `SQLAction` to be officially repeatable. That allows it to be used without wrapping in `@SQLActions` (though old code that does wrap it will also still compile and work). Update the examples to leave out the no-longer-needed wrapping.

Generalize the repeated-annotation processing logic in `DDRProcessor` so now `@Cast`, and other future repeatable annotations, can share it.