### PR TITLE
Bump ant to 1.10.11, suggested by dependabot

### DIFF
--- a/pljava-packaging/pom.xml
+++ b/pljava-packaging/pom.xml
@@ -167,7 +167,7 @@ function execute()
 					<dependency>
 						<groupId>org.apache.ant</groupId>
 						<artifactId>ant</artifactId>
-						<version>[1.8.3,1.10.0)</version>
+						<version>1.10.11</version>
 					</dependency>
 				</dependencies>
 				<executions>


### PR DESCRIPTION
Making this change manually, as dependabot would probably make it in the wrong branch.

1.10 requires Java 8, so no backpatching to REL1_5_STABLE.

This whole dependency on ant can probably be removed easily now, by moving the build.xml logic into pom.xml as a `scripted-goal`.