### PR TITLE
Expose predefined category codes in BaseUDT

### DIFF
--- a/pljava-api/src/main/java/org/postgresql/pljava/annotation/processing/DDRProcessor.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/annotation/processing/DDRProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2021 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2022 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -2999,6 +2999,13 @@ hunt:	for ( ExecutableElement ee : ees )
 			if ( 32 > category() || category() > 126 )
 				msg( Kind.ERROR, tclass,
 					"UDT category must be a printable ASCII character");
+
+			if ( categoryExplicit && Character.isUpperCase(category()) )
+				if ( null == PredefinedCategory.valueOf(category()) )
+					msg( Kind.WARNING, tclass,
+						"upper-case letters are reserved for PostgreSQL's " +
+						"predefined UDT categories, but '%c' is not recognized",
+						category());
 
 			recordImplicitTags();
 			recordExplicitTags(_provides, _requires);


### PR DESCRIPTION
The PostgreSQL type 'category' is a bit awkward, because there are several predefined, but other codes can be used for custom purposes. So an enumeration of the predefined ones cannot be used as the type of the 'category' annotation element, but it still can improve readability when one of the predefined categories is what's wanted.

Also add a warning from the DDR processor if an upper-case category code has been given (that's the range reserved for PostgreSQL's predefined categories) but it doesn't correspond to any value of the `PredefinedCategory` enum.