### PR TITLE
Detect if running in a post-JEP411 JVM

### DIFF
--- a/src/site/markdown/install/install.md.vm
+++ b/src/site/markdown/install/install.md.vm
@@ -217,6 +217,9 @@ and are subject to very few restrictions at runtime. Functions that specify
 `USAGE` permission `ON LANGUAGE java`. They run under a security manager that
 denies access to the host filesystem.
 
+__Note: For implications when running on Java 17 or later,
+please see [JEP 411][jep411]__.
+
 PostgreSQL, by default, would grant `USAGE` to `PUBLIC` on the `java` language,
 but PL/Java takes a more conservative approach on a new installation.
 In keeping with the principle of least privilege,
@@ -393,3 +396,5 @@ $h3 PostgreSQL superuser, OS user distinct from the user running postgres
 In this case, simply place the files in any location where you can make them
 readable by the user running `postgres`, and set the `pljava.*` variables
 accordingly.
+
+[jep411]: https://github.com/tada/pljava/wiki/JEP-411


### PR DESCRIPTION
PL/Java 1.5's build system already breaks as of Java 15, so it won't be necessary to add `SuppressWarnings("removal")` anywhere in the 1.5 sources. It also will not start by default on a JVM later than 17, because it does not use `-Djava.security.manager=allow` among the invocation options by default. The logic here is only to detect if it has been run with that option explicitly added (in `pljava.vmoptions`) and is running on a Java version where the functionality has been gutted.

More at https://github.com/tada/pljava/wiki/JEP-411