### PR TITLE
Treat an autovacuum worker process specially

### DIFF
--- a/pljava-so/src/main/include/pljava/InstallHelper.h
+++ b/pljava-so/src/main/include/pljava/InstallHelper.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2015-2021 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -73,8 +73,9 @@ extern bool InstallHelper_isPLJavaFunction(Oid fn);
 
 /*
  * Return the name of the current database, from MyProcPort ... don't free it.
- * In a background worker, there's no MyProcPort, and the name is found another
- * way and strdup'd in TopMemoryContext, it'll keep, don't bother freeing it.
+ * In a background or autovacuum worker, there's no MyProcPort, and the name is
+ * found another way and strdup'd in TopMemoryContext. It'll keep; don't bother
+ * freeing it.
  */
 extern char *pljavaDbName();
 


### PR DESCRIPTION
PL/Java can be invoked in an autovacuum worker process if there is a functional index declared that uses a PL/Java function. Like the background worker case, there may not be a `MyProcPort` structure available.

This fix is only usable back to PG 9.5. In older PG versions, it may be necessary to use `false` as the per-table `autovacuum_enabled` storage parameter on any table having a Java-based functional index, and run explicit `VACUUM` on such tables over a normal connection. Prior to PG 8.4, there was no such per-table setting, and the only workaround would be to forego autovacuum database-wide and use explicit `VACUUM` on some schedule.