### PR TITLE
Fix access-denied exceptions from getResource or ResourceBundle.getBundle

### DIFF
--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/UsingProperties.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/UsingProperties.java
@@ -26,6 +26,7 @@ import java.util.Properties;
 import java.util.logging.Logger;
 
 import org.postgresql.pljava.ResultSetProvider;
+import org.postgresql.pljava.annotation.SQLAction;
 
 /**
  * An example that retrieves a {@code Properties} resource, and returns
@@ -33,6 +34,20 @@ import org.postgresql.pljava.ResultSetProvider;
  * interface.
  * @author Thomas Hallgren
  */
+@SQLAction(requires = "propertyExampleAnno", install = {
+	"WITH" +
+	" expected AS (VALUES" +
+	"  ('adjective' ::varchar(200), 'avaricious' ::varchar(200))," +
+	"  ('noun',                     'platypus')" +
+	" )" +
+	"SELECT" +
+	"  CASE WHEN every(prop IN (SELECT expected FROM expected))" +
+	"  THEN javatest.logmessage('INFO',    'get resource passes')" +
+	"  ELSE javatest.logmessage('WARNING', 'get resource fails')" +
+	"  END" +
+	" FROM" +
+	"  propertyexampleanno() AS prop"
+})
 public class UsingProperties implements ResultSetProvider.Large
 {
 	private static Logger s_logger = Logger.getAnonymousLogger();
@@ -42,7 +57,9 @@ public class UsingProperties implements ResultSetProvider.Large
 	throws IOException
 	{
 		Properties v = new Properties();
-		InputStream propStream = this.getClass().getResourceAsStream("example.properties");
+		InputStream propStream =
+			this.getClass().getResourceAsStream("example.properties");
+
 		if(propStream == null)
 		{
 			s_logger.fine("example.properties was null");
@@ -76,7 +93,7 @@ public class UsingProperties implements ResultSetProvider.Large
 	 * Return the contents of the {@code example.properties} resource,
 	 * one (key,value) row per entry.
 	 */
-	@Function( type = "javatest._properties")
+	@Function(type = "javatest._properties", provides = "propertyExampleAnno")
 	public static ResultSetProvider propertyExampleAnno()
 	throws SQLException
 	{

--- a/pljava-packaging/src/main/resources/pljava.policy
+++ b/pljava-packaging/src/main/resources/pljava.policy
@@ -58,6 +58,8 @@ grant codebase "${org.postgresql.pljava.codesource}" {
 		"charsetProvider";
 	permission java.lang.RuntimePermission
 		"createClassLoader";
+	permission java.net.NetPermission
+		"specifyStreamHandler";
 	permission java.util.logging.LoggingPermission
 		"control";
 	permission java.security.SecurityPermission

--- a/pljava/src/main/java/org/postgresql/pljava/sqlj/Loader.java
+++ b/pljava/src/main/java/org/postgresql/pljava/sqlj/Loader.java
@@ -342,12 +342,12 @@ public class Loader extends ClassLoader
 	{
 		try
 		{
-			return new URL(
+			return doPrivileged(() -> new URL(
 					"dbf",
 					"localhost",
 					-1,
 					"/" + entryId,
-					EntryStreamHandler.getInstance());
+					EntryStreamHandler.getInstance()));
 		}
 		catch(MalformedURLException e)
 		{


### PR DESCRIPTION
PL/Java's class loader has historically handled resource lookups by returning a URL that has a custom `URLStreamHandler` wired in. Permission to do that wasn't included in the `pljava.policy` shipped with 1.6.0. Fix that. Addresses #322.

Still does not get closer to fixing #266, but at least avoids making it worse.