### PR TITLE
Preparations in PL/Java 1.6 for impacts of Java's JEP 411

### DIFF
--- a/.github/workflows/ci-runnerpg.yml
+++ b/.github/workflows/ci-runnerpg.yml
@@ -251,7 +251,9 @@ jobs:
           String type = parts[0];
           results.compute(type, (k,v) -> 1 + v);
           if ( whatIsNG.contains(type) )
-            results.compute("ng", (k,v) -> 1 + v);
+            if ( ! "warning".equals(type)
+              ||  ! message.startsWith("[JEP 411]") )
+              results.compute("ng", (k,v) -> 1 + v);
           return true;
         }
 

--- a/.github/workflows/ci-runnerpg.yml
+++ b/.github/workflows/ci-runnerpg.yml
@@ -249,6 +249,7 @@ jobs:
             return false;
           String[] parts = Node.classify((Throwable)o);
           String type = parts[0];
+          String message = parts[2];
           results.compute(type, (k,v) -> 1 + v);
           if ( whatIsNG.contains(type) )
             if ( ! "warning".equals(type)

--- a/.travis.yml
+++ b/.travis.yml
@@ -188,6 +188,7 @@ script: |
       return false;
     String[] parts = Node.classify((Throwable)o);
     String type = parts[0];
+    String message = parts[2];
     results.compute(type, (k,v) -> 1 + v);
     if ( whatIsNG.contains(type) )
       if ( ! "warning".equals(type)  ||  ! message.startsWith("[JEP 411]") )

--- a/.travis.yml
+++ b/.travis.yml
@@ -190,7 +190,8 @@ script: |
     String type = parts[0];
     results.compute(type, (k,v) -> 1 + v);
     if ( whatIsNG.contains(type) )
-      results.compute("ng", (k,v) -> 1 + v);
+      if ( ! "warning".equals(type)  ||  ! message.startsWith("[JEP 411]") )
+        results.compute("ng", (k,v) -> 1 + v);
     return true;
   }
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -128,7 +128,8 @@ test_script:
         String type = parts[0];
         results.compute(type, (k,v) -> 1 + v);
         if ( whatIsNG.contains(type) )
-          results.compute("ng", (k,v) -> 1 + v);
+          if ( ! "warning".equals(type)  ||  ! message.startsWith("[JEP 411]") )
+            results.compute("ng", (k,v) -> 1 + v);
         return true;
       }
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -126,6 +126,7 @@ test_script:
           return false;
         String[] parts = Node.classify((Throwable)o);
         String type = parts[0];
+        String message = parts[2];
         results.compute(type, (k,v) -> 1 + v);
         if ( whatIsNG.contains(type) )
           if ( ! "warning".equals(type)  ||  ! message.startsWith("[JEP 411]") )

--- a/pljava-so/src/main/c/DualState.c
+++ b/pljava-so/src/main/c/DualState.c
@@ -20,6 +20,7 @@
 #include "org_postgresql_pljava_internal_DualState_SingleSPIcursorClose.h"
 #include "pljava/DualState.h"
 
+#include "pljava/Backend.h"
 #include "pljava/Exception.h"
 #include "pljava/Invocation.h"
 #include "pljava/PgObject.h"
@@ -268,6 +269,9 @@ static void resourceReleaseCB(ResourceReleasePhase phase,
 		return;
 
 	pljava_DualState_nativeRelease(CurrentResourceOwner);
+
+	if ( isTopLevel )
+		Backend_warnJEP411(isCommit);
 }
 
 

--- a/pljava-so/src/main/c/InstallHelper.c
+++ b/pljava-so/src/main/c/InstallHelper.c
@@ -97,12 +97,6 @@
 #endif
 #endif
 
-#ifndef PLJAVA_SO_VERSION
-#error "PLJAVA_SO_VERSION needs to be defined to compile this file."
-#else
-#define SO_VERSION_STRING CppAsString2(PLJAVA_SO_VERSION)
-#endif
-
 /*
  * The name of the table the extension scripts will create to pass information
  * here. The table name is phrased as an error message because it will appear
@@ -445,7 +439,14 @@ char *pljavaFnOidToLibPath(Oid fnOid, char **langName, bool *trusted)
 
 bool InstallHelper_shouldDeferInit()
 {
-	return IsBackgroundWorker || IsBinaryUpgrade || IsAutoVacuumWorkerProcess();
+	if ( IsBackgroundWorker || IsAutoVacuumWorkerProcess() )
+		return true;
+
+	if ( ! IsBinaryUpgrade )
+		return false;
+
+	Backend_warnJEP411(true);
+	return true;
 }
 
 bool InstallHelper_isPLJavaFunction(Oid fn, char **langName, bool *trusted)

--- a/pljava-so/src/main/c/JNICalls.c
+++ b/pljava-so/src/main/c/JNICalls.c
@@ -1109,6 +1109,15 @@ jmethodID JNI_getStaticMethodIDOrNull(jclass clazz, const char* name, const char
 	return result;
 }
 
+jint JNI_getStaticIntField(jclass clazz, jfieldID field)
+{
+	jint result;
+	BEGIN_JAVA
+	result = (*env)->GetStaticIntField(env, clazz, field);
+	END_JAVA
+	return result;
+}
+
 jobject JNI_getStaticObjectField(jclass clazz, jfieldID field)
 {
 	jobject result;

--- a/pljava-so/src/main/include/pljava/Backend.h
+++ b/pljava-so/src/main/include/pljava/Backend.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2020 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2021 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -26,11 +26,28 @@ extern "C" {
  * 
  * @author Thomas Hallgren
  *****************************************************************/
+#ifndef PLJAVA_SO_VERSION
+#error "PLJAVA_SO_VERSION needs to be defined to compile this file."
+#else
+#define SO_VERSION_STRING CppAsString2(PLJAVA_SO_VERSION)
+#endif
+
 #if PG_VERSION_NUM < 100000
 extern bool integerDateTimes;
 #endif
 
 int Backend_setJavaLogLevel(int logLevel);
+
+/*
+ * Called at the ends of committing transactions to emit a warning about future
+ * JEP 411 impacts, at most once per session, if any PL/Java functions were
+ * declared or redeclared in the transaction, or if PL/Java was installed or
+ * upgraded. Also called from InstallHelper, if pg_upgrade is happening. Yes,
+ * this is a bit tangled. The tracking of function declaration and
+ * install/upgrade is encapsulated in Backend.c. If isCommit is false,
+ * no warning is emitted, and the tracking bit is reset.
+ */
+void Backend_warnJEP411(bool isCommit);
 
 #ifdef PG_GETCONFIGOPTION
 #error The macro PG_GETCONFIGOPTION needs to be renamed.

--- a/pljava-so/src/main/include/pljava/JNICalls.h
+++ b/pljava-so/src/main/include/pljava/JNICalls.h
@@ -196,6 +196,7 @@ extern void         JNI_getShortArrayRegion(jshortArray array, jsize start, jsiz
 extern jfieldID     JNI_getStaticFieldID(jclass clazz, const char* name, const char* sig);
 extern jmethodID    JNI_getStaticMethodID(jclass clazz, const char* name, const char* sig);
 extern jmethodID    JNI_getStaticMethodIDOrNull(jclass clazz, const char* name, const char* sig);
+extern jint         JNI_getStaticIntField(jclass clazz, jfieldID field);
 extern jobject      JNI_getStaticObjectField(jclass clazz, jfieldID field);
 extern const char*  JNI_getStringUTFChars(jstring string, jboolean* isCopy);
 extern jboolean     JNI_hasNullArrayElement(jobjectArray array);

--- a/pljava/src/main/java/org/postgresql/pljava/internal/Backend.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/Backend.java
@@ -311,6 +311,16 @@ public class Backend
 	}
 
 	/**
+	 * Attempt (best effort, unexposed JDK internals) to suppress
+	 * the layer-inappropriate JEP 411 warning when {@code InstallHelper}
+	 * sets up permission enforcement.
+	 */
+	static void pokeJEP411()
+	{
+		_pokeJEP411(InstallHelper.class, true);
+	}
+
+	/**
 	 * Returns <code>true</code> if the backend is awaiting a return from a
 	 * call into the JVM. This method will only return <code>false</code>
 	 * when called from a thread other then the main thread and the main
@@ -331,6 +341,7 @@ public class Backend
 	private static native void _clearFunctionCache();
 	private static native boolean _isCreatingExtension();
 	private static native String _myLibraryPath();
+	private static native void _pokeJEP411(Class<?> caller, Object token);
 
 	private static class EarlyNatives
 	{

--- a/pljava/src/main/java/org/postgresql/pljava/internal/Backend.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/Backend.java
@@ -47,6 +47,8 @@ public class Backend
 	 */
 	public static final ThreadLocal<Boolean> IAMPGTHREAD = new ThreadLocal<>();
 
+	static final int JAVA_MAJOR = Runtime.version().major();
+
 	static
 	{
 		IAMPGTHREAD.set(Boolean.TRUE);

--- a/pom.xml
+++ b/pom.xml
@@ -153,6 +153,7 @@
 				<configuration>
 					<encoding>${project.build.sourceEncoding}</encoding>
 					<release>9</release>
+					<showDeprecation>true</showDeprecation>
 					<showWarnings>true</showWarnings>
 				</configuration>
 			</plugin>


### PR DESCRIPTION
The PL/Java 1.6 series definitely relies on the Java functionality that JEP 411 begins to phase out; it will take some future PL/Java major release to implement the security enforcement in some completely different way. But 1.6 will remain usable at least as long as Java 17 does, and Java 17 is positioned as a long term support release.

This pull request simply makes adjustments in 1.6 to provide useful advance notice of the future changes, and useful and specific exception messages if run on a later Java version with the needed functionality missing. (Late in the process, when some future Java version has completely removed the classes and methods in question, this PL/Java version will flat-out fail to start, with linkage errors. A future minor release could set out to address that by referring to those components only reflectively or with method handles, but only if it seems feasible and worthwhile to field a degraded version with no security enforcement.)

In this PR:

* The boilerplate warning written to standard error by Java itself, starting in 17, is suppressed (it would be going into the server log, if `logging_collector` is on, for every backend that starts PL/Java, and nothing it says would be useful to a PostgreSQL or PL/Java admin)
* An advance warning, written usefully in PL/Java terms and including the wiki page URL below, is emitted, if the Java version in use is 12 or later, no more than once per session and only when certain PL/Java administrative actions occur (installing or upgrading PL/Java, declaring or redeclaring Java functions, or running `pg_upgrade` on a database with PL/Java installed.
* Specific and explanatory exception messages are generated if run on a Java version that throws `UnsupportedOperationException` or shows "degraded" behavior of the affected API.
* A system property will be recognized as an administrative approval to ignore the degraded behavior and simply run with no enforcement. (With the difficulty of predicting just how the behavior will be "degraded" in as-yet-unreleased Java versions, there can be no guarantee that property will do anything useful, other than perhaps move failure to a later point.)

Java 12 is chosen for starting the advance advisory warnings, so that a site that tends to move slowly between LTS releases will not see warnings while on 11, but will begin to see them after moving to 17, while a site that moves at a faster pace between non-LTS Java releases will still be getting notice well in advance. (The warning during `pg_upgrade` is not conditioned on Java version, because no JVM is launched then whose version could be checked.)

More at https://github.com/tada/pljava/wiki/JEP-411