### PR TITLE
Add SQL generation for user-defined operators

### DIFF
--- a/pljava-api/src/main/java/org/postgresql/pljava/annotation/Aggregate.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/annotation/Aggregate.java
@@ -123,6 +123,7 @@ public @interface Aggregate
 	 * explicit. The two-string form with {@code ""} as the schema represents
 	 * an explicitly non-schema-qualified name.
 	 */
+	@Documented
 	@Target({})
 	@Retention(RetentionPolicy.CLASS)
 	@interface Plan

--- a/pljava-api/src/main/java/org/postgresql/pljava/annotation/BaseUDT.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/annotation/BaseUDT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015- Tada AB and other contributors, as listed below.
+ * Copyright (c) 2015-2020 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -11,6 +11,7 @@
  */
 package org.postgresql.pljava.annotation;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -64,7 +65,7 @@ import java.sql.SQLData; // referred to in javadoc
  * be used in their {@code @Function} annotations and this annotation, to make
  * the order come out right.
  */
-@Target(ElementType.TYPE) @Retention(RetentionPolicy.CLASS)
+@Target(ElementType.TYPE) @Retention(RetentionPolicy.CLASS) @Documented
 public @interface BaseUDT
 {
 	/**

--- a/pljava-api/src/main/java/org/postgresql/pljava/annotation/MappedUDT.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/annotation/MappedUDT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015- Tada AB and other contributors, as listed below.
+ * Copyright (c) 2015-2020 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -11,6 +11,7 @@
  */
 package org.postgresql.pljava.annotation;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -42,7 +43,7 @@ import java.sql.SQLData; // referred to in javadoc
  * of the class being annotated, and found in {@link #schema schema} if
  * specified, or by following the search path) to the annotated class.
  */
-@Target(ElementType.TYPE) @Retention(RetentionPolicy.CLASS)
+@Target(ElementType.TYPE) @Retention(RetentionPolicy.CLASS) @Documented
 public @interface MappedUDT
 {
 	/**

--- a/pljava-api/src/main/java/org/postgresql/pljava/annotation/Operator.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/annotation/Operator.java
@@ -1,0 +1,280 @@
+/*
+ * Copyright (c) 2020 Tada AB and other contributors, as listed below.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Chapman Flack
+ */
+package org.postgresql.pljava.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Declares a PostgreSQL {@code OPERATOR}.
+ *<p>
+ * May annotate a Java method (which should also carry a
+ * {@link Function @Function} annotation, making it a PostgreSQL function),
+ * or a class or interface (just to have a place to put it when not directly
+ * annotating a method).
+ *
+ * @author Chapman Flack
+ */
+@Documented
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Repeatable(Operator.Container.class)
+@Retention(RetentionPolicy.CLASS)
+public @interface Operator
+{
+	/**
+	 * Name for this operator.
+	 *<p>
+	 * May be specified in explicit {@code {"schema","operatorname"}} form, or
+	 * as a single string that will be leniently parsed as an optionally
+	 * schema-qualified name. In the explicit form, {@code ""} as the schema
+	 * will make the name explicitly unqualified.
+	 */
+	String[] name();
+
+	/**
+	 * The type of the operator's left operand, if any.
+	 * Will default to the first parameter type of an associated two-parameter
+	 * function, or none for an associated one-parameter function.
+	 */
+	String left() default "";
+
+	/**
+	 * The type of the operator's right operand, if any.
+	 * Will default to the second parameter type of an associated two-parameter
+	 * function, or the parameter type for an associated one-parameter function.
+	 */
+	String right() default "";
+
+	/**
+	 * Name of the function backing the operator; may be omitted if this
+	 * annotation appears on a method.
+	 *<p>
+	 * The function named here must take one parameter of the matching type if
+	 * only one of {@code left} or {@code right} is specified, or the
+	 * {@code left} and {@code right} types in that order if both are present.
+	 */
+	String[] function() default {};
+
+	/**
+	 * Name of an operator that is the commutator of this one.
+	 *<p>
+	 * Specified in the same ways as {@code name}.
+	 */
+	String[] commutator() default {};
+
+	/**
+	 * Name of an operator that is the negator of this one.
+	 *<p>
+	 * Specified in the same ways as {@code name}.
+	 */
+	String[] negator() default {};
+
+	/**
+	 * Whether this operator can be used in computing a hash join.
+	 *<p>
+	 * Only sensible for a boolean-valued binary operator, which must have a
+	 * commutator in the same hash index operator family, with the underlying
+	 * functions marked {@link Function.Effects#IMMUTABLE} or
+	 * {@link Function.Effects#STABLE}.
+	 */
+	boolean hashes() default false;
+
+	/**
+	 * Whether this operator can be used in computing a merge join.
+	 *<p>
+	 * Only sensible for a boolean-valued binary operator, which must have a
+	 * commutator also appearing as an equality member in the same btree index
+	 * operator family, with the underlying functions marked
+	 * {@link Function.Effects#IMMUTABLE} or {@link Function.Effects#STABLE}.
+	 */
+	boolean merges() default false;
+
+	/**
+	 * Name of a function that can estimate the selectivity of this operator
+	 * when used in a {@code WHERE} clause.
+	 *<p>
+	 * Specified in the same ways as {@code function}.
+	 *<p>
+	 * A custom estimator is a complex undertaking (and, at present, requires
+	 * a language other than Java), but several predefined ones can be found in
+	 * {@link SelectivityEstimators}.
+	 */
+	String[] restrict() default {};
+
+	/**
+	 * Name of a function that can estimate the selectivity of this operator
+	 * when used in a join.
+	 *<p>
+	 * Specified in the same ways as {@code function}.
+	 *<p>
+	 * A custom estimator is a complex undertaking (and, at present, requires
+	 * a language other than Java), but several predefined ones can be found in
+	 * {@link SelectivityEstimators}.
+	 */
+	String[] join() default {};
+
+	/**
+	 * One or more arbitrary labels that will be considered 'provided' by the
+	 * object carrying this annotation. The deployment descriptor will be
+	 * generated in such an order that other objects that 'require' labels
+	 * 'provided' by this come later in the output for install actions, and
+	 * earlier for remove actions.
+	 */
+	String[] provides() default {};
+
+	/**
+	 * One or more arbitrary labels that will be considered 'required' by the
+	 * object carrying this annotation. The deployment descriptor will be
+	 * generated in such an order that other objects that 'provide' labels
+	 * 'required' by this come earlier in the output for install actions, and
+	 * later for remove actions.
+	 */
+	String[] requires() default {};
+
+	/**
+	 * The {@code <implementor name>} to be used around SQL code generated
+	 * for this operator. Defaults to {@code PostgreSQL}. Set explicitly to
+	 * {@code ""} to emit code not wrapped in an {@code <implementor block>}.
+	 */
+	String implementor() default "";
+
+	/**
+	 * A comment to be associated with the operator. If left to default, and the
+	 * annotated Java construct has a doc comment, its first sentence will be
+	 * used. If an empty string is explicitly given, no comment will be set.
+	 */
+	String comment() default "";
+
+	/**
+	 * Names of several functions predefined in PostgreSQL for estimating the
+	 * selectivity of operators in restriction clauses or joins.
+	 */
+	interface SelectivityEstimators
+	{
+		/**
+		 * A restriction-selectivity estimator suitable for an operator
+		 * with rather high selectivity typical of an operator like {@code =}.
+		 */
+		String EQSEL = "pg_catalog.eqsel";
+
+		/**
+		 * A restriction-selectivity estimator suitable for an operator
+		 * somewhat less strict than a typical {@code =} operator.
+		 */
+		String MATCHINGSEL = "pg_catalog.matchingsel";
+
+		/**
+		 * A restriction-selectivity estimator suitable for an operator
+		 * with rather low selectivity typical of an operator like {@code <>}.
+		 */
+		String NEQSEL = "pg_catalog.neqsel";
+
+		/**
+		 * A restriction-selectivity estimator suitable for an operator
+		 * with selectivity typical of an operator like {@code <}.
+		 */
+		String SCALARLTSEL = "pg_catalog.scalarltsel";
+
+		/**
+		 * A restriction-selectivity estimator suitable for an operator
+		 * with selectivity typical of an operator like {@code <=}.
+		 */
+		String SCALARLESEL = "pg_catalog.scalarlesel";
+
+		/**
+		 * A restriction-selectivity estimator suitable for an operator
+		 * with selectivity typical of an operator like {@code >}.
+		 */
+		String SCALARGTSEL = "pg_catalog.scalargtsel";
+
+		/**
+		 * A restriction-selectivity estimator suitable for an operator
+		 * with selectivity typical of an operator like {@code >=}.
+		 */
+		String SCALARGESEL = "pg_catalog.scalargesel";
+
+		/**
+		 * A join-selectivity estimator suitable for an operator
+		 * with rather high selectivity typical of an operator like {@code =}.
+		 */
+		String EQJOINSEL = "pg_catalog.eqjoinsel";
+
+		/**
+		 * A join-selectivity estimator suitable for an operator
+		 * somewhat less strict than a typical {@code =} operator.
+		 */
+		String MATCHINGJOINSEL = "pg_catalog.matchingjoinsel";
+
+		/**
+		 * A join-selectivity estimator suitable for an operator
+		 * with rather low selectivity typical of an operator like {@code <>}.
+		 */
+		String NEQJOINSEL = "pg_catalog.neqjoinsel";
+
+		/**
+		 * A join-selectivity estimator suitable for an operator
+		 * with selectivity typical of an operator like {@code <}.
+		 */
+		String SCALARLTJOINSEL = "pg_catalog.scalarltjoinsel";
+
+		/**
+		 * A join-selectivity estimator suitable for an operator
+		 * with selectivity typical of an operator like {@code <=}.
+		 */
+		String SCALARLEJOINSEL = "pg_catalog.scalarlejoinsel";
+
+		/**
+		 * A join-selectivity estimator suitable for an operator
+		 * with selectivity typical of an operator like {@code >}.
+		 */
+		String SCALARGTJOINSEL = "pg_catalog.scalargtjoinsel";
+
+		/**
+		 * A join-selectivity estimator suitable for an operator
+		 * with selectivity typical of an operator like {@code >=}.
+		 */
+		String SCALARGEJOINSEL = "pg_catalog.scalargejoinsel";
+
+		/**
+		 * A join-selectivity estimator suitable for an operator
+		 * doing 2-D area-based comparisons.
+		 */
+		String AREAJOINSEL = "pg_catalog.areajoinsel";
+
+		/**
+		 * A join-selectivity estimator suitable for an operator
+		 * doing 2-D position-based comparisons.
+		 */
+		String POSITIONJOINSEL = "pg_catalog.positionjoinsel";
+
+		/**
+		 * A join-selectivity estimator suitable for an operator
+		 * doing 2-D containment-based comparisons.
+		 */
+		String CONTJOINSEL = "pg_catalog.contjoinsel";
+	}
+
+	/**
+	 * @hidden container type allowing Operator to be repeatable.
+	 */
+	@Documented
+	@Target({ElementType.METHOD, ElementType.TYPE})
+	@Retention(RetentionPolicy.CLASS)
+	@interface Container
+	{
+		Operator[] value();
+	}
+}

--- a/pljava-api/src/main/java/org/postgresql/pljava/annotation/Operator.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/annotation/Operator.java
@@ -35,6 +35,13 @@ import java.lang.annotation.Target;
 public @interface Operator
 {
 	/**
+	 * Distinguished value usable for {@link #commutator commutator=} to
+	 * indicate that an operator is its own commutator without having to
+	 * repeat its schema and name.
+	 */
+	String SELF = "self";
+
+	/**
 	 * Name for this operator.
 	 *<p>
 	 * May be specified in explicit {@code {"schema","operatorname"}} form, or
@@ -71,7 +78,9 @@ public @interface Operator
 	/**
 	 * Name of an operator that is the commutator of this one.
 	 *<p>
-	 * Specified in the same ways as {@code name}.
+	 * Specified in the same ways as {@code name}. The value
+	 * {@link #SELF SELF} can be used to avoid repeating the schema and name
+	 * for the common case of an operator that is its own commutator.
 	 */
 	String[] commutator() default {};
 

--- a/pljava-api/src/main/java/org/postgresql/pljava/annotation/Operator.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/annotation/Operator.java
@@ -76,6 +76,17 @@ public @interface Operator
 	String[] function() default {};
 
 	/**
+	 * Name of a function to be synthesized by PL/Java based on the method this
+	 * annotation appears on and this operator's {@code commutator} or
+	 * {@code negator} relationship to another operator declared on the same
+	 * method.
+	 *<p>
+	 * Only allowed in an annotation on a Java method, and where
+	 * {@code function} is not specified.
+	 */
+	String[] synthetic() default {};
+
+	/**
 	 * Name of an operator that is the commutator of this one.
 	 *<p>
 	 * Specified in the same ways as {@code name}. The value

--- a/pljava-api/src/main/java/org/postgresql/pljava/annotation/Operator.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/annotation/Operator.java
@@ -38,8 +38,32 @@ public @interface Operator
 	 * Distinguished value usable for {@link #commutator commutator=} to
 	 * indicate that an operator is its own commutator without having to
 	 * repeat its schema and name.
+	 *<p>
+	 * This value strictly declares that the operator is its own commutator, and
+	 * therefore is only allowed for an operator with two operands of the same
+	 * type. If the types are different, a commutator with the same
+	 * <em>name</em> would in fact be a different operator with the operand
+	 * types exchanged; use {@link #TWIN TWIN} for that.
 	 */
-	String SELF = "self";
+	String SELF = ".self.";
+
+	/**
+	 * Distinguished value usable for {@link #commutator commutator=} to
+	 * indicate that an operator's commutator is another operator with the same
+	 * schema and name, without having to repeat them.
+	 *<p>
+	 * This value strictly declares that the commutator is a different
+	 * operator, and therefore is only allowed for an operator with two
+	 * operands of different types. As commutators, this operator and its twin
+	 * will have those operand types in opposite orders, so PostgreSQL
+	 * overloading will allow them to have the same name.
+	 *<p>
+	 * This value may also be used with {@link #synthetic synthetic=} to give
+	 * the synthesized function the same schema and name as the one it is based
+	 * on; this also is possible only for a function synthesized by commutation
+	 * where the commuted parameter types differ.
+	 */
+	String TWIN = ".twin.";
 
 	/**
 	 * Name for this operator.
@@ -83,6 +107,14 @@ public @interface Operator
 	 *<p>
 	 * Only allowed in an annotation on a Java method, and where
 	 * {@code function} is not specified.
+	 *<p>
+	 * The special value {@link #TWIN TWIN} is allowed, to avoid repeating the
+	 * schema and name when the desired name for the synthesized function is the
+	 * same as the one it is derived from (which is only possible if the
+	 * derivation involves commuting the arguments and their types are
+	 * different, so the two functions can be distinguished by overloading). A
+	 * typical case would be the twin of a cross-type function like {@code add}
+	 * that is commutative, so using the same name makes sense.
 	 */
 	String[] synthetic() default {};
 
@@ -91,7 +123,12 @@ public @interface Operator
 	 *<p>
 	 * Specified in the same ways as {@code name}. The value
 	 * {@link #SELF SELF} can be used to avoid repeating the schema and name
-	 * for the common case of an operator that is its own commutator.
+	 * for the common case of an operator that is its own commutator. The value
+	 * {@link #TWIN TWIN} can likewise declare that the commutator is the
+	 * different operator with the same name and schema but the operand types
+	 * (which must be different) reversed. A typical case would be the twin of a
+	 * cross-type operator like {@code +} that is commutative, so using the same
+	 * name makes sense.
 	 */
 	String[] commutator() default {};
 

--- a/pljava-api/src/main/java/org/postgresql/pljava/annotation/Trigger.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/annotation/Trigger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2013 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2020 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -9,9 +9,11 @@
  * Contributors:
  *   Tada AB
  *   Purdue University
+ *   Chapman Flack
  */
 package org.postgresql.pljava.annotation;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -40,7 +42,7 @@ import java.lang.annotation.Target;
  * the complete transition tables on each invocation.
  * @author Thomas Hallgren
  */
-@Target({}) @Retention(RetentionPolicy.CLASS)
+@Target({}) @Retention(RetentionPolicy.CLASS) @Documented
 public @interface Trigger
 {
 	/**

--- a/pljava-api/src/main/java/org/postgresql/pljava/annotation/processing/DDRProcessor.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/annotation/processing/DDRProcessor.java
@@ -3108,6 +3108,7 @@ hunt:	for ( ExecutableElement ee : ees )
 		Identifier.Qualified<Identifier.Operator> negator;
 		Identifier.Qualified<Identifier.Simple> restrict;
 		Identifier.Qualified<Identifier.Simple> join;
+		boolean selfCommutator;
 
 		private String operand(int i)
 		{
@@ -3140,7 +3141,13 @@ hunt:	for ( ExecutableElement ee : ees )
 		public void setCommutator( Object o, boolean explicit, Element e)
 		{
 			if ( explicit )
-				commutator = operatorNameFrom(avToArray( o, String.class));
+			{
+				String[] ss = avToArray( o, String.class);
+				if ( 1 == ss.length  &&  SELF.equals(ss[0]) )
+					selfCommutator = true;
+				else
+					commutator = operatorNameFrom(ss);
+			}
 		}
 
 		public void setNegator( Object o, boolean explicit, Element e)
@@ -3166,6 +3173,9 @@ hunt:	for ( ExecutableElement ee : ees )
 		public boolean characterize()
 		{
 			boolean ok = true;
+
+			if ( selfCommutator )
+				commutator = qname;
 
 			if ( ElementKind.METHOD.equals(m_targetElement.getKind()) )
 			{
@@ -3273,6 +3283,14 @@ hunt:	for ( ExecutableElement ee : ees )
 				{
 					msg(Kind.ERROR, m_targetElement, m_origin,
 						"unary @Operator cannot have a commutator"
+					);
+					ok = false;
+				}
+				else if ( selfCommutator && ! operands[0].equals(operands[1]) )
+				{
+					msg(Kind.ERROR, m_targetElement, m_origin,
+						"@Operator with different left and right operand " +
+						"types cannot be its own commutator"
 					);
 					ok = false;
 				}

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/ComplexScalar.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/ComplexScalar.java
@@ -224,7 +224,7 @@ public class ComplexScalar implements SQLData {
 		provides = "complex relationals"
 	)
 	@Operator(
-		name = "javatest.<>", synthetic = "javatest.magnitudeNE",
+		name = "javatest.<>", synthetic = "javatest.componentsNE",
 		commutator = SELF, provides = "complex relationals"
 	)
 	@Function(

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/ComplexScalar.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/ComplexScalar.java
@@ -139,7 +139,7 @@ public class ComplexScalar implements SQLData {
 						&& tz.nextToken() == StreamTokenizer.TT_NUMBER) {
 					double y = tz.nval;
 					if (tz.nextToken() == ')') {
-						s_logger.info(typeName + " from string");
+						s_logger.fine(typeName + " from string");
 						return new ComplexScalar(x, y, typeName);
 					}
 				}
@@ -290,7 +290,7 @@ public class ComplexScalar implements SQLData {
 	@Function(effects=IMMUTABLE, onNullInput=RETURNS_NULL)
 	@Override
 	public void readSQL(SQLInput stream, String typeName) throws SQLException {
-		s_logger.info(typeName + " from SQLInput");
+		s_logger.fine(typeName + " from SQLInput");
 		m_x = stream.readDouble();
 		m_y = stream.readDouble();
 		m_typeName = typeName;
@@ -299,7 +299,7 @@ public class ComplexScalar implements SQLData {
 	@Function(effects=IMMUTABLE, onNullInput=RETURNS_NULL)
 	@Override
 	public String toString() {
-		s_logger.info(m_typeName + " toString");
+		s_logger.fine(m_typeName + " toString");
 		StringBuffer sb = new StringBuffer();
 		sb.append('(');
 		sb.append(m_x);
@@ -312,7 +312,7 @@ public class ComplexScalar implements SQLData {
 	@Function(effects=IMMUTABLE, onNullInput=RETURNS_NULL)
 	@Override
 	public void writeSQL(SQLOutput stream) throws SQLException {
-		s_logger.info(m_typeName + " to SQLOutput");
+		s_logger.fine(m_typeName + " to SQLOutput");
 		stream.writeDouble(m_x);
 		stream.writeDouble(m_y);
 	}

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/ComplexScalar.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/ComplexScalar.java
@@ -23,6 +23,7 @@ import java.util.logging.Logger;
 
 import org.postgresql.pljava.annotation.Function;
 import org.postgresql.pljava.annotation.Operator;
+import static org.postgresql.pljava.annotation.Operator.SELF;
 import org.postgresql.pljava.annotation.SQLAction;
 import org.postgresql.pljava.annotation.BaseUDT;
 
@@ -111,7 +112,7 @@ public class ComplexScalar implements SQLData {
 	/**
 	 * Add two instances of {@code ComplexScalar}.
 	 */
-	@Operator(name = {"javatest","+"}, commutator = "javatest.+")
+	@Operator(name = {"javatest","+"}, commutator = SELF)
 	@Function(
 		schema = "javatest", effects = IMMUTABLE, onNullInput = RETURNS_NULL
 	)

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/ComplexScalar.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/ComplexScalar.java
@@ -22,6 +22,7 @@ import java.sql.SQLOutput;
 import java.util.logging.Logger;
 
 import org.postgresql.pljava.annotation.Function;
+import org.postgresql.pljava.annotation.Operator;
 import org.postgresql.pljava.annotation.SQLAction;
 import org.postgresql.pljava.annotation.BaseUDT;
 
@@ -105,6 +106,19 @@ public class ComplexScalar implements SQLData {
 	private String m_typeName;
 
 	public ComplexScalar() {
+	}
+
+	/**
+	 * Add two instances of {@code ComplexScalar}.
+	 */
+	@Operator(name = {"javatest","+"}, commutator = "javatest.+")
+	@Function(
+		schema = "javatest", effects = IMMUTABLE, onNullInput = RETURNS_NULL
+	)
+	public static ComplexScalar add(ComplexScalar a, ComplexScalar b)
+	{
+		return new ComplexScalar(
+			a.m_x + b.m_x, a.m_y + b.m_y, a.m_typeName);
 	}
 
 	public ComplexScalar(double x, double y, String typeName) {

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/ComplexScalar.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/ComplexScalar.java
@@ -28,6 +28,7 @@ import java.util.logging.Logger;
 import org.postgresql.pljava.annotation.Function;
 import org.postgresql.pljava.annotation.Operator;
 import static org.postgresql.pljava.annotation.Operator.SELF;
+import static org.postgresql.pljava.annotation.Operator.TWIN;
 import org.postgresql.pljava.annotation.SQLAction;
 import org.postgresql.pljava.annotation.BaseUDT;
 
@@ -124,6 +125,19 @@ public class ComplexScalar implements SQLData {
 	{
 		return new ComplexScalar(
 			a.m_x + b.m_x, a.m_y + b.m_y, a.m_typeName);
+	}
+
+	/**
+	 * Add a {@code ComplexScalar} and a real (supplied as a {@code double}).
+	 */
+	@Operator(name = {"javatest","+"}, commutator = TWIN)
+	@Operator(name = {"javatest","+"},  synthetic = TWIN)
+	@Function(
+		schema = "javatest", effects = IMMUTABLE, onNullInput = RETURNS_NULL
+	)
+	public static ComplexScalar add(ComplexScalar a, double b)
+	{
+		return new ComplexScalar(a.m_x + b, a.m_y, a.m_typeName);
 	}
 
 	/**

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/ComplexScalar.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/ComplexScalar.java
@@ -15,10 +15,14 @@ package org.postgresql.pljava.example.annotation;
 import java.io.IOException;
 import java.io.StreamTokenizer;
 import java.io.StringReader;
+
+import static java.lang.Math.hypot;
+
 import java.sql.SQLData;
 import java.sql.SQLException;
 import java.sql.SQLInput;
 import java.sql.SQLOutput;
+
 import java.util.logging.Logger;
 
 import org.postgresql.pljava.annotation.Function;
@@ -120,6 +124,52 @@ public class ComplexScalar implements SQLData {
 	{
 		return new ComplexScalar(
 			a.m_x + b.m_x, a.m_y + b.m_y, a.m_typeName);
+	}
+
+	/**
+	 * True if the left argument is smaller than the right in magnitude
+	 * (Euclidean distance from the origin).
+	 */
+	@Operator(
+		name = "javatest.<",
+		commutator = "javatest.>", negator = "javatest.>="
+	)
+	@Operator(
+		name = "javatest.<=", synthetic = "javatest.magnitudeLE"
+	)
+	@Operator(
+		name = "javatest.>=", synthetic = "javatest.magnitudeGE",
+		commutator = "javatest.<="
+	)
+	@Operator(
+		name = "javatest.>", synthetic = "javatest.magnitudeGT",
+		negator = "javatest.<="
+	)
+	@Function(
+		schema = "javatest", effects = IMMUTABLE, onNullInput = RETURNS_NULL
+	)
+	public static boolean magnitudeLT(ComplexScalar a, ComplexScalar b)
+	{
+		return hypot(a.m_x, a.m_y) < hypot(b.m_x, b.m_y);
+	}
+
+	/**
+	 * True if the left argument and the right are componentwise equal.
+	 */
+	@Operator(
+		name = "javatest.=",
+		commutator = SELF, negator = "javatest.<>"
+	)
+	@Operator(
+		name = "javatest.<>", synthetic = "javatest.magnitudeNE",
+		commutator = SELF
+	)
+	@Function(
+		schema = "javatest", effects = IMMUTABLE, onNullInput = RETURNS_NULL
+	)
+	public static boolean componentsEQ(ComplexScalar a, ComplexScalar b)
+	{
+		return a.m_x == b.m_x  &&  a.m_y == b.m_y;
 	}
 
 	public ComplexScalar(double x, double y, String typeName) {


### PR DESCRIPTION
A new `@Operator` annotation allows PostgreSQL `CREATE OPERATOR` to be generated, with compile-time sanity checking, and concise notation when the annotation is on a Java method, from which many of the operator's vitals can be inferred.

The generator can emit synthetic function and operator declarations to complete a set of operators related to each other by commutation and/or negation, relieving much of the tedium of implementing a full set of `btree` relational operators, for example, or a set of cross-type operators and their commutators.

This PR does not add generation of operator classes or families. Until that is added, `CREATE OPERATOR CLASS` and friends can be done in `@SQLAction` blocks, declaring `requires` on some tag the needed operators/functions will 'provide', to get the ordering right.

The SQL generator's `provides`/`requires` handling has, until now, reported an error if a given dependency tag is 'provided' by more than one snippet. That restriction wasn't necessary, and forced needless verbosity when declaring one thing, such as an operator class, depending on several other things. Previously, that would require inventing several different tags, each to be 'provided' by one of the dependencies, and having the dependent thing 'require' all of them.

That excessively-strict rule has been relaxed, so it is now possible, for example, to have an `@SQLAction` for `CREATE OPERATOR CLASS` say `requires = "class prereqs"` and have each of the prerequisite operators/functions 'provide' that same tag.

This PR also adds some bits of `@Aggregate` that were left out of its earlier PR because one of them, anyway (`sortOperator`) implied awareness of operators.