### PR TITLE
Document and enforce MappedUDT/typlen-2 exclusion

### DIFF
--- a/pljava-so/src/main/c/type/Type.c
+++ b/pljava-so/src/main/c/type/Type.c
@@ -712,6 +712,18 @@ checkTypeMappedUDT(Oid typeId, jobject typeMap, Form_pg_type typeStruct)
 	if ( NULL == typeClass )
 		return NULL;
 
+	if ( -2 == typeStruct->typlen )
+	{
+		JNI_deleteLocalRef(typeClass);
+		ereport(ERROR, (
+			errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+			errmsg(
+				"type mapping in PL/Java for %s with NUL-terminated(-2) "
+				"storage not supported",
+				format_type_be_qualified(typeId))
+		));
+	}
+
 	readMH  = pljava_Function_udtReadHandle( typeClass, NULL, true);
 	writeMH = pljava_Function_udtWriteHandle(typeClass, NULL, true);
 

--- a/src/site/markdown/develop/coercion.md
+++ b/src/site/markdown/develop/coercion.md
@@ -600,6 +600,17 @@ PostgreSQL does call through those slots, PL/Java always does a raw binary
 transfer using the `libpq` API directly (for fixed-size representations),
 `bytearecv`/`byteasend` for `varlena` representations, or
 `unknownrecv`/`unknownsend` for C string representations.
+Responsible code in `type/UDT.c` is commented with "Assumption 2".
 
 A future version could revisit this limitation, and allow PL/Java UDTs to
 specify custom binary transfer formats also.
+
+"Assumption 1" in `UDT.c` is that any PostgreSQL type declared with
+`internallength=-2` (meaning it is stored as a variable number of nonzero
+bytes terminated by a zero byte) must have a human-readable representation
+identical to its stored form, and must be converted to and from Java using
+the `INPUT` and `OUTPUT` slots. A `MappedUDT` does not have functions in
+those slots, and therefore "Assumption 1" rules out any such type as target
+of a `MappedUDT`.
+
+A future version could revisit this limitation also.


### PR DESCRIPTION
Check at runtime whether a `MappedUDT` is being applied to a PostgreSQL type declared with `typlen` of -2 (a variable-length, NUL-terminated representation), and report an error if so. Explain in the developer documentation why the implementation cannot support the use.

It already didn't work, but an explanatory error message is a better way of not working.

Addresses #370.