### PR TITLE
Fix a thinko in context classloader management

### DIFF
--- a/pljava-so/src/main/c/Function.c
+++ b/pljava-so/src/main/c/Function.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2021 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2022 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -493,13 +493,8 @@ jboolean pljava_Function_vpcInvoke(
 	 * static area parameter counts; this reservation will therefore not see a
 	 * need to push a frame. If one was pushed for the user function itself, it
 	 * remains on top, to be popped when the Invocation is.
-	 *
-	 * It is better to avoid calling installContextLoader a second time under
-	 * the same Invocation.
 	 */
 	reserveParameterFrame(1, 2);
-	if ( 0 != call_cntr )
-		installContextLoader(self);
 
 	JNI_setObjectArrayElement(s_referenceParameters, 0, rowcollect);
 	s_primitiveParameters[0].j = call_cntr;

--- a/pljava-so/src/main/c/type/Type.c
+++ b/pljava-so/src/main/c/type/Type.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2021 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2022 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -168,11 +168,9 @@ static void _closeIteration(CallContextData* ctxData)
 	 * Why pass 1 as the call_cntr? We won't always have the actual call_cntr
 	 * value at _closeIteration time (the _endOfSetCB isn't passed it), and the
 	 * Java interfaces being used don't need it (close() isn't passed a row
-	 * number), but vpcInvoke needs a way to know when to skip its call to
-	 * installContextLoader (which shouldn't happen on its very first call,
-	 * the one with call_cntr of zero, which always happens as part of the first
-	 * invocation of the SRF so the work has already been done). So passing any
-	 * fixed value here that isn't zero is enough to distinguish the cases.
+	 * number), but at least 1 is different from zero, in case vpcInvoke has
+	 * a reason to distinguish the first call (in the same invocation as the
+	 * overall setup) from subsequent ones.
 	 */
 	pljava_Function_vpcInvoke(
 		ctxData->fn, ctxData->rowProducer, NULL, 1, JNI_TRUE, &dummy);


### PR DESCRIPTION
The clever arrangements in `Function_vpcInvoke` to avoid duplicating the context classloader assignment on the first call were too clever by half, because every call to `vpcInvoke` will have come through `Function_invoke`, which already assigned it, and therefore the duplicate assignment was still happening on every call but the first.

Addresses #389.