### PR TITLE
Fix a bug that blocked SQL generation for some synthetic operator derivations

### DIFF
--- a/pljava-api/src/main/java/org/postgresql/pljava/annotation/processing/DDRProcessor.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/annotation/processing/DDRProcessor.java
@@ -2359,6 +2359,27 @@ hunt:	for ( ExecutableElement ee : ees )
 			return Collections.emptyList();
 		}
 
+		private Map<DependTag.Function,Transformed> m_variants= new HashMap<>();
+
+		/**
+		 * Return an instance representing a transformation of this function,
+		 * or null on second and subsequent requests for the same
+		 * transformation (so the caller will not register the variant more
+		 * than once).
+		 */
+		Transformed transformed(
+			Identifier.Qualified<Identifier.Simple> qname,
+			boolean commute, boolean negate)
+		{
+			Transformed prospect = new Transformed(qname, commute, negate);
+			DependTag.Function tag =
+				(DependTag.Function)prospect.provideTags().iterator().next();
+			Transformed found = m_variants.putIfAbsent(tag, prospect);
+			if ( null == found )
+				return prospect;
+			return null;
+		}
+
 		class Transformed implements Snippet
 		{
 			final Identifier.Qualified<Identifier.Simple> m_qname;
@@ -2368,13 +2389,21 @@ hunt:	for ( ExecutableElement ee : ees )
 
 			Transformed(
 				Identifier.Qualified<Identifier.Simple> qname,
-				boolean commute, boolean negate, String comment)
+				boolean commute, boolean negate)
 			{
-				assert commute || negate : "no transformation to apply";
+				EnumSet<OperatorPath.Transform> how =
+					EnumSet.noneOf(OperatorPath.Transform.class);
+				if ( commute )
+					how.add(OperatorPath.Transform.COMMUTATION);
+				if ( negate )
+					how.add(OperatorPath.Transform.NEGATION);
+				assert ! how.isEmpty() : "no transformation to apply";
 				m_qname = requireNonNull(qname);
 				m_commute = commute;
 				m_negate = negate;
-				m_comment = comment;
+				m_comment = "Function automatically derived by " + how +
+					" from " + qnameFrom(
+						FunctionImpl.this.name(), FunctionImpl.this.schema());
 			}
 
 			List<ParameterInfo> parameterInfo()
@@ -3340,10 +3369,10 @@ hunt:	for ( ExecutableElement ee : ees )
 		 *    pending: contains all synthetic snippets
 		 * Step:
 		 *  A snippet s is removed from ready and added to processed.
-		 *  If s.commutator or s.negator matches a synthetic snippet in pending
-		 *  or ready, a corresponding path is recorded on that snippet. If it is
-		 *  the first path recorded on that snippet (which must have been found
-		 *  on pending), that snippet is moved to ready.
+		 *  If s.commutator or s.negator matches a synthetic snippet in pending,
+		 *  a corresponding path is recorded on that snippet. If it is
+		 *  the first path recorded on that snippet, the snippet is moved
+		 *  to ready.
 		 */
 
 		List<OperatorImpl> processed =
@@ -3358,9 +3387,6 @@ hunt:	for ( ExecutableElement ee : ees )
 			processed.add(snip);
 			if ( null != snip.commutator )
 			{
-				for ( OperatorImpl other : ready )
-					maybeAddPath(snip, other,
-						OperatorPath.Transform.COMMUTATION);
 				ListIterator<OperatorImpl> it = pending.listIterator();
 				while ( it.hasNext() )
 				{
@@ -3375,9 +3401,6 @@ hunt:	for ( ExecutableElement ee : ees )
 			}
 			if ( null != snip.negator )
 			{
-				for ( OperatorImpl other : ready )
-					maybeAddPath(snip, other,
-						OperatorPath.Transform.NEGATION);
 				ListIterator<OperatorImpl> it = pending.listIterator();
 				while ( it.hasNext() )
 				{
@@ -3408,6 +3431,17 @@ hunt:	for ( ExecutableElement ee : ees )
 		if ( ! to.isSynthetic )
 			return false; // don't add paths to a non-synthetic operator
 
+		/*
+		 * setSynthetic will have left synthetic null in the synthetic=TWIN
+		 * case. That case imposes more constraints on what paths can be added:
+		 * an acceptable path must involve commutation (and only commutation)
+		 * from another operator that will have a function name (so, either
+		 * a non-synthetic one, or a synthetic one given an actual name, other
+		 * than TWIN). In the latter case, copy the name here (for the former,
+		 * it will be copied from the function's name, in characterize()).
+		 */
+		boolean syntheticTwin = null == to.synthetic;
+
 		switch ( how )
 		{
 		case COMMUTATION:
@@ -3421,7 +3455,26 @@ hunt:	for ( ExecutableElement ee : ees )
 				return false; // move along
 			if ( null != to.negator && ! to.negator.equals(from.qname) )
 				return false; // move along
+			if ( syntheticTwin )
+				return false;
 			break;
+		}
+
+		if ( syntheticTwin )
+		{
+			/*
+			 * We will apply commutation to 'from' (the negation case
+			 * would have been rejected above). Either 'from' is nonsynthetic
+			 * and its function name will be copied in characterize(), or it is
+			 * synthetic and must have a name or we reject it here. If not
+			 * rejected, copy the name.
+			 */
+			if ( from.isSynthetic )
+			{
+				if ( null == from.synthetic )
+					return false;
+				to.synthetic = from.synthetic;
+			}
 		}
 
 		if ( null == to.paths )
@@ -3439,6 +3492,20 @@ hunt:	for ( ExecutableElement ee : ees )
 		}
 
 		return true;
+	}
+
+	/**
+	 * Why has {@code Set} or at least {@code EnumSet} not got this?
+	 */
+	static <E extends Enum<E>> EnumSet<E> symmetricDifference(
+		EnumSet<E> a, EnumSet<E> b)
+	{
+		EnumSet<E> result = a.clone();
+		result.removeAll(b);
+		b = b.clone();
+		b.removeAll(a);
+		result.addAll(b);
+		return result;
 	}
 
 	List<OperatorImpl> m_nonSynthetic = new ArrayList<>();
@@ -3463,15 +3530,9 @@ hunt:	for ( ExecutableElement ee : ees )
 			fromProximate = proximateToNew.clone();
 
 			if ( base == proximate )
-				fromBase = proximateToNew;
+				fromBase = fromProximate;
 			else
-			{
-				fromBase = baseToProximate.clone();
-				fromBase.removeAll(proximateToNew);
-				proximateToNew = proximateToNew.clone();
-				proximateToNew.removeAll(fromBase);
-				fromBase.addAll(proximateToNew);
-			}
+				fromBase = symmetricDifference(baseToProximate, proximateToNew);
 		}
 
 		public String toString()
@@ -4089,7 +4150,7 @@ hunt:	for ( ExecutableElement ee : ees )
 				}
 
 				syntheticFunction =
-					func.new Transformed(synthetic, commute, negate, comment());
+					func.transformed(synthetic, commute, negate);
 			}
 
 			recordImplicitTags();

--- a/pljava-api/src/main/java/org/postgresql/pljava/annotation/processing/DDRProcessor.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/annotation/processing/DDRProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2020 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2021 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -3427,7 +3427,7 @@ hunt:	for ( ExecutableElement ee : ees )
 		if ( null == to.paths )
 			to.paths = new ArrayList<>();
 
-		if ( null == from.synthetic )
+		if ( ! from.isSynthetic )
 			to.paths.add(new OperatorPath(from, from, null, EnumSet.of(how)));
 		else
 		{

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/ComplexScalar.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/ComplexScalar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2015 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2021 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -240,6 +240,41 @@ public class ComplexScalar implements SQLData {
 	public static boolean componentsEQ(ComplexScalar a, ComplexScalar b)
 	{
 		return a.m_x == b.m_x  &&  a.m_y == b.m_y;
+	}
+
+	/**
+	 * True if the complex argument is real-valued and equal to the real
+	 * argument.
+	 *<p>
+	 * From one equality method on (complex,double) can be synthesized all four
+	 * cross-type operators, {@code =} and {@code <>} for that pair of types and
+	 * their {@code TWIN} commutators. One of the {@code <>} twins does need to
+	 * specify what its synthetic function should be named.
+	 */
+	@Operator(
+		name = "javatest.=",
+		commutator = TWIN, negator = "javatest.<>",
+		provides = "complex:double relationals"
+	)
+	@Operator(
+		name = "javatest.=",
+		synthetic = TWIN, negator = "javatest.<>",
+		provides = "complex:double relationals"
+	)
+	@Operator(
+		name = "javatest.<>", synthetic = "javatest.neToReal",
+		commutator = TWIN, provides = "complex:double relationals"
+	)
+	@Operator(
+		name = "javatest.<>", synthetic = TWIN,
+		provides = "complex:double relationals"
+	)
+	@Function(
+		schema = "javatest", effects = IMMUTABLE, onNullInput = RETURNS_NULL
+	)
+	public static boolean eqToReal(ComplexScalar a, double b)
+	{
+		return a.m_x == b  &&  0. == a.m_y;
 	}
 
 	/**


### PR DESCRIPTION
With the bug fixed, it is now possible to write one Java method, say `boolean eqToReal(Complex,double)`, and synthesize from it the four operators `=(Complex,double)`, `<>(Complex,double)`, `=(double,Complex)`, and `<>(double,Complex)`.

The runtime was already up to the job, but the SQL generator couldn't figure out the declarations.