### PR TITLE
Fix mapping errors to java.time dates and times

### DIFF
--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/JDBC42_21.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/JDBC42_21.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2018-2022 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -36,9 +36,11 @@ import org.postgresql.pljava.example.annotation.ConditionalDDR; // for javadoc
 	"  END" +
 	" FROM" +
 	"  (VALUES" +
+	"   (date 'infinity')," +
 	"   (date '2017-08-21')," +
 	"   (date '1970-03-07')," +
-	"   (date '1919-05-29')" +
+	"   (date '1919-05-29')," +
+	"   (date '-infinity')" +
 	"  ) AS p(orig)," +
 	"  javatest.roundtrip(p, 'java.time.LocalDate')" +
 	"  AS r(roundtripped date)",
@@ -49,7 +51,11 @@ import org.postgresql.pljava.example.annotation.ConditionalDDR; // for javadoc
 	"  ELSE javatest.logmessage('WARNING', 'java.time.LocalTime fails')" +
 	"  END" +
 	" FROM" +
-	"  (SELECT current_time::time) AS p(orig)," +
+	"  (VALUES" +
+	"   (current_time::time)," +
+	"   ('00:00:00')," +
+	"   ('24:00:00')" +
+	"  ) AS p(orig)," +
 	"  javatest.roundtrip(p, 'java.time.LocalTime')" +
 	"  AS r(roundtripped time)",
 
@@ -59,7 +65,11 @@ import org.postgresql.pljava.example.annotation.ConditionalDDR; // for javadoc
 	"  ELSE javatest.logmessage('WARNING', 'java.time.OffsetTime fails')" +
 	"  END" +
 	" FROM" +
-	"  (SELECT current_time::timetz) AS p(orig)," +
+	"  (VALUES" +
+	"   (current_time::timetz)," +
+	"   ('00:00:00')," +
+	"   ('24:00:00')" +
+	"  ) AS p(orig)," +
 	"  javatest.roundtrip(p, 'java.time.OffsetTime')" +
 	"  AS r(roundtripped timetz)",
 

--- a/pljava-so/src/main/c/type/Date.c
+++ b/pljava-so/src/main/c/type/Date.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2018 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2022 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -57,7 +57,7 @@ static bool _LocalDate_canReplaceType(Type self, Type other)
 static jvalue _LocalDate_coerceDatum(Type self, Datum arg)
 {
 	DateADT pgDate = DatumGetDateADT(arg);
-	jlong days = (jlong)(pgDate + EPOCH_DIFF);
+	jlong days = (jlong)pgDate + EPOCH_DIFF;
 	jvalue result;
 	result.l = JNI_callStaticObjectMethod(
 		s_LocalDate_class, s_LocalDate_ofEpochDay, days);

--- a/pljava-so/src/main/c/type/Time.c
+++ b/pljava-so/src/main/c/type/Time.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2019 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2022 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -83,6 +83,8 @@ static jvalue _LocalTime_coerceDatum(Type self, Datum arg)
 #endif
 		1000 * DatumGetInt64(arg);
 	jvalue result;
+	if ( 1000L * USECS_PER_DAY == nanos )
+		-- nanos;
 	result.l = JNI_callStaticObjectMethod(
 		s_LocalTime_class, s_LocalTime_ofNanoOfDay, nanos);
 	return result;
@@ -95,7 +97,7 @@ static Datum _LocalTime_coerceObject(Type self, jobject time)
 #if PG_VERSION_NUM < 100000
 		(!integerDateTimes) ? Float8GetDatum(((double)nanos) / 1e9) :
 #endif
-		Int64GetDatum(nanos / 1000);
+		Int64GetDatum((nanos + 1) / 1000);
 }
 
 static Type _LocalTime_obtain(Oid typeId)

--- a/src/site/markdown/use/datetime.md
+++ b/src/site/markdown/use/datetime.md
@@ -73,6 +73,11 @@ zone, which can vary from session to session. Any code developed for PL/Java
 and Java 8 or newer is strongly encouraged to use these types for date/time
 manipulations, for their much better fit to the PostgreSQL types.
 
+PostgreSQL accepts 24:00:00.000000 as a valid time, while a day for
+`LocalTime` or `OffsetTime` maxes out at the preceding nanosecond. That is
+still a distinguishable value (as the PostgreSQL resolution is only to
+microseconds), so the PostgreSQL 24 value is bidirectionally mapped to that.
+
 ### Mapping of time and timestamp with time zone
 
 When a `time with time zone` is mapped to a `java.time.OffsetTime`, the Java
@@ -103,16 +108,12 @@ Java values to compare others against. It must compare with `equals()`; it
 cannot assume that the mapping will produce the very same Java objects
 repeatedly, but only objects with equal values.
 
-When timestamps are mapped to the `java.time` classes, the mapping will have
+When dates and timestamps are mapped to the `java.time` classes,
+the mapping will have
 the useful property that `-infinity` really is earlier than other
 PostgreSQL-representable values, and `infinity` really is later. That does not
 hold under the old `java.sql.Timestamp` mapping, where both values will be
 distant from the present but not further specified.
-
-The convenient relation does not hold for dates at all, under the `java.sql` or
-`java.time` mappings; `infinity` and `-infinity` just have to be treated as two
-special values. They come out as two consecutive days in the late Miocene,
-as it happens, in the third week of June.
 
 #### Infinite timestamps without `integer_datetimes`
 


### PR DESCRIPTION
The (documented, but not necessary) limitation in the mapping of `date` infinity/-infinity to java.time.LocalDate was an avoidable integer overflow. It only affected dates within 30 years of `infinity` or `-infinity`.

Addresses #390.

In passing, solve the problem that the valid PostgreSQL `time` value 24:00:00.000000 is not valid to `java.time.LocalTime` or `OffsetTime`. The Java classes will accept the preceding nanosecond, which is still distinguishable from any other mapped PostgreSQL value (as those have only microsecond resolution), so make that the mapping of 24:00:00.