### PR TITLE
Quiet new gcc implicit-fallthrough warnings, and some minor Java lint

### DIFF
--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/PassXML.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/PassXML.java
@@ -1243,7 +1243,7 @@ public class PassXML implements SQLData
 		}
 
 		if ( s instanceof Adjusting.XML.Source )
-			return applyAdjustments(adjust, (Adjusting.XML.Source)s).get();
+			return applyAdjustments(adjust, (Adjusting.XML.Source<?>)s).get();
 		return s;
 	}
 
@@ -1275,7 +1275,7 @@ public class PassXML implements SQLData
 		}
 
 		if ( r instanceof Adjusting.XML.Result )
-			return applyAdjustments(adjust, (Adjusting.XML.Result)r).get();
+			return applyAdjustments(adjust, (Adjusting.XML.Result<?>)r).get();
 		return r;
 	}
 

--- a/pljava-so/src/main/c/Backend.c
+++ b/pljava-so/src/main/c/Backend.c
@@ -518,6 +518,7 @@ static void initsequencer(enum initstage is, bool tolerant)
 		initstage = IS_GUCS_REGISTERED;
 		if ( deferInit )
 			return;
+		/*FALLTHROUGH*/
 
 	case IS_GUCS_REGISTERED:
 		if ( NULL == libjvmlocation )
@@ -530,6 +531,7 @@ static void initsequencer(enum initstage is, bool tolerant)
 			goto check_tolerant;
 		}
 		initstage = IS_CAND_JVMLOCATION;
+		/*FALLTHROUGH*/
 
 	case IS_CAND_JVMLOCATION:
 		if ( NULL == policy_urls )
@@ -542,6 +544,7 @@ static void initsequencer(enum initstage is, bool tolerant)
 			goto check_tolerant;
 		}
 		initstage = IS_CAND_POLICYURLS;
+		/*FALLTHROUGH*/
 
 	case IS_CAND_POLICYURLS:
 		if ( ! pljavaEnabled )
@@ -556,6 +559,7 @@ static void initsequencer(enum initstage is, bool tolerant)
 			goto check_tolerant;
 		}
 		initstage = IS_PLJAVA_ENABLED;
+		/*FALLTHROUGH*/
 
 	case IS_PLJAVA_ENABLED:
 		libjvm_handle = pg_dlopen(libjvmlocation);
@@ -569,6 +573,7 @@ static void initsequencer(enum initstage is, bool tolerant)
 			goto check_tolerant;
 		}
 		initstage = IS_CAND_JVMOPENED;
+		/*FALLTHROUGH*/
 
 	case IS_CAND_JVMOPENED:
 		pljava_createvm =
@@ -592,6 +597,7 @@ static void initsequencer(enum initstage is, bool tolerant)
 			goto check_tolerant;
 		}
 		initstage = IS_CREATEVM_SYM_FOUND;
+		/*FALLTHROUGH*/
 
 	case IS_CREATEVM_SYM_FOUND:
 		s_javaLogLevel = INFO;
@@ -605,6 +611,7 @@ static void initsequencer(enum initstage is, bool tolerant)
 		pljavaDebug = 1;
 #endif
 		initstage = IS_MISC_ONCE_DONE;
+		/*FALLTHROUGH*/
 
 	case IS_MISC_ONCE_DONE:
 		JVMOptList_init(&optList); /* uses CurrentMemoryContext */
@@ -625,6 +632,7 @@ static void initsequencer(enum initstage is, bool tolerant)
 			JVMOptList_add(&optList, effectiveModulePath, 0, true);
 		}
 		initstage = IS_JAVAVM_OPTLIST;
+		/*FALLTHROUGH*/
 
 	case IS_JAVAVM_OPTLIST:
 		JNIresult = initializeJavaVM(&optList); /* frees the optList */
@@ -648,6 +656,7 @@ static void initsequencer(enum initstage is, bool tolerant)
 		jvmStartedAtLeastOnce = true;
 		elog(DEBUG2, "successfully created Java virtual machine");
 		initstage = IS_JAVAVM_STARTED;
+		/*FALLTHROUGH*/
 
 	case IS_JAVAVM_STARTED:
 #ifdef USE_PLJAVA_SIGHANDLERS
@@ -659,6 +668,7 @@ static void initsequencer(enum initstage is, bool tolerant)
 		 */
 		on_proc_exit(_destroyJavaVM, 0);
 		initstage = IS_SIGHANDLERS;
+		/*FALLTHROUGH*/
 
 	case IS_SIGHANDLERS:
 		Invocation_pushBootContext(&ctx);
@@ -709,6 +719,7 @@ static void initsequencer(enum initstage is, bool tolerant)
 			_destroyJavaVM(0, 0);
 			goto check_tolerant;
 		}
+		/*FALLTHROUGH*/
 
 	case IS_PLJAVA_FOUND:
 		greeting = InstallHelper_hello();
@@ -717,11 +728,13 @@ static void initsequencer(enum initstage is, bool tolerant)
 				errdetail("versions:\n%s", greeting)));
 		pfree(greeting);
 		initstage = IS_PLJAVA_INSTALLING;
+		/*FALLTHROUGH*/
 
 	case IS_PLJAVA_INSTALLING:
 		if ( NULL != pljavaLoadPath )
 			InstallHelper_groundwork(); /* sqlj schema, language handlers, ...*/
 		initstage = IS_COMPLETE;
+		/*FALLTHROUGH*/
 
 	case IS_COMPLETE:
 		pljavaLoadingAsExtension = false;

--- a/pljava-so/src/main/c/type/Type.c
+++ b/pljava-so/src/main/c/type/Type.c
@@ -243,6 +243,7 @@ static Type _getCoerce(Type self, Type other, Oid fromOid, Oid toOid,
 	case COERCION_PATH_NONE:
 		elog(ERROR, "no conversion function from (regtype) %d to %d",
 			 fromOid, toOid);
+		pg_unreachable(); /*elog(ERROR is already so marked; what's with gcc?*/
 	case COERCION_PATH_RELABELTYPE:
 		/*
 		 * Binary compatible type. No need for a special coercer.
@@ -255,9 +256,11 @@ static Type _getCoerce(Type self, Type other, Oid fromOid, Oid toOid,
 	case COERCION_PATH_COERCEVIAIO:
 		elog(ERROR, "COERCEVIAIO not implemented from (regtype) %d to %d",
 			 fromOid, toOid);
+		pg_unreachable();
 	case COERCION_PATH_ARRAYCOERCE:
 		elog(ERROR, "ARRAYCOERCE not implemented from (regtype) %d to %d",
 			 fromOid, toOid);
+		pg_unreachable();
 	case COERCION_PATH_FUNC:
 		break;
 	}


### PR DESCRIPTION
Travis builds against Linux PG13 were showing gcc invoked with `-Wimplicit-fallthrough=3`, so quiet the warnings that result. I cannot explain why gcc is not respecting the `pg_unreachable` built into `elog(ERROR` but does respect a `pg_unreachable` added right there in the code.