### PR TITLE
Bump ant to 1.10.11, suggested by dependabot

### DIFF
--- a/pljava-packaging/pom.xml
+++ b/pljava-packaging/pom.xml
@@ -167,7 +167,7 @@ function execute()
 					<dependency>
 						<groupId>org.apache.ant</groupId>
 						<artifactId>ant</artifactId>
-						<version>[1.8.3,1.10.0)</version>
+						<version>1.10.11</version>
 					</dependency>
 				</dependencies>
 				<executions>

--- a/pljava-so/src/main/c/type/Type.c
+++ b/pljava-so/src/main/c/type/Type.c
@@ -712,6 +712,18 @@ checkTypeMappedUDT(Oid typeId, jobject typeMap, Form_pg_type typeStruct)
 	if ( NULL == typeClass )
 		return NULL;
 
+	if ( -2 == typeStruct->typlen )
+	{
+		JNI_deleteLocalRef(typeClass);
+		ereport(ERROR, (
+			errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+			errmsg(
+				"type mapping in PL/Java for %s with NUL-terminated(-2) "
+				"storage not supported",
+				format_type_be_qualified(typeId))
+		));
+	}
+
 	readMH  = pljava_Function_udtReadHandle( typeClass, NULL, true);
 	writeMH = pljava_Function_udtWriteHandle(typeClass, NULL, true);
 

--- a/src/site/markdown/develop/coercion.md
+++ b/src/site/markdown/develop/coercion.md
@@ -600,6 +600,17 @@ PostgreSQL does call through those slots, PL/Java always does a raw binary
 transfer using the `libpq` API directly (for fixed-size representations),
 `bytearecv`/`byteasend` for `varlena` representations, or
 `unknownrecv`/`unknownsend` for C string representations.
+Responsible code in `type/UDT.c` is commented with "Assumption 2".
 
 A future version could revisit this limitation, and allow PL/Java UDTs to
 specify custom binary transfer formats also.
+
+"Assumption 1" in `UDT.c` is that any PostgreSQL type declared with
+`internallength=-2` (meaning it is stored as a variable number of nonzero
+bytes terminated by a zero byte) must have a human-readable representation
+identical to its stored form, and must be converted to and from Java using
+the `INPUT` and `OUTPUT` slots. A `MappedUDT` does not have functions in
+those slots, and therefore "Assumption 1" rules out any such type as target
+of a `MappedUDT`.
+
+A future version could revisit this limitation also.


### PR DESCRIPTION
Making this change manually, as dependabot would probably make it in the wrong branch.

1.10 requires Java 8, so no backpatching to REL1_5_STABLE.

This whole dependency on ant can probably be removed easily now, by moving the build.xml logic into pom.xml as a `scripted-goal`.