### PR TITLE
Do not turn consecutive spaces in pg_config output into empty cc/ld arguments

### DIFF
--- a/pljava-pgxs/src/test/java/PgConfigPropertyAsListTest.java
+++ b/pljava-pgxs/src/test/java/PgConfigPropertyAsListTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2020-2021 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -8,6 +8,7 @@
  *
  * Contributors:
  *   Kartik Ohri
+ *   Chapman Flack
  */
 
 import org.junit.Before;
@@ -50,6 +51,16 @@ public class PgConfigPropertyAsListTest {
 	{
 		List<String> actualResult = pgxs.getPgConfigPropertyAsList(
 			"-Wl,--as-needed -Wl,-rpath,'/usr/local test/pgsql/lib',--enable-new-dtags");
+		List<String> expectedResult = List.of("-Wl,--as-needed",
+			"-Wl,-rpath,/usr/local test/pgsql/lib,--enable-new-dtags");
+		assertEquals(expectedResult, actualResult);
+	}
+
+	@Test
+	public void testMultipleSpaceSeparator()
+	{
+		List<String> actualResult = pgxs.getPgConfigPropertyAsList(
+			"-Wl,--as-needed  -Wl,-rpath,'/usr/local test/pgsql/lib',--enable-new-dtags");
 		List<String> expectedResult = List.of("-Wl,--as-needed",
 			"-Wl,-rpath,/usr/local test/pgsql/lib,--enable-new-dtags");
 		assertEquals(expectedResult, actualResult);


### PR DESCRIPTION
The change in f8e475b was a hasty measure on discovering that the single quotes in a quoted argument reported by `pg_config` may appear within the argument rather than only surrounding it. It solved that problem, but can be fooled into empty arguments where multiple spaces separate arguments in the `pg_config` output (issue #347).

Revert to the regex-based approach from before f8e475b and just tweak that.

This implementation openly makes _no_ allowance for an argument having a single quote in its content. PostgreSQL's own build process failed in a simple attempt to create such a case, so supporting it here is probably not necessary for now.