### PR TITLE
When validating, run class initializer in same access control context as when function is called

### DIFF
--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/PreJSR310.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/PreJSR310.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2018-2021 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -46,6 +46,21 @@ import org.postgresql.pljava.annotation.SQLAction;
 public class PreJSR310
 {
 	private static final String TZPRAGUE = "Europe/Prague";
+
+	static
+	{
+		TimeZone oldZone = TimeZone.getDefault();
+		TimeZone tzPrague = TimeZone.getTimeZone(TZPRAGUE);
+
+		try
+		{
+			TimeZone.setDefault(tzPrague);
+		}
+		finally
+		{
+			TimeZone.setDefault(oldZone);
+		}
+	}
 
 	/**
 	 * Test for a regression in PG date to/from java.sql.Date conversion

--- a/pljava/src/main/java/org/postgresql/pljava/internal/Function.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/Function.java
@@ -172,7 +172,9 @@ public class Function
 	 *<p>
 	 * The return type is the last element of {@code jTypes}.
 	 *<p>
-	 * {@code acc} is null except when validating; see {@code loadClass}.
+	 * {@code acc} is non-null if validating and class initializers should
+	 * be run for parameter and return-type classes; in any other case it is
+	 * null (see {@code loadClass}).
 	 */
 	private static MethodType buildSignature(
 		ClassLoader schemaLoader, String[] jTypes, AccessControlContext acc,
@@ -232,7 +234,9 @@ public class Function
 	 * non-multicall case, else one of {@code ResultSetHandle} or
 	 * {@code ResultSetProvider} depending on {@code altForm}.
 	 *<p>
-	 * {@code acc} is null except when validating; see {@code loadClass}.
+	 * {@code acc} is non-null if validating and class initializers should
+	 * be run for parameter and return-type classes; in any other case it is
+	 * null (see {@code loadClass}).
 	 */
 	private static Class<?> getReturnSignature(
 		ClassLoader schemaLoader, String retJType, AccessControlContext acc,
@@ -286,7 +290,9 @@ public class Function
 	 * For now, this is a near-facsimile of the C implementation. A further step
 	 * of refactoring into clearer idiomatic Java can come later.
 	 *<p>
-	 * {@code acc} is null except when validating; see {@code loadClass}.
+	 * {@code acc} is non-null if validating and class initializers should
+	 * be run for parameter and return-type classes; in any other case it is
+	 * null (see {@code loadClass}).
 	 */
 	private static MethodHandle getMethodHandle(
 		ClassLoader schemaLoader, Class<?> clazz, String methodName,
@@ -1369,7 +1375,7 @@ public class Function
 
 		MethodHandle handle =
 			getMethodHandle(schemaLoader, clazz, methodName,
-				forValidator ? acc : null,
+				null, // or acc to initialize parameter classes; overkill.
 				commute, resolvedTypes, retTypeIsOutParameter, isMultiCall)
 			.asFixedArity();
 		MethodType mt = handle.type();


### PR DESCRIPTION
When a PL/Java function is called, it gets its own access control context selected based on the "procedural language" and trusted/untrusted attribute; it is simple to grant it whatever permissions it may need in the policy file.

At `CREATE FUNCTION` time, when validating (`check_function_bodies` is `on`), run the class initializer the same way. That avoids the inconvenience reported in #342, where permissions needed only by the user class (used in its static initializer) had to be granted also to PL/Java itself or the `CREATE FUNCTION` would fail validation, because some PL/Java code was still on the protection domain stack when the initializer was invoked.

Add a section on the topic to `policy.md`.