### PR TITLE
Fix the problem of invalid timer in _destroyJavaVM

### DIFF
--- a/pljava-so/src/main/c/Backend.c
+++ b/pljava-so/src/main/c/Backend.c
@@ -1406,6 +1406,7 @@ static void _destroyJavaVM(int status, Datum dummy)
 
 #if PG_VERSION_NUM >= 90300
 		tid = RegisterTimeout(USER_TIMEOUT, terminationTimeoutHandler);
+		enable_timeout_after(tid, 5000);
 #else
 		saveSigAlrm = pqsignal(SIGALRM, terminationTimeoutHandler);
 		enable_sig_alarm(5000, false);


### PR DESCRIPTION
After registering the timer with RegisterTimeout(),
call enable_timeout_after() to make the timer take effect