### PR TITLE
Flesh out the XSLT 1.0 functions in the XML examples

### DIFF
--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/PassXML.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/PassXML.java
@@ -215,6 +215,8 @@ import org.w3c.dom.bootstrap.DOMImplementationRegistry;
 		   requires={"prepareXMLTransform", "transformXML"},
 	install={
 		"REVOKE EXECUTE ON FUNCTION javatest.prepareXMLTransformWithJava" +
+		" (pg_catalog.varchar, pg_catalog.xml, integer, boolean," +
+		"  pg_catalog.RECORD)" +
 		" FROM PUBLIC",
 
 		"SELECT" +


### PR DESCRIPTION
My usual advice to anyone considering XSLT 1.0 is "run away!" because it is so primitive and limiting compared to the later versions. And certainly what's possible by downloading Saxon and using XSLT 3 or XQuery 3.1 is far and away preferable to struggling with XSLT 1.0.

Its one advantage is that it is directly included in Java with no need of a large, separately-downloaded jar, and that's enough to make it useful if there's some simple transformation to be done that doesn't require the big guns. Another redeeming feature of Java's XSLT support is that it can call out to Java methods, often allowing a way around the otherwise crippling limitations of strict XSLT 1.0.

So, it is worthwhile to take the existing example methods demonstrating the XSLT 1.0 support and give them a little further polishing to make them convenient for more serious use.