### PR TITLE
Add SQL generation for user-defined aggregate functions

### DIFF
--- a/pljava-api/src/main/java/org/postgresql/pljava/annotation/Aggregate.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/annotation/Aggregate.java
@@ -1,0 +1,382 @@
+/*
+ * Copyright (c) 2020 Tada AB and other contributors, as listed below.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Chapman Flack
+ */
+package org.postgresql.pljava.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Declares a PostgreSQL aggregate.
+ *<p>
+ * An aggregate function in PostgreSQL is defined by using
+ * {@code CREATE AGGREGATE} to specify its name and argument types, along with
+ * at least one "plan" for evaluating it, where the plan specifies at least:
+ * a data type to use for the accumulating state, and a function (here called
+ * "accumulate") called for each row to update the state. If the plan includes
+ * a function "finish", its return type is the return type of the aggregate;
+ * with no "finish" function, the state type is also the aggregate's return
+ * type.
+ *<p>
+ * Optionally, a plan can include a "combine" function, which is passed two
+ * instances of the state type and combines them, to allow aggregate evaluation
+ * to be parallelized. The names "accumulate", "combine", and "finish" are not
+ * exactly as used in the PostgreSQL command (those are unpronounceable
+ * abbreviations), but follow the usage in {@code java.util.stream.Collector},
+ * which should make them natural to Java programmers. PL/Java will generate the
+ * SQL with the unpronounceable names.
+ *<p>
+ * If an aggregate function might be used in a window with a moving frame start,
+ * it can be declared with a second plan ({@code movingPlan}) that includes a
+ * "remove" function that may be called, passing values that were earlier
+ * accumulated into the state, to remove them again as the frame start advances
+ * past them. (Java's {@code Collector} has no equivalent of a "remove"
+ * function.) A "remove" function may only be specified (and must be specified)
+ * in a plan given as {@code movingPlan}.
+ *<p>
+ * Any function referred to in a plan is specified by its name, optionally
+ * schema-qualified. Its argument types are not specified; they are implied by
+ * those declared for the aggregate itself. An "accumulate" function gets one
+ * argument of the state type, followed by all those given as {@code arguments}.
+ * The same is true of a "remove" function. A "combine" function is passed
+ * two arguments of the state type.
+ *<p>
+ * A "finish" function has a first argument of the state type. If the aggregate
+ * is declared with any {@code directArguments}, those follow the state type.
+ * (Declaring {@code directArguments} makes the aggregate an "ordered-set
+ * aggregate", which could additionally have {@code hypothetical=true} to make
+ * it a "hypothetical-set aggregate", for which the PostgreSQL documentation
+ * covers the details.) If {@code polymorphic=true}, the "finish" function's
+ * argument list will end with {@code arguments.length} additional arguments;
+ * they will all be passed as {@code NULL} when the finisher is called, but will
+ * have the right run-time types, which may be necessary to resolve the
+ * finisher's return type, if polymorphic types are involved.
+ *<p>
+ * If any of the functions or types mentioned in this declaration are also being
+ * generated into the same deployment descriptor, the {@code CREATE AGGREGATE}
+ * generated from this annotation will follow them. Other ordering dependencies,
+ * if necessary, can be explicitly arranged with {@code provides} and
+ * {@code requires}.
+ *<p>
+ * While this annotation can generate {@code CREATE AGGREGATE} deployment
+ * commands with most of the features available in PostgreSQL (currently not
+ * covered are {@code SERIALFUNC}, {@code DESERIALFUNC}, and {@code SORTOP}),
+ * at present there are limits to which aggregate features can be implemented
+ * purely in PL/Java. In particular, PL/Java functions currently have no access
+ * to the PostgreSQL data structures needed for an ordered-set or
+ * hypothetical-set aggregate. Such an aggregate could be implemented by writing
+ * some of its support functions in another procedural language; this annotation
+ * could still be used to automatically generate the declaration.
+ * @author Chapman Flack
+ */
+@Documented
+@Target(ElementType.TYPE)
+@Repeatable(Aggregate.Container.class)
+@Retention(RetentionPolicy.CLASS)
+public @interface Aggregate
+{
+	/**
+	 * Declares the effect of the {@code finish} function in a {@code Plan}.
+	 *<p>
+	 * If {@code READ_ONLY}, PostgreSQL can continue updating the same state
+	 * with additional rows, and call the finisher again for updated results.
+	 *<p>
+	 * If {@code SHAREABLE}, the state cannot be further updated after
+	 * a finisher call, but finishers for other aggregates that use the same
+	 * state representation (and are also {@code SHAREABLE}) can be called to
+	 * produce the results for those aggregates. An example could be the several
+	 * linear-regression-related aggregates, all of which can work from a state
+	 * that contains the count of values, sum of values, and sum of squares.
+	 *<p>
+	 * If {@code READ_WRITE}, no further use can be made of the state after
+	 * the finisher has run.
+	 */
+	enum FinishEffect { READ_ONLY, SHAREABLE, READ_WRITE };
+
+	/**
+	 * Specifies one "plan" for evaluating the aggregate; one must always be
+	 * specified (as {@code plan}), and a second may be specified (as
+	 * {@code movingPlan}).
+	 *<p>
+	 * A plan must specify a data type {@code stateType} to hold the
+	 * accumulating state, optionally an estimate of its expected size in bytes,
+	 * and optionally its initial contents. The plan also specifies up to four
+	 * functions {@code accumulate}, {@code combine}, {@code finish}, and
+	 * {@code remove}. Only {@code accumulate} is always required;
+	 * {@code remove} is required in a {@code movingPlan}, and otherwise not
+	 * allowed.
+	 *<p>
+	 * Each of the four functions may be specified as a single string "name",
+	 * which will be leniently parsed as an optionally schema-qualified name,
+	 * or as two strings {@code {"schema","local"}} with the schema made
+	 * explicit. The two-string form with {@code ""} as the schema represents
+	 * an explicitly non-schema-qualified name.
+	 */
+	@Target({})
+	@Retention(RetentionPolicy.CLASS)
+	@interface Plan
+	{
+		/**
+		 * The data type to be used to hold the accumulating state.
+		 *<p>
+		 * This will be the first argument type for all of the support functions
+		 * (both argument types for {@code combine}) and also, if there is no
+		 * {@code finish} function, the result type of the aggregate.
+		 */
+		String stateType();
+
+		/**
+		 * An optional estimate of the size in bytes that the state may grow
+		 * to occupy.
+		 */
+		int stateSize() default 0;
+
+		/**
+		 * An optional initial value for the state (which will otherwise be
+		 * initially null).
+		 *<p>
+		 * Must be a string the state type's text-input conversion would accept.
+		 *<p>
+		 * Omitting the initial value only works if the {@code accumulate}
+		 * function is {@code onNullInput=CALLED}, or if the aggregate's first
+		 * argument type is the same as the state type.
+		 */
+		String initialState() default "";
+
+		/**
+		 * Name of the function that will be called for each row being
+		 * aggregated.
+		 *<p>
+		 * The function named here must have an argument list that starts with
+		 * one argument of the state type, followed by all of this aggregate's
+		 * {@code arguments}. It does not receive the {@code directArguments},
+		 * if any.
+		 */
+		String[] accumulate();
+
+		/**
+		 * Name of an optional function to combine two instances of the state
+		 * type.
+		 *<p>
+		 * The function named here should be one that has two arguments, both
+		 * of the state type, and returns the state type.
+		 */
+		String[] combine() default {};
+
+		/**
+		 * Name of an optional function to produce the aggregate's result from
+		 * the final value of the state; without this function, the aggregate's
+		 * result type is the state type, and the result is simply the final
+		 * value of the state.
+		 *<p>
+		 * When this function is specified, its result type determines the
+		 * result type of the aggregate. Its argument list signature is a single
+		 * argument of the state type, followed by all the
+		 * {@code directArguments} if any, followed (only if {@code polymorphic}
+		 * is true) by {@code arguments.length} additional arguments for which
+		 * nulls will be passed at runtime but with their resolved runtime
+		 * types.
+		 */
+		String[] finish() default {};
+
+		/**
+		 * Name of an optional function that can reverse the effect on the state
+		 * of a row previously passed to {@code accumulate}.
+		 *<p>
+		 * The function named here should have the same argument list signature
+		 * as the {@code accumulate} function.
+		 *<p>
+		 * Required in a {@code movingPlan}; not allowed otherwise.
+		 */
+		String[] remove() default {};
+
+		/**
+		 * Whether the argument list for {@code finish} should be extended with
+		 * slots corresponding to the aggregated {@code arguments}, all nulls at
+		 * runtime but with their resolved runtime types.
+		 */
+		boolean polymorphic() default false;
+
+		/**
+		 * The effect of the {@code finish} function in this {@code Plan}.
+		 *<p>
+		 * If {@code READ_ONLY}, PostgreSQL can continue updating the same
+		 * state with additional rows, and call the finisher again for updated
+		 * results.
+		 *<p>
+		 * If {@code SHAREABLE}, the state cannot be further updated after a
+		 * finisher call, but finishers for other aggregates that use the same
+		 * state representation (and are also {@code SHAREABLE}) can be called
+		 * to produce the results for those aggregates. An example could be the
+		 * several linear-regression-related aggregates, all of which can work
+		 * from a state that contains the count of values, sum of values, and
+		 * sum of squares.
+		 *<p>
+		 * If {@code READ_WRITE}, no further use can be made of the state after
+		 * the finisher has run.
+		 *<p>
+		 * Leaving this to default is not exactly equivalent to specifying the
+		 * default value shown here. If left to default, it will be left
+		 * unspecified in the generated {@code CREATE AGGREGATE}, and PostgreSQL
+		 * will apply its default, which is {@code READ_ONLY} in the case of an
+		 * ordinary aggregate, but {@code READ_WRITE} for an ordered-set or
+		 * hypothetical-set aggregate.
+		 */
+		FinishEffect finishEffect() default FinishEffect.READ_ONLY;
+	}
+
+	/**
+	 * Name for this aggregate.
+	 *<p>
+	 * May be specified in explicit {@code {"schema","localname"}} form, or as
+	 * a single string that will be leniently parsed as an optionally
+	 * schema-qualified name. In the explicit form, {@code ""} as the schema
+	 * will make the name explicitly unqualified (in case the local name might
+	 * contain a dot and be misread as a qualified name).
+	 */
+	String[] name();
+
+	/**
+	 * Names and types of the arguments to be aggregated: the ones passed to the
+	 * {@code accumulate} function for each aggregated row.
+	 *<p>
+	 * Each element is a name and a type specification, separated by whitespace.
+	 * An element that begins with whitespace declares a parameter with no
+	 * name, only a type. The name is an ordinary SQL identifier; if it would
+	 * be quoted in SQL, naturally each double-quote must be represented as
+	 * {@code \"} in Java.
+	 */
+	String[] arguments();
+
+	/**
+	 * Names and types of the "direct arguments" to an ordered-set or
+	 * hypothetical-set aggregate (specifying this element is what makes an
+	 * ordered-set aggregate, which will be a hypothetical-set aggregate if
+	 * {@code hypothetical=true} is also supplied).
+	 *<p>
+	 * Specified as for {@code arguments}. The direct arguments are not passed
+	 * to the {@code accumulate} function for each aggregated row; they are only
+	 * passed to the {@code finish} function when producing the result.
+	 */
+	String[] directArguments() default {};
+
+	/**
+	 * Specify {@code true} in an ordered-set aggregate (one with
+	 * {@code directArguments} specified) to make it a hypothetical-set
+	 * aggregate.
+	 *<p>
+	 * When {@code true}, the {@code directArguments} list must be at least as
+	 * long as {@code arguments}, and its last {@code arguments.length} types
+	 * must match {@code arguments} one-to-one. When the {@code finish} function
+	 * is called, those last direct arguments will carry the caller-supplied
+	 * values for the "hypothetical" row.
+	 */
+	boolean hypothetical() default false;
+
+	/**
+	 * Whether the aggregate has a variadic last argument.
+	 *<p>
+	 * Specify as a single boolean, {@code variadic=true}, to declare an
+	 * ordinary aggregate variadic. The last type of its declared
+	 * {@code arguments} must then be either an array type, or
+	 * {@code pg_catalog."any"}
+	 *<p>
+	 * The form {@code variadic={boolean,boolean}} is for an ordered-set
+	 * aggregate, which has both a list of {@code directArguments} (the first
+	 * boolean) and its aggregated {@code arguments} (the second). For an
+	 * ordered-set aggregate, {@code "any"} is the only allowed type for a
+	 * variadic argument.
+	 *<p>
+	 * When also {@code hypothetical} is true, the requirement that the
+	 * {@code directArguments} have a tail matching the {@code arguments}
+	 * implies that the two lists must both or neither be variadic.
+	 */
+	boolean[] variadic() default {};
+
+	/**
+	 * The {@link Plan Plan} normally to be used for evaluating this aggregate,
+	 * except possibly in a moving-window context if {@code movingPlan} is also
+	 * supplied.
+	 *<p>
+	 * Required. This plan may not name a {@code remove} function; only
+	 * a {@code movingPlan} can do that.
+	 */
+	Plan plan();
+
+
+	/**
+	 * An optional {@link Plan Plan} that may be more efficient for evaluating
+	 * this aggregate in a moving-window context.
+	 *<p>
+	 * Though declared as an array, only one plan is allowed here. It must
+	 * name a {@code remove} function.
+	 */
+	Plan[] movingPlan() default {};
+
+	/**
+	 * Parallel-safety declaration for this aggregate; PostgreSQL's planner
+	 * will consult this only, not the declarations on the individual supporting
+	 * functions.
+	 *<p>
+	 * See {@link Function#parallel() Function.parallel} for the implications.
+	 * In PL/Java, any setting other than {@code UNSAFE} should be considered
+	 * experimental.
+	 */
+	Function.Parallel parallel() default Function.Parallel.UNSAFE;
+
+	// not yet here: serialfunc, deserialfunc, sortop
+
+	/**
+	 * One or more arbitrary labels that will be considered 'provided' by the
+	 * object carrying this annotation. The deployment descriptor will be
+	 * generated in such an order that other objects that 'require' labels
+	 * 'provided' by this come later in the output for install actions, and
+	 * earlier for remove actions.
+	 */
+	String[] provides() default {};
+
+	/**
+	 * One or more arbitrary labels that will be considered 'required' by the
+	 * object carrying this annotation. The deployment descriptor will be
+	 * generated in such an order that other objects that 'provide' labels
+	 * 'required' by this come earlier in the output for install actions, and
+	 * later for remove actions.
+	 */
+	String[] requires() default {};
+
+	/**
+	 * The {@code <implementor name>} to be used around SQL code generated
+	 * for this aggregate. Defaults to {@code PostgreSQL}. Set explicitly to
+	 * {@code ""} to emit code not wrapped in an {@code <implementor block>}.
+	 */
+	String implementor() default "";
+
+	/**
+	 * A comment to be associated with the aggregate. The default is to create
+	 * no comment.
+	 */
+	String comment() default "";
+
+	/**
+	 * @hidden container type allowing Cast to be repeatable.
+	 */
+	@Documented
+	@Target(ElementType.TYPE)
+	@Retention(RetentionPolicy.CLASS)
+	@interface Container
+	{
+		Aggregate[] value();
+	}
+}

--- a/pljava-api/src/main/java/org/postgresql/pljava/annotation/processing/DDRProcessor.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/annotation/processing/DDRProcessor.java
@@ -3197,7 +3197,7 @@ hunt:	for ( ExecutableElement ee : ees )
 			// array of arguments (length 0 for (*)). No check needed here; the
 			// annotation declares those without defaults.
 
-			// Could check argument count agains FUNC_MAX_ARGS, but that would
+			// Could check argument count against FUNC_MAX_ARGS, but that would
 			// hardcode an assumed value for PostgreSQL's FUNC_MAX_ARGS.
 
 			// Check that, if a stateType is polymorphic, there are compatible
@@ -3391,27 +3391,9 @@ hunt:	for ( ExecutableElement ee : ees )
 
 			if ( moving )
 			{
-				accumulatorSig =
-					Stream.of(
-						Stream.of(_movingPlan[0].stateType),
-						aggregateArgs.stream().map(Map.Entry::getValue))
-					.flatMap(identity()).toArray(DBType[]::new);
-
-				combinerSig = new DBType[]
-					{ _movingPlan[0].stateType, _movingPlan[0].stateType };
-
-				finisherSig =
-					Stream.of(
-						Stream.of(_movingPlan[0].stateType),
-						orderedSet ?
-							directArgs.stream().map(Map.Entry::getValue)
-							: Stream.of(),
-						_movingPlan[0]._polymorphic
-							? aggregateArgs.stream().map(Map.Entry::getValue)
-							: Stream.of()
-					)
-					.flatMap(identity())
-					.toArray(DBType[]::new);
+				accumulatorSig[0] = _movingPlan[0].stateType;
+				Arrays.fill(combinerSig, _movingPlan[0].stateType);
+				finisherSig[0] = _movingPlan[0].stateType;
 
 				requires.add(new DependTag.Function(
 					_movingPlan[0].accumulate, accumulatorSig));

--- a/pljava-api/src/main/java/org/postgresql/pljava/annotation/processing/DDRProcessor.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/annotation/processing/DDRProcessor.java
@@ -52,6 +52,7 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.ListIterator;
 import java.util.Locale;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -63,6 +64,7 @@ import java.util.Queue;
 import java.util.Set;
 
 import java.util.function.Supplier;
+import static java.util.function.UnaryOperator.identity;
 
 import java.util.stream.Stream;
 import static java.util.stream.Collectors.joining;
@@ -107,6 +109,7 @@ import org.postgresql.pljava.ResultSetHandle;
 import org.postgresql.pljava.ResultSetProvider;
 import org.postgresql.pljava.TriggerData;
 
+import org.postgresql.pljava.annotation.Aggregate;
 import org.postgresql.pljava.annotation.Cast;
 import org.postgresql.pljava.annotation.Function;
 import org.postgresql.pljava.annotation.SQLAction;
@@ -226,6 +229,8 @@ class DDRProcessorImpl
 	final TypeElement  AN_SQLACTIONS;
 	final TypeElement  AN_CAST;
 	final TypeElement  AN_CASTS;
+	final TypeElement  AN_AGGREGATE;
+	final TypeElement  AN_AGGREGATES;
 
 	// Certain familiar DBTypes (capitalized as this file historically has)
 	//
@@ -237,6 +242,8 @@ class DDRProcessorImpl
 		Identifier.Qualified.nameFromJava("pg_catalog.trigger"));
 	final DBType DT_VOID = new DBType.Named(
 		Identifier.Qualified.nameFromJava("pg_catalog.void"));
+	final DBType DT_ANY = new DBType.Named(
+		Identifier.Qualified.nameFromJava("pg_catalog.\"any\""));
 
 	// Function signatures for certain known functions
 	//
@@ -328,6 +335,9 @@ class DDRProcessorImpl
 		AN_CAST   = elmu.getTypeElement( Cast.class.getName());
 		AN_CASTS  = elmu.getTypeElement(
 			Cast.Container.class.getCanonicalName());
+		AN_AGGREGATE   = elmu.getTypeElement( Aggregate.class.getName());
+		AN_AGGREGATES  = elmu.getTypeElement(
+			Aggregate.Container.class.getCanonicalName());
 	}
 	
 	void msg( Kind kind, String fmt, Object... args)
@@ -441,6 +451,7 @@ class DDRProcessorImpl
 		boolean baseUDTPresent = false;
 		boolean mappedUDTPresent = false;
 		boolean castPresent = false;
+		boolean aggregatePresent = false;
 		
 		boolean willClaim = true;
 		
@@ -458,6 +469,8 @@ class DDRProcessorImpl
 				sqlActionPresent = true;
 			else if ( AN_CAST.equals( te) || AN_CASTS.equals( te) )
 				castPresent = true;
+			else if ( AN_AGGREGATE.equals( te) || AN_AGGREGATES.equals( te) )
+				aggregatePresent = true;
 			else
 			{
 				msg( Kind.WARNING, te,
@@ -490,6 +503,12 @@ class DDRProcessorImpl
 				: re.getElementsAnnotatedWithAny( AN_CAST, AN_CASTS) )
 				processRepeatable(
 					e, AN_CAST, AN_CASTS, CastImpl.class);
+
+		if ( aggregatePresent )
+			for ( Element e
+				: re.getElementsAnnotatedWithAny( AN_AGGREGATE, AN_AGGREGATES) )
+				processRepeatable(
+					e, AN_AGGREGATE, AN_AGGREGATES, AggregateImpl.class);
 
 		tmpr.workAroundJava7Breakage(); // perhaps to be fixed in Java 9? nope.
 
@@ -3041,6 +3060,637 @@ hunt:	for ( ExecutableElement ee : ees )
 		}
 	}
 
+	class AggregateImpl
+	extends Repeatable
+	implements Aggregate, Snippet, Commentable
+	{
+		AggregateImpl(Element e, AnnotationMirror am)
+		{
+			super(e, am);
+		}
+
+		public String[]                name() { return qstrings(qname); }
+		public String[]           arguments() { return argsOut(aggregateArgs); }
+		public String[]     directArguments() { return argsOut(directArgs); }
+		public boolean         hypothetical() { return _hypothetical; }
+		public boolean[]           variadic() { return _variadic; }
+		public Plan                    plan() { return _plan; }
+		public Plan[]            movingPlan() { return _movingPlan; }
+		public Function.Parallel   parallel() { return _parallel; }
+		public String[]            provides() { return _provides; }
+		public String[]            requires() { return _requires; }
+
+		public boolean           _hypothetical;
+		public boolean[]             _variadic = {false, false};
+		public Plan                      _plan;
+		public Plan[]              _movingPlan;
+		public Function.Parallel     _parallel;
+		public String[]              _provides;
+		public String[]              _requires;
+
+		Identifier.Qualified<Identifier.Simple> qname;
+		List<Map.Entry<Identifier.Simple,DBType>> aggregateArgs;
+		List<Map.Entry<Identifier.Simple,DBType>> directArgs;
+		static final int DIRECT_ARGS = 0; // index into _variadic[]
+		static final int AGG_ARGS = 1;    // likewise
+		boolean directVariadicExplicit;
+
+		private List<Map.Entry<Identifier.Simple,DBType>>
+			argsIn(String[] names)
+		{
+			return Arrays.stream(names)
+				.map(DBType::fromNameAndType)
+				.collect(toList());
+		}
+
+		private String[]
+			argsOut(List<Map.Entry<Identifier.Simple,DBType>> names)
+		{
+			return names.stream()
+				.map(e -> e.getKey() + " " + e.getValue())
+				.toArray(String[]::new);
+		}
+
+		@Override
+		public String derivedComment( Element e)
+		{
+			/*
+			 * For the time being, this annotation targets a TYPE, just as a
+			 * place to hang it, and there's no particular reason to believe a
+			 * doc comment on the type has anything to do with this aggregate.
+			 */
+			return null;
+		}
+
+		public void setName( Object o, boolean explicit, Element e)
+		{
+			qname = qnameFrom(avToArray( o, String.class));
+		}
+
+		public void setArguments( Object o, boolean explicit, Element e)
+		{
+			aggregateArgs = argsIn( avToArray( o, String.class));
+		}
+
+		public void setDirectArguments( Object o, boolean explicit, Element e)
+		{
+			if ( explicit )
+				directArgs = argsIn( avToArray( o, String.class));
+		}
+
+		public void setVariadic( Object o, boolean explicit, Element e)
+		{
+			if ( ! explicit )
+				return;
+
+			Boolean[] a = avToArray( o, Boolean.class);
+
+			if ( 1 > a.length  ||  a.length > 2 )
+				throw new IllegalArgumentException(
+					"supply only boolean or {boolean,boolean} for variadic");
+
+			if ( ! Arrays.asList(a).contains(true) )
+				throw new IllegalArgumentException(
+					"supply variadic= only if aggregated arguments, direct " +
+					"arguments, or both, are variadic");
+
+			_variadic[AGG_ARGS] = a[a.length - 1];
+			if ( 2 == a.length )
+			{
+				directVariadicExplicit = true;
+				_variadic[DIRECT_ARGS] = a[0];
+			}
+		}
+
+		public void setPlan( Object o, boolean explicit, Element e)
+		{
+			Plan p = new Plan();
+			populateAnnotationImpl( p, e, (AnnotationMirror)o);
+			_plan = p;
+		}
+
+		public void setMovingPlan( Object o, boolean explicit, Element e)
+		{
+			if ( ! explicit )
+				return;
+
+			AnnotationMirror[] ams = avToArray( o, AnnotationMirror.class);
+
+			if ( 1 != ams.length )
+				throw new IllegalArgumentException(
+					"movingPlan must be given exactly one @Plan");
+
+			_movingPlan = new Plan[1];
+
+			Plan p = new Moving();
+			populateAnnotationImpl( p, e, ams[0]);
+			_movingPlan [ 0 ] = p;
+		}
+
+		public boolean characterize()
+		{
+			boolean ok = true;
+			boolean orderedSet = null != directArgs;
+			boolean moving = null != _movingPlan;
+
+			// Must have a name, a plan with an accumulate function, and an
+			// array of arguments (length 0 for (*)). No check needed here; the
+			// annotation declares those without defaults.
+
+			// Could check argument count agains FUNC_MAX_ARGS, but that would
+			// hardcode an assumed value for PostgreSQL's FUNC_MAX_ARGS.
+
+			// Check that, if a stateType is polymorphic, there are compatible
+			// polymorphic arg types? Not today.
+
+			// If a plan has no initialState, then either the accumulate
+			// function must NOT be RETURNS NULL ON NULL INPUT, or the first
+			// aggregated argument type must be the same as the state type.
+			// The type check is easy, but the returnsNull check on the
+			// accumulate function would require looking up the function (and
+			// still we wouldn't know, if it's not seen in this compilation).
+			// For another day.
+
+			// Allow hypothetical only for ordered-set aggregate.
+			if ( _hypothetical && ! orderedSet )
+			{
+				msg(Kind.ERROR, m_targetElement, m_origin,
+					"hypothetical=true is only allowed for an ordered-set " +
+					"aggregate (one with directArguments specified, " +
+					"even if only {})");
+				ok = false;
+			}
+
+			// Allow two-element variadic= only for ordered-set aggregate.
+			if ( directVariadicExplicit && ! orderedSet )
+			{
+				msg(Kind.ERROR, m_targetElement, m_origin,
+					"Two values for variadic= are only allowed for an " +
+					"ordered-set aggregate (one with directArguments " +
+					"specified, even if only {})");
+				ok = false;
+			}
+
+			// Require a movingPlan to have a remove function.
+			if ( moving && null == _movingPlan[0].remove )
+			{
+				msg(Kind.ERROR, m_targetElement, m_origin,
+					"a movingPlan must include a remove function");
+				ok = false;
+			}
+
+			// Checks if the aggregated argument list is declared variadic.
+			// The last element must be an array type or "any"; an ordered-set
+			// aggregate allows only one argument and it must be "any".
+			if ( _variadic[AGG_ARGS] )
+			{
+				if ( 1 > aggregateArgs.size() )
+				{
+					msg(Kind.ERROR, m_targetElement, m_origin,
+						"To declare the aggregated argument list variadic, " +
+						"there must be at least one argument.");
+					ok = false;
+				}
+				else
+				{
+					DBType t =
+						aggregateArgs.get(aggregateArgs.size() - 1).getValue();
+					boolean isAny = // allow omission of pg_catalog namespace
+						DT_ANY.equals(t)  ||  "\"any\"".equals(t.toString());
+					if ( orderedSet && (! isAny || 1 != aggregateArgs.size()) )
+					{
+						msg(Kind.ERROR, m_targetElement, m_origin,
+							"If variadic, an ordered-set aggregate's " +
+							"aggregated argument list must be only one " +
+							"argument and of type \"any\".");
+						ok = false;
+					}
+					else if ( ! isAny  &&  ! t.isArray() )
+					{
+						msg(Kind.ERROR, m_targetElement, m_origin,
+							"If variadic, the last aggregated argument must " +
+							"be an array type (or \"any\").");
+						ok = false;
+					}
+				}
+			}
+
+			// Checks specific to ordered-set aggregates.
+			if ( orderedSet )
+			{
+				if ( 0 == aggregateArgs.size() )
+				{
+					msg(Kind.ERROR, m_targetElement, m_origin,
+						"An ordered-set aggregate needs at least one " +
+						"aggregated argument");
+					ok = false;
+				}
+
+				// Checks specific to hypothetical-set aggregates.
+				// The aggregated argument types must match the trailing direct
+				// arguments, and the two variadic declarations must match.
+				if ( _hypothetical )
+				{
+					if ( _variadic[DIRECT_ARGS] != _variadic[AGG_ARGS] )
+					{
+						msg(Kind.ERROR, m_targetElement, m_origin,
+							"For a hypothetical-set aggregate, neither or " +
+							"both the direct and aggregated argument lists " +
+							"must be declared variadic.");
+						ok = false;
+					}
+					if ( directArgs.size() < aggregateArgs.size()
+						||
+						! directArgs.subList(
+							directArgs.size() - aggregateArgs.size(),
+							directArgs.size())
+							.equals(aggregateArgs) )
+					{
+						msg(Kind.ERROR, m_targetElement, m_origin,
+							"The last direct arguments of a hypothetical-set " +
+							"aggregate must match the types of the " +
+							"aggregated arguments");
+						ok = false;
+					}
+				}
+			}
+
+			// It is allowed to omit a finisher function, but some things
+			// make no sense without one.
+			if ( orderedSet && null == _plan.finish && 0 < directArgs.size() )
+			{
+				msg(Kind.ERROR, m_targetElement, m_origin,
+					"Direct arguments serve no purpose without a finisher");
+				ok = false;
+			}
+
+			if ( null == _plan.finish && _plan._polymorphic )
+			{
+				msg(Kind.ERROR, m_targetElement, m_origin,
+					"The polymorphic flag is meaningless with no finisher");
+				ok = false;
+			}
+
+			// The same finisher checks for a movingPlan, if present.
+			if ( moving )
+			{
+				if ( orderedSet
+					&& null == _movingPlan[0].finish
+					&& directArgs.size() > 0 )
+				{
+					msg(Kind.ERROR, m_targetElement, m_origin,
+						"Direct arguments serve no purpose without a finisher");
+					ok = false;
+				}
+
+				if ( null == _movingPlan[0].finish
+					&& _movingPlan[0]._polymorphic )
+				{
+					msg(Kind.ERROR, m_targetElement, m_origin,
+						"The polymorphic flag is meaningless with no finisher");
+					ok = false;
+				}
+			}
+
+			if ( ! ok )
+				return false;
+
+			Set<DependTag> requires = requireTags();
+
+			DBType[] accumulatorSig =
+				Stream.of(
+					Stream.of(_plan.stateType),
+					aggregateArgs.stream().map(Map.Entry::getValue))
+				.flatMap(identity()).toArray(DBType[]::new);
+
+			DBType[] combinerSig = { _plan.stateType, _plan.stateType };
+
+			DBType[] finisherSig =
+				Stream.of(
+					Stream.of(_plan.stateType),
+					orderedSet
+						? directArgs.stream().map(Map.Entry::getValue)
+						: Stream.of(),
+					_plan._polymorphic
+						? aggregateArgs.stream().map(Map.Entry::getValue)
+						: Stream.of()
+				)
+				.flatMap(identity())
+				.toArray(DBType[]::new);
+
+			requires.add(
+				new DependTag.Function(_plan.accumulate, accumulatorSig));
+
+			if ( null != _plan.combine )
+				requires.add(
+					new DependTag.Function(_plan.combine, combinerSig));
+
+			if ( null != _plan.finish )
+				requires.add(
+					new DependTag.Function(_plan.finish, finisherSig));
+
+			if ( moving )
+			{
+				accumulatorSig =
+					Stream.of(
+						Stream.of(_movingPlan[0].stateType),
+						aggregateArgs.stream().map(Map.Entry::getValue))
+					.flatMap(identity()).toArray(DBType[]::new);
+
+				combinerSig = new DBType[]
+					{ _movingPlan[0].stateType, _movingPlan[0].stateType };
+
+				finisherSig =
+					Stream.of(
+						Stream.of(_movingPlan[0].stateType),
+						orderedSet ?
+							directArgs.stream().map(Map.Entry::getValue)
+							: Stream.of(),
+						_movingPlan[0]._polymorphic
+							? aggregateArgs.stream().map(Map.Entry::getValue)
+							: Stream.of()
+					)
+					.flatMap(identity())
+					.toArray(DBType[]::new);
+
+				requires.add(new DependTag.Function(
+					_movingPlan[0].accumulate, accumulatorSig));
+
+				requires.add(new DependTag.Function(
+					_movingPlan[0].remove, accumulatorSig));
+
+				if ( null != _movingPlan[0].combine )
+					requires.add(new DependTag.Function(
+						_movingPlan[0].combine, combinerSig));
+
+				if ( null != _movingPlan[0].finish )
+					requires.add(new DependTag.Function(
+						_movingPlan[0].finish, finisherSig));
+			}
+
+			/*
+			 * That establishes dependency on the various support functions,
+			 * which should, transitively, depend on all of the types. But it is
+			 * possible we do not have a whole-program view (perhaps some
+			 * support functions are implemented in other languages, and there
+			 * are @SQLActions setting them up?). Therefore also, redundantly as
+			 * it may be, declare dependency on the types.
+			 */
+
+			Stream.of(
+				aggregateArgs.stream().map(Map.Entry::getValue),
+				orderedSet
+					? directArgs.stream().map(Map.Entry::getValue)
+					: Stream.<DBType>of(),
+				Stream.of(_plan.stateType),
+				moving
+					? Stream.of(_movingPlan[0].stateType)
+					: Stream.<DBType>of()
+				)
+				.flatMap(identity())
+				.map(DBType::dependTag)
+				.filter(Objects::nonNull)
+				.forEach(requires::add);
+
+			recordExplicitTags(_provides, _requires);
+			return true;
+		}
+
+		public String[] deployStrings()
+		{
+			List<String> al = new ArrayList<>();
+
+			StringBuilder sb = new StringBuilder("CREATE AGGREGATE ");
+			appendNameAndArguments(sb);
+			sb.append(" (");
+
+			String[] planStrings = _plan.deployStrings();
+			int n = planStrings.length;
+			for ( String s : planStrings )
+			{
+				sb.append("\n\t").append(s);
+				if ( 0 < -- n )
+					sb.append(',');
+			}
+
+			if ( null != _movingPlan )
+			{
+				planStrings = _movingPlan[0].deployStrings();
+				for ( String s : planStrings )
+					sb.append(",\n\tM").append(s);
+			}
+
+			if ( Function.Parallel.UNSAFE != _parallel )
+				sb.append(",\n\tPARALLEL = ").append(_parallel);
+
+			if ( _hypothetical )
+				sb.append(",\n\tHYPOTHETICAL");
+
+			sb.append(')');
+
+			al.add(sb.toString());
+
+			if ( null != comment() )
+			{
+				sb = new StringBuilder("COMMENT ON AGGREGATE ");
+				appendNameAndArguments(sb);
+				sb.append(" IS ").append(DDRWriter.eQuote(comment()));
+				al.add(sb.toString());
+			}
+
+			return al.toArray( new String [ al.size() ]);
+		}
+
+		public String[] undeployStrings()
+		{
+			StringBuilder sb = new StringBuilder("DROP AGGREGATE ");
+			appendNameAndArguments(sb);
+			return new String[] { sb.toString() };
+		}
+
+		private void appendNameAndArguments(StringBuilder sb)
+		{
+			ListIterator<Map.Entry<Identifier.Simple,DBType>> iter;
+			Map.Entry<Identifier.Simple,DBType> entry;
+
+			sb.append(qname).append('(');
+			if ( null != directArgs )
+			{
+				iter = directArgs.listIterator();
+				while ( iter.hasNext() )
+				{
+					entry = iter.next();
+					sb.append("\n\t");
+					if ( _variadic[DIRECT_ARGS]  &&  ! iter.hasNext() )
+						sb.append("VARIADIC ");
+					if ( null != entry.getKey() )
+						sb.append(entry.getKey()).append(' ');
+					sb.append(entry.getValue());
+					if ( iter.hasNext() )
+						sb.append(',');
+					else
+						sb.append("\n\t");
+				}
+				sb.append("ORDER BY");
+			}
+			else if ( 0 == aggregateArgs.size() )
+				sb.append('*');
+
+			iter = aggregateArgs.listIterator();
+			while ( iter.hasNext() )
+			{
+				entry = iter.next();
+				sb.append("\n\t");
+				if ( _variadic[AGG_ARGS]  &&  ! iter.hasNext() )
+					sb.append("VARIADIC ");
+				if ( null != entry.getKey() )
+					sb.append(entry.getKey()).append(' ');
+				sb.append(entry.getValue());
+				if ( iter.hasNext() )
+					sb.append(',');
+			}
+			sb.append(')');
+		}
+
+		class Plan extends AbstractAnnotationImpl implements Aggregate.Plan
+		{
+			public String          stateType() { return stateType.toString(); }
+			public int             stateSize() { return _stateSize; }
+			public String       initialState() { return _initialState; }
+			public String[]       accumulate() { return qstrings(accumulate); }
+			public String[]          combine() { return qstrings(combine); }
+			public String[]           finish() { return qstrings(finish); }
+			public String[]           remove() { return qstrings(remove); }
+			public boolean       polymorphic() { return _polymorphic; }
+			public FinishEffect finishEffect() { return _finishEffect; }
+
+			public int             _stateSize;
+			public String       _initialState;
+			public boolean       _polymorphic;
+			public FinishEffect _finishEffect;
+
+			DBType stateType;
+			Identifier.Qualified<Identifier.Simple> accumulate;
+			Identifier.Qualified<Identifier.Simple> combine;
+			Identifier.Qualified<Identifier.Simple> finish;
+			Identifier.Qualified<Identifier.Simple> remove;
+
+			public void setStateType(Object o, boolean explicit, Element e)
+			{
+				stateType = DBType.fromSQLTypeAnnotation((String)o);
+			}
+
+			public void setStateSize(Object o, boolean explicit, Element e)
+			{
+				_stateSize = (Integer)o;
+				if ( explicit  &&  0 >= _stateSize )
+					throw new IllegalArgumentException(
+						"An explicit stateSize must be positive");
+			}
+
+			public void setInitialState(Object o, boolean explicit, Element e)
+			{
+				if ( explicit )
+					_initialState = (String)o;
+			}
+
+			public void setAccumulate(Object o, boolean explicit, Element e)
+			{
+				if ( explicit )
+					accumulate = qnameFrom(avToArray( o, String.class));
+			}
+
+			public void setCombine(Object o, boolean explicit, Element e)
+			{
+				if ( explicit )
+					combine = qnameFrom(avToArray( o, String.class));
+			}
+
+			public void setFinish(Object o, boolean explicit, Element e)
+			{
+				if ( explicit )
+					finish = qnameFrom(avToArray( o, String.class));
+			}
+
+			public void setRemove(Object o, boolean explicit, Element e)
+			{
+				if ( explicit )
+					throw new IllegalArgumentException(
+						"Only a movingPlan may have a remove function");
+			}
+
+			public void setFinishEffect( Object o, boolean explicit, Element e)
+			{
+				if ( explicit )
+					_finishEffect = FinishEffect.valueOf(
+						((VariableElement)o).getSimpleName().toString());
+			}
+
+			public boolean characterize()
+			{
+				return false;
+			}
+
+			/**
+			 * Returns one string per plan element (not per SQL statement).
+			 *<p>
+			 * This method has to be here anyway because the class extends
+			 * {@code AbstractAnnotationImpl}, but it will never be processed as
+			 * an actual SQL snippet. This will be called by the containing
+			 * {@code AggregateImpl} and return the individual plan elements
+			 * that it will build into its own deploy strings.
+			 *<p>
+			 * When this class represents a moving plan, the caller will prefix
+			 * each of these strings with {@code M}.
+			 */
+			public String[] deployStrings()
+			{
+				List<String> al = new ArrayList<>();
+
+				al.add("STYPE = " + stateType);
+
+				if ( 0 != _stateSize )
+					al.add("SSPACE = " + _stateSize);
+
+				if ( null != _initialState )
+					al.add("INITCOND = " + DDRWriter.eQuote(_initialState));
+
+				al.add("SFUNC = " + accumulate);
+
+				if ( null != remove )
+					al.add("INVFUNC = " + remove);
+
+				if ( null != finish )
+					al.add("FINALFUNC = " + finish);
+
+				if ( _polymorphic )
+					al.add("FINALFUNC_EXTRA");
+
+				if ( null != _finishEffect )
+					al.add("FINALFUNC_MODIFY = " + _finishEffect);
+
+				if ( null != combine )
+					al.add("COMBINEFUNC = " + combine);
+
+				return al.toArray( new String [ al.size() ]);
+			}
+
+			public String[] undeployStrings()
+			{
+				return null;
+			}
+		}
+
+		class Moving extends Plan
+		{
+			public void setRemove(Object o, boolean explicit, Element e)
+			{
+				if ( explicit )
+					remove = qnameFrom(avToArray( o, String.class));
+			}
+		}
+	}
+
 	/**
 	 * Provides the default mappings from Java types to SQL types.
 	 */
@@ -3514,6 +4164,36 @@ hunt:	for ( ExecutableElement ee : ees )
 	Identifier.Qualified<Identifier.Simple> qnameFrom(String name)
 	{
 		return Identifier.Qualified.nameFromJava(name, msgr);
+	}
+
+	/**
+	 * Return an {@code Identifier.Qualified} from an array of Java strings
+	 * representing schema and local name separately if of length two, or as by
+	 * {@link #qnameFrom(String)} if of length one; invalid if of any other
+	 * length.
+	 *<p>
+	 * The first of two elements may be explicitly {@code ""} to produce a
+	 * qualified name with null qualifier.
+	 */
+	Identifier.Qualified<Identifier.Simple> qnameFrom(String[] names)
+	{
+		switch ( names.length )
+		{
+		case 2: return qnameFrom(names[1], names[0]);
+		case 1: return qnameFrom(names[0]);
+		default:
+			throw new IllegalArgumentException(
+				"Only a one- or two-element String array is accepted");
+		}
+	}
+
+	String[] qstrings(Identifier.Qualified<?> qname)
+	{
+		if ( null == qname )
+			return null;
+		Identifier.Simple q = qname.qualifier();
+		String local = qname.local().toString();
+		return new String[] { null == q ? null : q.toString(), local };
 	}
 }
 

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/Aggregates.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/Aggregates.java
@@ -1,0 +1,276 @@
+/*
+ * Copyright (c) 2020 Tada AB and other contributors, as listed below.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Chapman Flack
+ */
+package org.postgresql.pljava.example.annotation;
+
+import static java.lang.Math.fma;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import org.postgresql.pljava.annotation.Aggregate;
+import org.postgresql.pljava.annotation.Function;
+import static
+	org.postgresql.pljava.annotation.Function.OnNullInput.RETURNS_NULL;
+import static org.postgresql.pljava.annotation.Function.Effects.IMMUTABLE;
+import org.postgresql.pljava.annotation.SQLAction;
+
+/**
+ * A class demonstrating several aggregate functions.
+ *<p>
+ * They are (some of) the same two-variable statistical aggregates already
+ * offered in core PostgreSQL, just because they make clear examples. For
+ * numerical reasons, they might not produce results identical to PG's built-in
+ * ones. These closely follow the "schoolbook" formulas in the HP-11C calculator
+ * owner's handbook, while the ones built into PostgreSQL use a more clever
+ * algorithm instead to reduce rounding error in the finishers.
+ *<p>
+ * All these aggregates can be computed by different finishers that share a
+ * state that accumulates the count of rows, sum of x, sum of xx, sum of y, sum
+ * of yy, and sum of xy. That is easy with finishers that don't need to modify
+ * the state, so the default {@code FinishEffect=READ_ONLY} is appropriate.
+ *<p>
+ * Everything here takes the y parameter first, then x, like the SQL ones.
+ */
+@SQLAction(requires = { "avgx", "avgy", "slope", "intercept" }, install = {
+    "WITH" +
+    " data (y, x) AS (VALUES" +
+    "  (1.761 ::float8, 5.552::float8)," +
+    "  (1.775,          5.963)," +
+    "  (1.792,          6.135)," +
+    "  (1.884,          6.313)," +
+    "  (1.946,          6.713)"  +
+    " )," +
+    " expected (avgx, avgy, slope, intercept) AS (" +
+    "  SELECT 6.1352, 1.8316, 0.1718, 0.7773" +
+    " )," +
+    " got AS (" +
+    "  SELECT" +
+    "    round(     avgx(y,x)::numeric, 4) AS avgx," +
+    "    round(     avgy(y,x)::numeric, 4) AS avgy," +
+    "    round(    slope(y,x)::numeric, 4) AS slope," +
+    "    round(intercept(y,x)::numeric, 4) AS intercept" +
+    "   FROM" +
+    "    data" +
+    " )" +
+    "SELECT" +
+    "  CASE WHEN expected IS NOT DISTINCT FROM got" +
+    "  THEN javatest.logmessage('INFO', 'aggregate examples ok')" +
+    "  ELSE javatest.logmessage('WARNING', 'aggregate examples ng')" +
+    "  END" +
+    " FROM" +
+    "  expected, got"
+})
+@Aggregate(provides = "avgx",
+	name = "avgx",
+	arguments = { "y double precision", "x double precision" },
+	plan = @Aggregate.Plan(
+		stateType = "double precision[]",
+		stateSize = 82,
+		initialState = "{0,0,0,0,0,0}",
+		accumulate = { "javatest", "accumulateXY" },
+		finish = { "javatest", "finishAvgX" }
+	)
+)
+@Aggregate(provides = "avgy",
+	name = "avgy",
+	arguments = { "y double precision", "x double precision" },
+	plan = @Aggregate.Plan(
+		stateType = "double precision[]",
+		stateSize = 82,
+		initialState = "{0,0,0,0,0,0}",
+		accumulate = { "javatest", "accumulateXY" },
+		finish = { "javatest", "finishAvgY" }
+	)
+)
+@Aggregate(provides = "slope",
+	name = "slope",
+	arguments = { "y double precision", "x double precision" },
+	plan = @Aggregate.Plan(
+		stateType = "double precision[]",
+		stateSize = 82,
+		initialState = "{0,0,0,0,0,0}",
+		accumulate = { "javatest", "accumulateXY" },
+		finish = { "javatest", "finishSlope" }
+	)
+)
+@Aggregate(provides = "intercept",
+	name = "intercept",
+	arguments = { "y double precision", "x double precision" },
+	plan = @Aggregate.Plan(
+		stateType = "double precision[]",
+		stateSize = 82,
+		initialState = "{0,0,0,0,0,0}",
+		accumulate = { "javatest", "accumulateXY" },
+		finish = { "javatest", "finishIntercept" }
+	)
+)
+@Aggregate(
+	name = "regression",
+	arguments = { "y double precision", "x double precision" },
+	plan = @Aggregate.Plan(
+		stateType = "double precision[]",
+		stateSize = 82,
+		initialState = "{0,0,0,0,0,0}",
+		accumulate = { "javatest", "accumulateXY" },
+		finish = { "javatest", "finishRegr" }
+	),
+	/*
+	 * There is no special reason for this aggregate and not the others to have
+	 * a movingPlan; one example is enough, that's all.
+	 */
+	movingPlan = @Aggregate.Plan(
+		stateType = "double precision[]",
+		stateSize = 82,
+		initialState = "{0,0,0,0,0,0}",
+		accumulate = { "javatest", "accumulateXY" },
+		remove = { "javatest", "removeXY" },
+		finish = { "javatest", "finishRegr" }
+	)
+)
+public class Aggregates
+{
+	private static final int N   = 0;
+	private static final int SX  = 1;
+	private static final int SXX = 2;
+	private static final int SY  = 3;
+	private static final int SYY = 4;
+	private static final int SXY = 5;
+
+	/**
+	 * A common accumulator for two-variable statistical aggregates that
+	 * depend on n, Sx, Sxx, Sy, Syy, and Sxy.
+	 */
+	@Function(
+		schema = "javatest", effects = IMMUTABLE, onNullInput = RETURNS_NULL
+	)
+	public static double[] accumulateXY(double[] state, double y, double x)
+	{
+		state[N  ] += 1.;
+		state[SX ] += x;
+		state[SXX] = fma(x, x, state[2]);
+		state[SY ] += y;
+		state[SYY] = fma(y, y, state[4]);
+		state[SXY] = fma(x, y, state[5]);
+		return state;
+	}
+
+	/**
+	 * 'Removes' from the state a row previously accumulated, for possible use
+	 * in a window with a moving frame start.
+	 *<p>
+	 * This can be a numerically poor idea for exactly the reasons covered in
+	 * the PostgreSQL docs involving loss of significance in long sums, but it
+	 * does demonstrate the idea.
+	 */
+	@Function(
+		schema = "javatest", effects = IMMUTABLE, onNullInput = RETURNS_NULL
+	)
+	public static double[] removeXY(double[] state, double y, double x)
+	{
+		state[N  ] -= 1.;
+		state[SX ] -= x;
+		state[SXX] = fma(x, -x, state[2]);
+		state[SY ] -= y;
+		state[SYY] = fma(y, -y, state[4]);
+		state[SXY] = fma(x, -y, state[5]);
+		return state;
+	}
+
+	/**
+	 * Finisher that returns the count of non-null rows accumulated.
+	 */
+	@Function(
+		schema = "javatest", effects = IMMUTABLE, onNullInput = RETURNS_NULL
+	)
+	public static long finishCount(double[] state)
+	{
+		return (long)state[N];
+	}
+
+	/**
+	 * Finisher that returns the mean of the accumulated x values.
+	 */
+	@Function(
+		schema = "javatest", effects = IMMUTABLE, onNullInput = RETURNS_NULL
+	)
+	public static Double finishAvgX(double[] state)
+	{
+		if ( 0. == state[N] )
+			return null;
+		return state[SX] / state[N];
+	}
+
+	/**
+	 * Finisher that returns the mean of the accumulated y values.
+	 */
+	@Function(
+		schema = "javatest", effects = IMMUTABLE, onNullInput = RETURNS_NULL
+	)
+	public static Double finishAvgY(double[] state)
+	{
+		if ( 0. == state[N] )
+			return null;
+		return state[SY] / state[N];
+	}
+
+	/**
+	 * Finisher that returns the slope of a regression line.
+	 */
+	@Function(
+		schema = "javatest", effects = IMMUTABLE, onNullInput = RETURNS_NULL
+	)
+	public static Double finishSlope(double[] state)
+	{
+		if ( 2. > state[N] )
+			return null;
+
+		double numer = fma(state[SX], -state[SY], state[N] * state[SXY]);
+		double denom = fma(state[SX], -state[SX], state[N] * state[SXX]);
+		return 0. == denom ? null : numer / denom;
+	}
+
+	/**
+	 * Finisher that returns the intercept of a regression line.
+	 */
+	@Function(
+		schema = "javatest", effects = IMMUTABLE, onNullInput = RETURNS_NULL
+	)
+	public static Double finishIntercept(double[] state)
+	{
+		if ( 2 > state[N] )
+			return null;
+
+		double numer = fma(state[SY], state[SXX], -state[SX] * state[SXY]);
+		double denom = fma(state[SX], -state[SX], state[N] * state[SXX]);
+		return 0. == denom ? null : numer / denom;
+	}
+
+	/**
+	 * A finisher that returns the slope and intercept together.
+	 *<p>
+	 * An aggregate can be built over this finisher and will return a record
+	 * result, but at present (PG 13) access to that record by field doesn't
+	 * work, as its tuple descriptor gets lost along the way. Unclear so far
+	 * whether it might be feasible to fix that.
+	 */
+	@Function(
+		schema = "javatest", effects = IMMUTABLE, onNullInput = RETURNS_NULL,
+		out = { "slope double precision", "intercept double precision" }
+	)
+	public static boolean finishRegr(double[] state, ResultSet out)
+	throws SQLException
+	{
+		out.updateObject(1, finishSlope(state));
+		out.updateObject(2, finishIntercept(state));
+		return true;
+	}
+}

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/Aggregates.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/Aggregates.java
@@ -74,7 +74,32 @@ import org.postgresql.pljava.annotation.SQLAction;
 	arguments = { "y double precision", "x double precision" },
 	plan = @Aggregate.Plan(
 		stateType = "double precision[]",
-		stateSize = 82,
+		/*
+		 * State size is merely a hint to PostgreSQL's planner and can
+		 * be omitted. Perhaps it is worth hinting, as the state type
+		 * "double precision[]" does not tell PostgreSQL how large the array
+		 * might be. Anyway, this is an example and should show how to do it.
+		 * For this aggregate, the state never grows; the size of the initial
+		 * value is the size forever.
+		 *
+		 * To get a quick sense of the size, one can assign the initial state
+		 * as the default for a table column, then consult the pg_node_tree for
+		 * the attribute default entry:
+		 *
+		 * CREATE TEMPORARY TABLE
+		 *   foo (bar DOUBLE PRECISION[] DEFAULT '{0,0,0,0,0,0}');
+		 *
+		 * SELECT
+		 *   xpath('/CONST/member[@name="constvalue"]/@length',
+		 *         javatest.pgNodeTreeAsXML(adbin)             )
+		 *  FROM pg_attrdef
+		 *  WHERE adrelid = 'foo'::regclass;
+		 *
+		 * In this case the 72 that comes back represents 48 bytes for six
+		 * float8s, plus 24 for varlena and array overhead, with no null bitmap
+		 * because no element is null.
+		 */
+		stateSize = 72,
 		initialState = "{0,0,0,0,0,0}",
 		accumulate = { "javatest", "accumulateXY" },
 		finish = { "javatest", "finishAvgX" }
@@ -85,7 +110,7 @@ import org.postgresql.pljava.annotation.SQLAction;
 	arguments = { "y double precision", "x double precision" },
 	plan = @Aggregate.Plan(
 		stateType = "double precision[]",
-		stateSize = 82,
+		stateSize = 72,
 		initialState = "{0,0,0,0,0,0}",
 		accumulate = { "javatest", "accumulateXY" },
 		finish = { "javatest", "finishAvgY" }
@@ -96,7 +121,7 @@ import org.postgresql.pljava.annotation.SQLAction;
 	arguments = { "y double precision", "x double precision" },
 	plan = @Aggregate.Plan(
 		stateType = "double precision[]",
-		stateSize = 82,
+		stateSize = 72,
 		initialState = "{0,0,0,0,0,0}",
 		accumulate = { "javatest", "accumulateXY" },
 		finish = { "javatest", "finishSlope" }
@@ -107,7 +132,7 @@ import org.postgresql.pljava.annotation.SQLAction;
 	arguments = { "y double precision", "x double precision" },
 	plan = @Aggregate.Plan(
 		stateType = "double precision[]",
-		stateSize = 82,
+		stateSize = 72,
 		initialState = "{0,0,0,0,0,0}",
 		accumulate = { "javatest", "accumulateXY" },
 		finish = { "javatest", "finishIntercept" }
@@ -118,7 +143,7 @@ import org.postgresql.pljava.annotation.SQLAction;
 	arguments = { "y double precision", "x double precision" },
 	plan = @Aggregate.Plan(
 		stateType = "double precision[]",
-		stateSize = 82,
+		stateSize = 72,
 		initialState = "{0,0,0,0,0,0}",
 		accumulate = { "javatest", "accumulateXY" },
 		finish = { "javatest", "finishRegr" }
@@ -129,7 +154,7 @@ import org.postgresql.pljava.annotation.SQLAction;
 	 */
 	movingPlan = @Aggregate.Plan(
 		stateType = "double precision[]",
-		stateSize = 82,
+		stateSize = 72,
 		initialState = "{0,0,0,0,0,0}",
 		accumulate = { "javatest", "accumulateXY" },
 		remove = { "javatest", "removeXY" },


### PR DESCRIPTION
A new `@Aggregate` annotation allows generating PostgreSQL `CREATE AGGREGATE` with most of the bells and whistles (including some that there is not yet any way for pure PL/Java functions to implement). Omitted for the moment are `SERIALFUNC` and `DESERIALFUNC` (there isn't much PL/Java functions can do with datatype `internal`), and `SORTOP` (not enough awareness of operators yet). There is still `@SQLAction` for any rare need to get a `CREATE AGGREGATE` into a deployment descriptor if this annotation can't describe it.