### PR TITLE
Backport 1.6's handling of SQL_ASCII to 1.5

### DIFF
--- a/pljava-so/src/main/c/type/String.c
+++ b/pljava-so/src/main/c/type/String.c
@@ -395,10 +395,14 @@ void String_initialize(void)
 
 static void String_initialize_codec()
 {
+	/*
+	 * Wondering why this function doesn't bother deleting its many local refs?
+	 * The call is wrapped in pushLocalFrame/popLocalFrame in the caller.
+	 */
 	jmethodID string_intern = PgObject_getJavaMethod(s_String_class,
 		"intern", "()Ljava/lang/String;");
 	jstring empty = JNI_newStringUTF( "");
-	jstring u8Name = JNI_newStringUTF( "UTF-8");
+	char const *charset_name;
 	jclass charset_class = PgObject_getJavaClass("java/nio/charset/Charset");
 	jmethodID charset_forName = PgObject_getStaticJavaMethod(charset_class,
 		"forName", "(Ljava/lang/String;)Ljava/nio/charset/Charset;");
@@ -406,8 +410,6 @@ static void String_initialize_codec()
 		"newDecoder", "()Ljava/nio/charset/CharsetDecoder;");
 	jmethodID charset_newEncoder = PgObject_getJavaMethod(charset_class,
 		"newEncoder", "()Ljava/nio/charset/CharsetEncoder;");
-	jobject u8cs = JNI_callStaticObjectMethod(charset_class, charset_forName,
-		u8Name);
 	jclass decoder_class =
 		PgObject_getJavaClass("java/nio/charset/CharsetDecoder");
 	jclass encoder_class =
@@ -420,11 +422,28 @@ static void String_initialize_codec()
 	jfieldID underflow = PgObject_getStaticJavaField(result_class, "UNDERFLOW",
 		"Ljava/nio/charset/CoderResult;");
 	jclass buffer_class = PgObject_getJavaClass("java/nio/Buffer");
+	jobject servercs;
+
+	s_server_encoding = GetDatabaseEncoding();
+
+	if ( PG_SQL_ASCII == s_server_encoding )
+	{
+		charset_name = "X-PGSQL_ASCII";
+		s_two_step_conversion = false;
+	}
+	else
+	{
+		charset_name = "UTF-8";
+		s_two_step_conversion = PG_UTF8 != s_server_encoding;
+	}
+
+	servercs = JNI_callStaticObjectMethodLocked(charset_class,
+		charset_forName, JNI_newStringUTF(charset_name));
 
 	s_CharsetDecoder_instance =
-		JNI_newGlobalRef(JNI_callObjectMethod(u8cs, charset_newDecoder));
+		JNI_newGlobalRef(JNI_callObjectMethod(servercs, charset_newDecoder));
 	s_CharsetEncoder_instance =
-		JNI_newGlobalRef(JNI_callObjectMethod(u8cs, charset_newEncoder));
+		JNI_newGlobalRef(JNI_callObjectMethod(servercs, charset_newEncoder));
 	s_CharsetDecoder_decode = PgObject_getJavaMethod(decoder_class, "decode",
 		"(Ljava/nio/ByteBuffer;)Ljava/nio/CharBuffer;");
 	s_CharsetEncoder_encode = PgObject_getJavaMethod(encoder_class, "encode",
@@ -450,7 +469,5 @@ static void String_initialize_codec()
 	s_the_empty_string = JNI_newGlobalRef(
 		JNI_callObjectMethod(empty, string_intern));
 
-	s_server_encoding = GetDatabaseEncoding();
-	s_two_step_conversion = PG_UTF8 != s_server_encoding;
 	uninitialized = false;
 }

--- a/pljava/src/main/java/org/postgresql/pljava/internal/SQL_ASCII.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/SQL_ASCII.java
@@ -1,0 +1,227 @@
+/*
+ * Copyright (c) 2020-2021 Tada AB and other contributors, as listed below.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Chapman Flack
+ */
+package org.postgresql.pljava.internal;
+
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+
+import java.nio.charset.Charset;
+import java.nio.charset.CharsetDecoder;
+import java.nio.charset.CharsetEncoder;
+import java.nio.charset.CoderResult;
+import java.nio.charset.spi.CharsetProvider;
+
+import static java.util.Collections.singletonList;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * An {@code SQL_ASCII}, a/k/a {@code X-PGSQL_ASCII}, "character set".
+ *<p>
+ * This is a principled Java take on the PostgreSQL definition of
+ * SQL_ASCII as an encoding where the seven-bit ASCII values are
+ * themselves and the remaining eight-bit values are who-knows-what.
+ * It isn't appropriate to just copy byte values with no conversion,
+ * as that would amount to saying we know the values correspond to
+ * LATIN-1, which would be lying. Java strings are by definition Unicode,
+ * so it's not ok to go stuffing code points in that do not mean what
+ * Unicode defines those code points to mean.
+ *<p>
+ * What this decoder does is decode the seven-bit ASCII values as
+ * themselves, and decode each eight-bit value into a pair of Unicode
+ * noncharacters, one from the range u+fdd8 to u+fddf, followed by one
+ * from u+fde0 to u+fdef, where the first one's four low bits are the
+ * four high bits of the original value, and the second has the low four.
+ * The encoder transparently reverses that.
+ *<p>
+ * Those noncharacter code points are permanently defined in Unicode
+ * to have no glyphs, no correspondence to specific characters, and
+ * no interesting properties. Implementing this charset allows PL/Java
+ * code to work usefully in a database with SQL_ASCII encoding, when the
+ * expectation is that whatever the code needs to recognize, act on, or
+ * edit will be in ASCII, and any non-ASCII content can be passed along
+ * uninterpreted and unchanged.
+ */
+class SQL_ASCII extends Charset
+{
+	static class Holder
+	{
+		static final List<Charset> s_list =
+			singletonList((Charset)new SQL_ASCII());
+	}
+
+
+	static final Charset US_ASCII;
+
+	static
+	{
+		try
+		{
+			US_ASCII = Charset.forName("US-ASCII");
+		}
+		catch ( IllegalArgumentException e ) // I'll take this chance
+		{
+			throw new ExceptionInInitializerError(e);
+		}
+	}
+
+	public static class Provider extends CharsetProvider
+	{
+		static final String s_canonName = "X-PGSQL_ASCII";
+		static final String[] s_aliases = { "SQL_ASCII" };
+
+		@Override
+		public Charset charsetForName(String charsetName)
+		{
+			if ( s_canonName.equalsIgnoreCase(charsetName) )
+				return Holder.s_list.get(0);
+			for ( String s : s_aliases )
+				if ( s.equalsIgnoreCase(charsetName) )
+					return Holder.s_list.get(0);
+			return null;
+		}
+
+		@Override
+		public Iterator<Charset> charsets()
+		{
+			return Holder.s_list.iterator();
+		}
+	}
+
+
+	private SQL_ASCII()
+	{
+		super(Provider.s_canonName, Provider.s_aliases);
+	}
+
+	@Override
+	public boolean contains(Charset cs)
+	{
+		return this.equals(cs)  ||  US_ASCII.equals(cs);
+	}
+
+	@Override
+	public CharsetDecoder newDecoder()
+	{
+		return new Decoder();
+	}
+
+	@Override
+	public CharsetEncoder newEncoder()
+	{
+		return new Encoder();
+	}
+
+
+	static class Decoder extends CharsetDecoder
+	{
+		Decoder()
+		{
+			super(Holder.s_list.get(0), 1.002f, 2.0f);
+		}
+
+		@Override
+		protected CoderResult decodeLoop(ByteBuffer in, CharBuffer out)
+		{
+			int ipos = in.position();
+			int opos = out.position();
+			int ilim = in.limit();
+			int olim = out.limit();
+
+			for ( ; ipos < ilim ; ++ ipos )
+			{
+				char b = (char)(0xff & in.get(ipos));
+
+				if ( b < 128 )
+				{
+					if ( opos == olim )
+					{
+						in.position(ipos);
+						out.position(opos);
+						return CoderResult.OVERFLOW;
+					}
+					out.put(opos++, b);
+				}
+				else
+				{
+					if ( opos + 1 >= olim )
+					{
+						in.position(ipos);
+						out.position(opos);
+						return CoderResult.OVERFLOW;
+					}
+					out.put(opos++, (char)(0xFDD0 | (b >> 4)));
+					out.put(opos++, (char)(0xFDE0 | (b & 0xf)));
+				}
+			}
+			in.position(ipos);
+			out.position(opos);
+			return CoderResult.UNDERFLOW;
+		}
+	}
+
+	static class Encoder extends CharsetEncoder
+	{
+		Encoder()
+		{
+			super(Holder.s_list.get(0), 0.998f, 1.0f);
+		}
+
+		@Override
+		protected CoderResult encodeLoop(CharBuffer in, ByteBuffer out)
+		{
+			int ipos = in.position();
+			int opos = out.position();
+			int ilim = in.limit();
+			int olim = out.limit();
+
+			for ( ; ipos < ilim ; ++ ipos )
+			{
+				if ( opos == olim )
+				{
+					in.position(ipos);
+					out.position(opos);
+					return CoderResult.OVERFLOW;
+				}
+
+				char c = in.get(ipos);
+
+				if ( '\uFDD8' <= c  &&  c < '\uFDE0' )
+				{
+					if ( ipos + 1 == ilim )
+						break;
+
+					char d = in.get(ipos + 1);
+
+					if ( '\uFDE0' > d  ||  d > '\uFDEF' )
+					{
+						in.position(ipos);
+						out.position(opos);
+						return CoderResult.malformedForLength(2);
+					}
+					c = (char)(( (c & 0xf) << 4 ) | (d & 0xf));
+					++ ipos;
+				}
+				else if ( c >= 128 )
+				{
+					in.position(ipos);
+					out.position(opos);
+					return CoderResult.unmappableForLength(1);
+				}
+				out.put(opos++, (byte)c);
+			}
+			in.position(ipos);
+			out.position(opos);
+			return CoderResult.UNDERFLOW;
+		}
+	}
+}

--- a/pljava/src/main/resources/META-INF/services/java.nio.charset.spi.CharsetProvider
+++ b/pljava/src/main/resources/META-INF/services/java.nio.charset.spi.CharsetProvider
@@ -1,0 +1,1 @@
+org.postgresql.pljava.internal.SQL_ASCII$Provider

--- a/src/site/markdown/use/variables.md
+++ b/src/site/markdown/use/variables.md
@@ -10,14 +10,11 @@ These PostgreSQL configuration variables can influence PL/Java's operation:
 `server_encoding`
 : Another non-PL/Java variable, this affects all text/character strings
     exchanged between PostgreSQL and Java. `UTF8` as the database and server
-    encoding is _strongly_ recommended. If a different encoding is used, it
+    encoding is strongly recommended. If a different encoding is used, it
     should be any of the available _fully defined_ character encodings. In
-    particular, the PostgreSQL pseudo-encoding `SQL_ASCII` (which means
-    "characters within ASCII are ASCII, others are no-one-knows-what") will
-    _not_ work well with PL/Java, raising exceptions whenever strings contain
-    non-ASCII characters. (PL/Java can still be used in such a database, but
-    the application code needs to know what it's doing and use the right
-    conversion functions where needed.)
+    particular, the PostgreSQL pseudo-encoding `SQL_ASCII` does not fully
+    define what any values outside ASCII represent; it is usable, but
+    [subject to limitations][sqlascii].
 
 `pljava.classpath`
 : The class path to be passed to the Java application class loader. There
@@ -123,3 +120,4 @@ These PostgreSQL configuration variables can influence PL/Java's operation:
 [jow]: https://docs.oracle.com/javase/8/docs/technotes/tools/windows/java.html
 [jou]: https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html
 [vmop]: ../install/vmoptions.html
+[sqlascii]: charsets.html#Using_PLJava_with_server_encoding_SQL_ASCII


### PR DESCRIPTION
1.5's handling of the `SQL_ASCII` encoding was a bit worse than just "it's a Unicode-incompatible PostgreSQL encoding, good luck with it"; issue #340 identified an actual live bug. (`pg_do_encoding_conversion` can be passed a non-NUL-terminated string, and can return that string unchanged in some cases, as a comment on it duly warns; it turns out that one such case is "every time, if your server encoding is `SQL_ASCII`".)

Knowing that the existing behavior is buggy weakens the argument against backporting the `SQL_ASCII` behavior change from 1.6. So here it is.