### PR TITLE
Improvements to experience when pljava.module_path may not be right

### DIFF
--- a/pljava-so/src/main/c/Backend.c
+++ b/pljava-so/src/main/c/Backend.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2020 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2021 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -1320,12 +1320,13 @@ static void _destroyJavaVM(int status, Datum dummy)
 		pqsigfunc saveSigAlrm;
 #endif
 
-		Invocation_pushInvocation(&ctx);
+		Invocation_pushBootContext(&ctx);
 		if(sigsetjmp(recoverBuf, 1) != 0)
 		{
 			elog(DEBUG2,
 				"needed to forcibly shut down the Java virtual machine");
 			s_javaVM = 0;
+			currentInvocation = 0;
 			return;
 		}
 
@@ -1347,7 +1348,7 @@ static void _destroyJavaVM(int status, Datum dummy)
 #endif
 
 #else
-		Invocation_pushInvocation(&ctx);
+		Invocation_pushBootContext(&ctx);
 		elog(DEBUG2, "shutting down the Java virtual machine");
 		JNI_destroyVM(s_javaVM);
 #endif

--- a/pljava-so/src/main/c/Backend.c
+++ b/pljava-so/src/main/c/Backend.c
@@ -924,6 +924,8 @@ void _PG_init()
 	if ( IS_PLJAVA_INSTALLING == initstage )
 		return; /* creating handler functions will cause recursive call */
 
+	InstallHelper_earlyHello();
+
 	/*
 	 * Find the platform's path separator. Java knows it, but that's no help in
 	 * preparing the launch options before it is launched. PostgreSQL knows what

--- a/pljava-so/src/main/c/InstallHelper.c
+++ b/pljava-so/src/main/c/InstallHelper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2015-2021 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -517,6 +517,12 @@ char const *InstallHelper_defaultModulePath(char *pathbuf, char pathsep)
 
 	*pbp = '-'; /* overwrite the \0 so now it's a single string. */
 	return pathbuf;
+}
+
+void InstallHelper_earlyHello()
+{
+	elog(DEBUG2,
+		"pljava-so-" SO_VERSION_STRING " built for (" PG_VERSION_STR ")");
 }
 
 char *InstallHelper_hello()

--- a/pljava-so/src/main/include/pljava/InstallHelper.h
+++ b/pljava-so/src/main/include/pljava/InstallHelper.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2015-2021 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -129,8 +129,27 @@ extern bool pljavaViableXact(void);
  */
 extern bool InstallHelper_shouldDeferInit(void);
 
+/*
+ * Emit a debug message as early as possible with the native code's version
+ * and build information. A nicer message is produced later by hello and
+ * includes both the native and Java versions, but that's too late if something
+ * goes wrong first.
+ */
+extern void InstallHelper_earlyHello(void);
+
+/*
+ * Perform early setup needed on every start (properties, security policy, etc.)
+ * and also construct and return a string of native code, Java code, and JVM
+ * version and build information, to be included in the "PL/Java loaded"
+ * message.
+ */
 extern char *InstallHelper_hello(void);
 
+/*
+ * Called only when the loading is directly due to CREATE EXTENSION or LOAD, and
+ * not simply to service a PL/Java function; checks for, and populates or brings
+ * up to date, as needed, the sqlj schema and its contents.
+ */
 extern void InstallHelper_groundwork(void);
 
 extern void InstallHelper_initialize(void);


### PR DESCRIPTION
Addressing #350:

* Don't segfault after reporting a failure to find the expected first Java class
* Don't have backend exit with no log message if the JVM can't build the boot module layer
* Do emit a very early `DEBUG2` message with version info for the shared object, just to allay suspicions about mismatched versions.