### PR TITLE
Compute supported source version in DDRProcessor

### DIFF
--- a/pljava-api/src/main/java/org/postgresql/pljava/annotation/processing/DDRProcessor.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/annotation/processing/DDRProcessor.java
@@ -172,7 +172,7 @@ public class DDRProcessor extends AbstractProcessor
 		 * Update latest_tested to be the latest Java release on which this
 		 * annotation processor has been tested without problems.
 		 */
-		int latest_tested = 17;
+		int latest_tested = 19;
 		int ordinal_9 = SourceVersion.RELEASE_9.ordinal();
 		int ordinal_latest = latest_tested - 9 + ordinal_9;
 

--- a/pljava-api/src/main/java/org/postgresql/pljava/annotation/processing/DDRProcessor.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/annotation/processing/DDRProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2023 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -9,6 +9,7 @@
  * Contributors:
  *   Tada AB
  *   Purdue University
+ *   Chapman Flack
  */
 package org.postgresql.pljava.annotation.processing;
 

--- a/pljava-api/src/main/java/org/postgresql/pljava/annotation/processing/DDRProcessor.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/annotation/processing/DDRProcessor.java
@@ -158,10 +158,31 @@ import static org.postgresql.pljava.sqlgen.Lexicals.Identifier.Simple.pgFold;
   "ddr.implementor",     // implementor when not annotated, default "PostgreSQL"
   "ddr.output"           // name of ddr file to write
 })
-@SupportedSourceVersion(SourceVersion.RELEASE_9)
 public class DDRProcessor extends AbstractProcessor
 {
 	private DDRProcessorImpl impl;
+
+	@Override
+	public SourceVersion getSupportedSourceVersion()
+	{
+		/*
+		 * Because this must compile on Java versions back to 9, it must not
+		 * mention by name any SourceVersion constant later than RELEASE_9.
+		 *
+		 * Update latest_tested to be the latest Java release on which this
+		 * annotation processor has been tested without problems.
+		 */
+		int latest_tested = 17;
+		int ordinal_9 = SourceVersion.RELEASE_9.ordinal();
+		int ordinal_latest = latest_tested - 9 + ordinal_9;
+
+		SourceVersion latestSupported = SourceVersion.latestSupported();
+
+		if ( latestSupported.ordinal() <= ordinal_latest )
+			return latestSupported;
+
+		return SourceVersion.values()[ordinal_latest];
+	}
 	
 	@Override
 	public void init( ProcessingEnvironment processingEnv)


### PR DESCRIPTION
Because PL/Java must be compilable on any Java back to release 9, the `DDRProcessor` cannot refer by name to any `SourceVersion` enum constant later than `RELEASE_9`. It also, arguably, _should_ not, because its development and testing rely on the `javax.lang.model` API as of release 9.

Happily, in practice, later Java releases do not often break the `DDRProcessor` code, so user Java code for releases later than 9 can be compiled with no difficulty, other than a compiler warning about the processor's source version being pegged at 9. But the warning is an obstacle if the user code is being compiled with a fail-on-warning policy, as in issue #403.

This patch adopts a compromise position, and keeps track of the latest source version for which the annotation processor at least has been seen to pass the CI tests (fully understanding that such testing is no substitute for thoroughly auditing any release-to-release changes in the `javax.lang.model` APIs and what impact they could have on the processor!). It will compute its "declared" supported source version to be the earlier of `SourceVersion.latestSupported()` and that latest tested version.

As a result, it should eliminate the compiler warning when running on any Java version in that range. The warning will reappear when running a compile on a later Java version, and it should be easy to alleviate that with a PL/Java release that bumps the `latest_tested` version.

Merely passing the CI tests as normally run isn't enough, because the project is built with a `--release 9` option. Before actually bumping `latest_tested`, a test build (at least of the `pljava-examples` project) should be done on the Java release in question and without the limiting `--release` option.