### PR TITLE
Give SQLType an optional= element

### DIFF
--- a/pljava-api/src/main/java/org/postgresql/pljava/annotation/SQLType.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/annotation/SQLType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2019 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2021 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -57,8 +57,26 @@ public @interface SQLType
 	 * needs to match the number and order of components of the row type (which
 	 * cannot be checked at compile time, but will cause the deployment
 	 * descriptor code to fail at jar install time if it does not).
+	 *<p>
+	 * A Java annotation value cannot be null. If null is what the default value
+	 * should be, use {@code optional=true}.
 	 */
 	String[] defaultValue() default {};
+
+	/**
+	 * What {@code optional=true} means is just what {@code defaultValue=null}
+	 * would mean, if Java permitted null values in annotations.
+	 *<p>
+	 * There is no difference between {@code optional=false} and simply having
+	 * no {@code optional} or {@code defaultValue} element at all.
+	 *<p>
+	 * Only one of {@code optional} or {@code defaultValue} may be present
+	 * in one annotation.
+	 *<p>
+	 * If {@code optional=true}, the function must not be annotated with
+	 * {@code onNullInput=RETURNS_NULL}.
+	 */
+	boolean optional() default false;
 	
 	// Is it worth having a defaultRaw() for rare cases wanting some
 	// arbitrary SQL expression for the default?

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/PassXML.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/PassXML.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2018-2021 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -524,14 +524,14 @@ public class PassXML implements SQLData
 		@SQLType(defaultValue="0") int howin,
 		@SQLType(defaultValue="0") int howout,
 		@SQLType(defaultValue={}) ResultSet adjust,
-		@SQLType(defaultValue="false") boolean indent,
-		@SQLType(defaultValue="4") int indentWidth)
+		@SQLType(optional=true) Boolean indent,
+		@SQLType(optional=true) Integer indentWidth)
 	throws SQLException
 	{
 		Templates tpl = null == transformName? null: s_tpls.get(transformName);
 		Source src = sxToSource(source, howin, adjust);
 
-		if ( indent  &&  0 == howout )
+		if ( Boolean.TRUE.equals(indent)  &&  0 == howout )
 			howout = 4; // transformer only indents if writing a StreamResult
 
 		Connection c = DriverManager.getConnection("jdbc:default:connection");
@@ -549,14 +549,17 @@ public class PassXML implements SQLData
 			if ( rlt instanceof StreamResult )
 				t.setOutputProperty(ENCODING,
 					System.getProperty("org.postgresql.server.encoding"));
-			else if ( indent )
+			else if ( Boolean.TRUE.equals(indent) )
 				logMessage("WARNING",
 					"indent requested, but howout specifies a non-stream " +
 					"Result type; no indenting will happen");
 
-			t.setOutputProperty("indent", indent ? "yes" : "no");
-			t.setOutputProperty(
-				"{http://xml.apache.org/xalan}indent-amount", "" + indentWidth);
+			if ( null != indent )
+				t.setOutputProperty("indent", indent ? "yes" : "no");
+			if ( null != indentWidth )
+				t.setOutputProperty(
+					"{http://xml.apache.org/xalan}indent-amount",
+					"" + indentWidth);
 
 			t.transform(src, rlt);
 		}


### PR DESCRIPTION
Because Java disallows `null` as an annotation element value, it has never been possible to say `defaultValue=null` for a method parameter. Allow `optional=true` as an alternative meaning just that.

Use it to tweak the `PassXML.transformXML` example function so it doesn't set indent-related properties on the transformer unless the caller specified them explicitly.