### PR TITLE
Allow declaring functions with OUT parameters

### DIFF
--- a/pljava-api/src/main/java/org/postgresql/pljava/annotation/Function.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/annotation/Function.java
@@ -78,8 +78,26 @@ category</a>
 	 * {@link org.postgresql.pljava.ResultSetProvider ResultSetProvider},
 	 * or can be used to specify the return type of any function if the
 	 * compiler hasn't inferred it correctly.
+	 *<p>
+	 * Only one of {@code type} or {@code out} may appear.
 	 */
 	String type() default "";
+
+	/**
+	 * The result column names and types of a composite-returning function.
+	 *<p>
+	 * This is for a function defining its own one-off composite type
+	 * (declared with {@code OUT} parameters). If the function returns some
+	 * composite type known to the catalog, simply use {@code type} and the name
+	 * of that type.
+	 *<p>
+	 * Each element is a name and a type specification, separated by whitespace.
+	 * An element that begins with whitespace declares an output column with no
+	 * name, only a type. The name is an ordinary SQL identifier; if it would
+	 * be quoted in SQL, naturally each double-quote must be represented as
+	 * {@code \"} in Java.
+	 */
+	String[] out() default {};
 
 	/**
 	 * The name of the function. This is optional. The default is

--- a/pljava-api/src/main/java/org/postgresql/pljava/annotation/processing/DDRProcessor.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/annotation/processing/DDRProcessor.java
@@ -4044,7 +4044,9 @@ abstract class DBType
 			nandt = nandt.substring(m.end());
 			name = identifierFrom(m);
 		}
-		return Map.entry(name, fromSQLTypeAnnotation(nandt));
+		return
+			new AbstractMap.SimpleImmutableEntry<>(
+				name, fromSQLTypeAnnotation(nandt));
 	}
 
 	/**
@@ -4085,6 +4087,7 @@ abstract class DBType
 
 		Matcher m = SEPARATOR.matcher(value);
 		separator(m, false);
+		int postSeparator = m.regionStart();
 
 		if ( m.usePattern(ISO_AND_PG_IDENTIFIER_CAPTURING).lookingAt() )
 		{
@@ -4184,7 +4187,8 @@ abstract class DBType
 		DBType result;
 
 		if ( reserved )
-			result = new DBType.Reserved(value.substring(0, m.regionEnd()));
+			result = new DBType.Reserved(
+				value.substring(postSeparator, m.regionEnd()));
 		else
 		{
 			result = new DBType.Named(qname);
@@ -4638,6 +4642,12 @@ abstract class DependTag<T>
 					return false;
 			}
 			return true;
+		}
+
+		@Override
+		public String toString()
+		{
+			return super.toString() + Arrays.toString(m_signature);
 		}
 	}
 }

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/ReturnComposite.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/ReturnComposite.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2020 Tada AB and other contributors, as listed below.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Chapman Flack
+ */
+package org.postgresql.pljava.example.annotation;
+
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+
+import java.util.Iterator;
+import java.util.List;
+
+import org.postgresql.pljava.ResultSetProvider;
+import org.postgresql.pljava.annotation.Function;
+import org.postgresql.pljava.annotation.SQLAction;
+
+/**
+ * Demonstrates {@code @Function(out={...})} for a function that returns a
+ * non-predeclared composite type.
+ */
+@SQLAction(requires = { "helloOutParams", "helloTable" }, install = {
+	"SELECT" +
+	"  CASE WHEN want IS NOT DISTINCT FROM helloOutParams()" +
+	"  THEN javatest.logmessage('INFO',    'composite return passes')" +
+	"  ELSE javatest.logmessage('WARNING', 'composite return fails')" +
+	"  END" +
+	" FROM" +
+	"  (SELECT 'Hello' ::text, 'world' ::text) AS want",
+
+	"WITH" +
+	" expected AS (VALUES" +
+	"  ('Hello' ::text, 'twelve' ::text)," +
+	"  ('Hello',        'thirteen')," +
+	"  ('Hello',        'love')" +
+	" )" +
+	"SELECT" +
+	"  CASE WHEN every(want IS NOT DISTINCT FROM got)" +
+	"  THEN javatest.logmessage('INFO',    'set of composite return passes')" +
+	"  ELSE javatest.logmessage('WARNING', 'set of composite return fails')" +
+	"  END" +
+	" FROM" +
+	"  (SELECT row_number() OVER (), * FROM expected) AS want" +
+	"  LEFT JOIN (SELECT row_number() OVER (), * FROM hellotable()) AS got" +
+	"  USING (row_number)"
+})
+public class ReturnComposite implements ResultSetProvider.Large
+{
+	/**
+	 * Returns a two-column composite result that does not have to be
+	 * a predeclared composite type, or require the calling SQL query to
+	 * follow the function call with a result column definition list, as is
+	 * needed for a bare {@code RECORD} return type.
+	 */
+	@Function(
+		schema = "javatest", out = { "greeting text", "addressee text" },
+		provides = "helloOutParams"
+	)
+	public static boolean helloOutParams(ResultSet out) throws SQLException
+	{
+		out.updateString(1, "Hello");
+		out.updateString(2, "world");
+		return true;
+	}
+
+	/**
+	 * Returns a two-column table result that does not have to be
+	 * a predeclared composite type, or require the calling SQL query to
+	 * follow the function call with a result column definition list, as is
+	 * needed for a bare {@code RECORD} return type.
+	 */
+	@Function(
+		schema = "javatest", out = { "greeting text", "addressee text" },
+		provides = "helloTable"
+	)
+	public static ResultSetProvider helloTable()
+	throws SQLException
+	{
+		return new ReturnComposite();
+	}
+
+	Iterator<String> addressees =
+		List.of("twelve", "thirteen", "love").iterator();
+
+	@Override
+	public boolean assignRowValues(ResultSet out, long currentRow)
+	throws SQLException
+	{
+		if ( ! addressees.hasNext() )
+			return false;
+
+		out.updateString(1, "Hello");
+		out.updateString(2, addressees.next());
+		return true;
+	}
+
+	@Override
+	public void close()
+	{
+	}
+}

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/UsingProperties.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/UsingProperties.java
@@ -42,7 +42,8 @@ import org.postgresql.pljava.annotation.SQLAction;
 	"  ('noun',                     'platypus')" +
 	" )" +
 	"SELECT" +
-	"  CASE WHEN every(prop IN (SELECT expected FROM expected))" +
+	"  CASE WHEN" +
+	"   2 = count(prop) AND every(prop IN (SELECT expected FROM expected))" +
 	"  THEN javatest.logmessage('INFO',    'get resource passes')" +
 	"  ELSE javatest.logmessage('WARNING', 'get resource fails')" +
 	"  END" +
@@ -55,7 +56,8 @@ import org.postgresql.pljava.annotation.SQLAction;
 	"  ('noun',                     'platypus')" +
 	" )" +
 	"SELECT" +
-	"  CASE WHEN every(prop IN (SELECT expected FROM expected))" +
+	"  CASE WHEN" +
+	"   2 = count(prop) AND every(prop IN (SELECT expected FROM expected))" +
 	"  THEN javatest.logmessage('INFO',    'get ResourceBundle passes')" +
 	"  ELSE javatest.logmessage('WARNING', 'get ResourceBundle fails')" +
 	"  END" +


### PR DESCRIPTION
Follows a fortuitous discovery that zero changes are needed to PL/Java's runtime code for functions with `OUT` parameters to work—they are simply treated the same as any other `RECORD`-returning function, with a writable `ResultSet` added as a last Java parameter. It's even possible somebody already knew that, but there were no existing examples showing it, and it was a discovery to me.

With the small addition of an `out` element to the `Function` annotation, poof! Generated SQL for PL/Java functions with `OUT` parameters.

It is a useful option. Functions could already be declared as returning `RECORD`, but then every SQL query using them has to supply `AS (`_column definition list_`)` after the function call. They could already be declared to return some known composite type, but that adds the clutter of having to go create a composite type and only then create the function. Giving `OUT` parameters to the function makes it convenient to use without the separate effort of creating a type.