### PR TITLE
Better workaround for javac 10 and 11 issue

### DIFF
--- a/pljava-api/src/main/java/org/postgresql/pljava/annotation/processing/DDRProcessor.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/annotation/processing/DDRProcessor.java
@@ -402,13 +402,13 @@ class DDRProcessorImpl
 				e = elmu.getTypeElement(m, className);
 		}
 
-		if ( null == e )
-			throw new AssertionError("Boo!");
+		requireNonNull(e,
+			() -> "unexpected failure to resolve TypeElement " + className);
 
 		DeclaredType t = typu.getDeclaredType(e);
 
-		if ( null == t )
-			throw new AssertionError("No TypeElement for " + e + "?");
+		requireNonNull(t,
+			() -> "unexpected failure to resolve DeclaredType " + e);
 
 		return t;
 	}

--- a/pom.xml
+++ b/pom.xml
@@ -70,42 +70,6 @@
 
 	<profiles>
 		<profile>
-			<id>release10</id>
-			<activation>
-				<jdk>[10,11)</jdk>
-			</activation>
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-compiler-plugin</artifactId>
-						<configuration>
-							<release>10</release>
-						</configuration>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
-
-		<profile>
-			<id>release11</id>
-			<activation>
-				<jdk>[11,12)</jdk>
-			</activation>
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-compiler-plugin</artifactId>
-						<configuration>
-							<release>11</release>
-						</configuration>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
-
-		<profile>
 			<id>nashorngone</id>
 			<activation>
 				<jdk>[15,)</jdk>


### PR DESCRIPTION
Revert the unsatisfying workaround added in c763cee for javac 10 and 11 misbehaving when passed a `--release` naming an earlier release, and add a better workaround in `DDRProcessor` itself. Now it is possible to build for `--release 9` whichever toolchain version is used for the build, and that was the original intent and so is much more satisfying.

It turned out (unsurprisingly, in retrospect) that the same issue would also bite someone building user code, and to have no better answer than "fudge your target release if building with 10 or 11" would be hard to stomach.

Addresses #328.