### PR TITLE
Avoid Session split-brain syndrome

### DIFF
--- a/pljava-api/src/main/java/org/postgresql/pljava/Session.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/Session.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2020 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2022 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -20,7 +20,7 @@ import java.sql.SQLException;
 /**
  * A Session brings together some useful methods and data for the current
  * database session. It provides a set of attributes (a
- * {@code String} to {@code Object} map. Until PL/Java 1.2.0, its attribute
+ * {@code String} to {@code Object} map). Until PL/Java 1.2.0, its attribute
  * store had transactional behavior (i.e., the data
  * added since the last commit would be lost on a transaction rollback, or kept
  * after a commit), but in 1.2.0 and later, it has not, and has functioned as a

--- a/pljava/src/main/java/org/postgresql/pljava/internal/Backend.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/Backend.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2021 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2022 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -73,17 +73,8 @@ public class Backend
 		}
    }
 
-	private static Session s_session;
-
 	private static final Pattern s_gucList = Pattern.compile(String.format(
 		"\\G(?:%1$s)(?<more>,\\s*+)?+", ISO_AND_PG_IDENTIFIER_CAPTURING));
-
-	public static synchronized Session getSession()
-	{
-		if(s_session == null)
-			s_session = new Session();
-		return s_session;
-	}
 
 	/**
 	 * Do an operation on a thread with serialized access to call into

--- a/pljava/src/main/java/org/postgresql/pljava/internal/Session.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/Session.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2020 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2022 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -44,6 +44,20 @@ import static org.postgresql.pljava.internal.Backend.doInPG;
  */
 public class Session implements org.postgresql.pljava.Session
 {
+	public static Session provider()
+	{
+		return Holder.INSTANCE;
+	}
+
+	private Session()
+	{
+	}
+
+	private static class Holder
+	{
+		static final Session INSTANCE = new Session();
+	}
+
 	@SuppressWarnings("removal")
 	private final TransactionalMap m_attributes = new TransactionalMap(new HashMap());
 

--- a/pljava/src/main/java/org/postgresql/pljava/internal/SubXactListener.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/SubXactListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2020 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2022 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -76,7 +76,7 @@ class SubXactListener
 	throws SQLException
 	{
 		Target target = s_refs[eventIndex];
-		Session session = Backend.getSession();
+		Session session = org.postgresql.pljava.internal.Session.provider();
 
 		// Take a snapshot. Handlers might unregister during event processing
 		for ( Invocable<SavepointListener> listener :

--- a/pljava/src/main/java/org/postgresql/pljava/internal/XactListener.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/XactListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2020 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2022 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -77,7 +77,7 @@ class XactListener
 	{
 		Checked.BiConsumer<TransactionListener,Session,SQLException> target =
 			s_refs.get(eventIndex);
-		Session session = Backend.getSession();
+		Session session = Session.provider();
 
 		// Take a snapshot. Handlers might unregister during event processing
 		for ( Invocable<TransactionListener> listener :


### PR DESCRIPTION
0772030 inadvertently created a chance for the user code to retrieve one `Session` instance from `SessionManager.current()` while implementation code gets a different one from `Backend.getSession()`.

In passing, fix a typo in the Session API interface's javadocs.

Addresses #388.