### PR TITLE
custom String type refactor to StringPL (fixes broken MVSC windows builds)

### DIFF
--- a/pljava-so/src/main/c/Backend.c
+++ b/pljava-so/src/main/c/Backend.c
@@ -663,6 +663,7 @@ static void initsequencer(enum initstage is, bool tolerant)
 		JVMOptList_add(&optList, "-Xrs", 0, true);
 #endif
 		// VISION NEEDED OPENS 
+		JVMOptList_add(&optList, "--enable-preview", 0, true);  // JDK 19 virtual threads
 		JVMOptList_add(&optList, "--add-opens=java.base/java.nio=ALL-UNNAMED", 0, true);
 		JVMOptList_add(&optList, "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED", 0, true);
 		// DO NOT CREATE hs_err_pid in PGDATA directory ?

--- a/pljava-so/src/main/c/Backend.c
+++ b/pljava-so/src/main/c/Backend.c
@@ -211,6 +211,7 @@ static char const visualVMprefix[] = "-Dvisualvm.display.name=";
 static char const moduleMainPrefix[] = "-Djdk.module.main=";
 static char const policyUrlsGUC[] = "pljava.policy_urls";
 
+
 /*
  * In a background worker, _PG_init may be called very early, before much of
  * the state needed during PL/Java initialization has even been set up. When
@@ -662,14 +663,7 @@ static void initsequencer(enum initstage is, bool tolerant)
 #ifndef GCJ
 		JVMOptList_add(&optList, "-Xrs", 0, true);
 #endif
-		// VISION NEEDED OPENS 
-		JVMOptList_add(&optList, "--enable-preview", 0, true);  // JDK 19 virtual threads
-		JVMOptList_add(&optList, "--add-opens=java.base/java.nio=ALL-UNNAMED", 0, true);
-		JVMOptList_add(&optList, "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED", 0, true);
-		// DO NOT CREATE hs_err_pid in PGDATA directory ?
-		//JVMOptList_add(&optList, "-XX:+SuppressFatalErrorMessage", 0, true);
 		//-------------------------------------------------------------------------------
-
 		effectiveModulePath = getModulePath("--module-path=");
 		if(effectiveModulePath != 0)
 		{
@@ -1521,24 +1515,10 @@ static void addUserJVMOptions(JVMOptList* optList)
 {
 	const char* cp = vmoptions;
 	//--------------------------------------------
-	// VisionR customization : use newline separator for options, because of problems parsing arguments with space (directory paths with -D<key>=<value>
-	//--------------------------------------------
-	const char* tcp = cp;
-	if (cp != NULL)  {
-		char c;
-		for (;;) {
-			c = *tcp++;
-			if (c == 0) {
-				tcp=NULL;
-				break;
-			}
-			if (c == '\n')
-				break;
-		}
-	}
-	//--------------------------------------------
-	// HAS NEWLINE IN VMOPTIONS ?
-	if(tcp != NULL) {
+	// use newline separator for options if first char in options is newline
+	//--------------------------------------------*/
+	if(cp != NULL && *cp == '\n')
+	{
 		StringInfoData buf;
 		char quote = 0;
 		char c;
@@ -1568,7 +1548,7 @@ static void addUserJVMOptions(JVMOptList* optList)
 		pfree(buf.data);
 	} else
 	//--------------------------------------------
-	// ORIGINAL CODE
+	// original optimistic parsing
 	//--------------------------------------------*/
 	if(cp != NULL)
 	{ 

--- a/pljava-so/src/main/c/Invocation.c
+++ b/pljava-so/src/main/c/Invocation.c
@@ -95,7 +95,11 @@ void Invocation_assertConnect(void)
 	int rslt;
 	if(!currentInvocation->hasConnected)
 	{
-		rslt = SPI_connect();
+		//rslt = SPI_connect();
+		// VISIONR requires SPI_commit, SPI_rollback
+		// https://www.postgresql.org/docs/current/spi-spi-connect.html
+		rslt = SPI_connect_ext(SPI_OPT_NONATOMIC);
+
 		if ( SPI_OK_CONNECT != rslt )
 			elog(ERROR, "SPI_connect returned %s",
 						SPI_result_code_string(rslt));

--- a/pljava-so/src/main/c/SPI.c
+++ b/pljava-so/src/main/c/SPI.c
@@ -56,19 +56,19 @@ void SPI_initialize(void)
 		"()V",
 		Java_org_postgresql_pljava_internal_SPI__1freeTupTable
 		},
-
-{		// require by VisionR
+		{		// required by VisionR
 		"_commit",
 		"()V",
 		Java_org_postgresql_pljava_internal_SPI__1commit
 		},
-{		// require by VisionR
+		{		// required by VisionR
 		"_rollback",
 		"()V",
 		Java_org_postgresql_pljava_internal_SPI__1rollback
 		},
-
-
+		{		// required by VisionR
+		"_checkForInterrupt",
+		"()V"
 		{ 0, 0, 0 }};
 
 	PgObject_registerNatives("org/postgresql/pljava/internal/SPI", methods);
@@ -261,6 +261,25 @@ Java_org_postgresql_pljava_internal_SPI__1rollback(JNIEnv* env, jclass cls)
 	PG_CATCH();
 	{
 		Exception_throw_ERROR("SPI_rollback");
+	}
+	PG_END_TRY();
+	STACK_BASE_POP()
+	END_NATIVE
+}
+
+JNIEXPORT void JNICALL
+Java_org_postgresql_pljava_internal_SPI__1checkForInterrupt(JNIEnv* env, jclass cls)
+{
+	BEGIN_NATIVE
+	STACK_BASE_VARS
+	STACK_BASE_PUSH(env)
+	PG_TRY();
+	{
+		CHECK_FOR_INTERRUPTS();
+	}
+	PG_CATCH();
+	{
+		Exception_throw_ERROR("SPI_interrupt");
 	}
 	PG_END_TRY();
 	STACK_BASE_POP()

--- a/pljava-so/src/main/c/SPI.c
+++ b/pljava-so/src/main/c/SPI.c
@@ -68,7 +68,9 @@ void SPI_initialize(void)
 		},
 		{		// required by VisionR
 		"_checkForInterrupt",
-		"()V"
+		"()V",
+		Java_org_postgresql_pljava_internal_SPI__1checkForInterrupt
+		},
 		{ 0, 0, 0 }};
 
 	PgObject_registerNatives("org/postgresql/pljava/internal/SPI", methods);

--- a/pljava-so/src/main/c/SPI.c
+++ b/pljava-so/src/main/c/SPI.c
@@ -56,6 +56,19 @@ void SPI_initialize(void)
 		"()V",
 		Java_org_postgresql_pljava_internal_SPI__1freeTupTable
 		},
+
+{		// require by VisionR
+		"_commit",
+		"()V",
+		Java_org_postgresql_pljava_internal_SPI__1commit
+		},
+{		// require by VisionR
+		"_rollback",
+		"()V",
+		Java_org_postgresql_pljava_internal_SPI__1rollback
+		},
+
+
 		{ 0, 0, 0 }};
 
 	PgObject_registerNatives("org/postgresql/pljava/internal/SPI", methods);
@@ -198,4 +211,58 @@ Java_org_postgresql_pljava_internal_SPI__1freeTupTable(JNIEnv* env, jclass cls)
 		SPI_tuptable = 0;
 		END_NATIVE
 	}
+}
+
+
+/*
+ * Class:     org_postgresql_pljava_internal_SPI
+ * Method:    _commit
+ * Signature: ()V;
+ */
+JNIEXPORT void JNICALL
+Java_org_postgresql_pljava_internal_SPI__1commit(JNIEnv* env, jclass cls)
+{
+	BEGIN_NATIVE
+	STACK_BASE_VARS
+	STACK_BASE_PUSH(env)
+	PG_TRY();
+	{
+		Invocation_assertConnect();
+		SPI_commit_and_chain();
+		//SPI_commit();
+	}
+	PG_CATCH();
+	{
+		Exception_throw_ERROR("SPI_commit");
+	}
+	PG_END_TRY();
+	STACK_BASE_POP()
+	END_NATIVE
+
+}
+
+/*
+ * Class:     org_postgresql_pljava_internal_SPI
+ * Method:    _rollback
+ * Signature: ()V;
+ */
+JNIEXPORT void JNICALL
+Java_org_postgresql_pljava_internal_SPI__1rollback(JNIEnv* env, jclass cls)
+{
+	BEGIN_NATIVE
+	STACK_BASE_VARS
+	STACK_BASE_PUSH(env)
+	PG_TRY();
+	{
+		Invocation_assertConnect();
+		//SPI_rollback();
+		SPI_rollback_and_chain();
+	}
+	PG_CATCH();
+	{
+		Exception_throw_ERROR("SPI_rollback");
+	}
+	PG_END_TRY();
+	STACK_BASE_POP()
+	END_NATIVE
 }

--- a/pljava-so/src/main/c/type/BigDecimal.c
+++ b/pljava-so/src/main/c/type/BigDecimal.c
@@ -38,9 +38,9 @@ static Datum _BigDecimal_coerceObject(Type self, jobject value)
 	return ret;
 }
 
-static Type BigDecimal_obtain(Oid typeId)
+static StringPL BigDecimal_obtain(Oid typeId)
 {
-	return (Type)StringClass_obtain(s_BigDecimalClass, typeId);
+	return /*(Type)*/StringClass_obtain(s_BigDecimalClass, typeId);
 }
 
 /* Make this datatype available to the postgres system.

--- a/pljava-so/src/main/c/type/Oid.c
+++ b/pljava-so/src/main/c/type/Oid.c
@@ -112,8 +112,11 @@ Oid Oid_forSqlType(int sqlType)
 		case java_sql_Types_DATALINK:
 			typeId = TEXTOID;
 			break;
+		case java_sql_Types_OTHER:	/* visionr needs other for unknown type nulls */
+			typeId = UNKNOWNOID;
+			break;
 		case java_sql_Types_NULL:
-		case java_sql_Types_OTHER:
+		//case java_sql_Types_OTHER:
 		case java_sql_Types_JAVA_OBJECT:
 		case java_sql_Types_DISTINCT:
 		case java_sql_Types_STRUCT:

--- a/pljava-so/src/main/c/type/String.c
+++ b/pljava-so/src/main/c/type/String.c
@@ -59,9 +59,9 @@ jvalue _String_coerceDatum(Type self, Datum arg)
 {
 	jvalue result;
 	char* tmp = DatumGetCString(FunctionCall3(
-					&((String)self)->textOutput,
+					&((StringPL)self)->textOutput,
 					arg,
-					ObjectIdGetDatum(((String)self)->elementType),
+					ObjectIdGetDatum(((StringPL)self)->elementType),
 					Int32GetDatum(-1)));
 	result.l = String_createJavaStringFromNTS(tmp);
 	pfree(tmp);
@@ -83,19 +83,19 @@ Datum _String_coerceObject(Type self, jobject jstr)
 	JNI_deleteLocalRef(jstr);
 
 	ret = FunctionCall3(
-					&((String)self)->textInput,
+					&((StringPL)self)->textInput,
 					CStringGetDatum(tmp),
-					ObjectIdGetDatum(((String)self)->elementType),
+					ObjectIdGetDatum(((StringPL)self)->elementType),
 					Int32GetDatum(-1));
 	pfree(tmp);
 	return ret;
 }
 
-static String String_create(TypeClass cls, Oid typeId)
+static StringPL String_create(TypeClass cls, Oid typeId)
 {
 	HeapTuple    typeTup = PgObject_getValidTuple(TYPEOID, typeId, "type");
 	Form_pg_type pgType  = (Form_pg_type)GETSTRUCT(typeTup);
-	String self = (String)TypeClass_allocInstance(cls, typeId);
+	StringPL self = (StringPL)TypeClass_allocInstance(cls, typeId);
 	MemoryContext ctx = GetMemoryChunkContext(self);
 	fmgr_info_cxt(pgType->typoutput, &self->textOutput, ctx);
 	fmgr_info_cxt(pgType->typinput,  &self->textInput,  ctx);
@@ -109,7 +109,7 @@ Type String_obtain(Oid typeId)
 	return (Type)StringClass_obtain(s_StringClass, typeId);
 }
 
-String StringClass_obtain(TypeClass self, Oid typeId)
+StringPL StringClass_obtain(TypeClass self, Oid typeId)
 {
 	return String_create(self, typeId);
 }
@@ -366,7 +366,7 @@ void String_initialize(void)
 	s_Object_toString = PgObject_getJavaMethod(s_Object_class, "toString", "()Ljava/lang/String;");
 	s_String_class = (jclass)JNI_newGlobalRef(PgObject_getJavaClass("java/lang/String"));
 
-	s_StringClass = TypeClass_alloc2("type.String", sizeof(struct TypeClass_), sizeof(struct String_));
+	s_StringClass = TypeClass_alloc2("type.StringPL", sizeof(struct TypeClass_), sizeof(struct String_));
 	s_StringClass->JNISignature   = "Ljava/lang/String;";
 	s_StringClass->javaTypeName   = "java.lang.String";
 	s_StringClass->canReplaceType = _String_canReplaceType;

--- a/pljava-so/src/main/include/pljava/type/String.h
+++ b/pljava-so/src/main/include/pljava/type/String.h
@@ -6,6 +6,7 @@
  *
  * @author Thomas Hallgren
  */
+
 #ifndef __pljava_type_String_h
 #define __pljava_type_String_h
 
@@ -29,7 +30,7 @@ extern "C" {
 extern jclass s_Object_class;
 extern jclass s_String_class;
 struct String_;
-typedef struct String_* String;
+typedef struct String_ *StringPL;
 
 /*
  * Create a Java String object from a null terminated string. Conversion is
@@ -73,7 +74,7 @@ extern text* String_createText(jstring javaString);
 
 extern Type String_obtain(Oid typeId);
 
-extern String StringClass_obtain(TypeClass self, Oid typeId);
+extern StringPL StringClass_obtain(TypeClass self, Oid typeId);
 
 #ifdef __cplusplus
 }

--- a/pljava/src/main/java/org/postgresql/pljava/internal/SPI.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/SPI.java
@@ -54,7 +54,7 @@ public class SPI
 	public static final int OK_REL_UNREGISTER   = 16;
 	public static final int OK_TD_REGISTER      = 17;
 
-	/**
+		/**
 	 * Execute a command using the internal <code>SPI_exec</code> function.
 	 * @param command The command to execute.
 	 * @param rowCount The maximum number of tuples to create. A value
@@ -67,6 +67,14 @@ public class SPI
 	private static int exec(String command, int rowCount)
 	{
 		return doInPG(() -> _exec(command, rowCount));
+	}
+
+	public static void commit() {
+		doInPG(() -> _commit());
+	}
+
+	public static void rollback() {
+		doInPG(() -> _rollback());
 	}
 
 	public static void freeTupTable()
@@ -156,4 +164,10 @@ public class SPI
 	private native static int _getResult();
 	private native static void _freeTupTable();
 	private native static TupleTable _getTupTable(TupleDesc known);
+
+
+	// required by VisionR
+	private native static void _commit();
+	// required by VisionR
+	private native static void _rollback();
 }

--- a/pljava/src/main/java/org/postgresql/pljava/internal/SPI.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/SPI.java
@@ -77,6 +77,11 @@ public class SPI
 		doInPG(() -> _rollback());
 	}
 
+	public static void checkForInterrupt() {
+		doInPG(() -> _checkForInterrupt());
+	}
+
+
 	public static void freeTupTable()
 	{
 		doInPG(SPI::_freeTupTable);
@@ -170,4 +175,6 @@ public class SPI
 	private native static void _commit();
 	// required by VisionR
 	private native static void _rollback();
+	// required by VisionR 
+	private native static void _checkForInterrupt();
 }

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/Invocation.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/Invocation.java
@@ -102,6 +102,14 @@ public class Invocation
 		}
 	}
 
+	public static void setSPIConnectionNonAtomic() {
+		doInPG(() ->
+		{
+			_setSPIConnectionNonAtomic();	
+			return null;
+		});
+	}
+
 	/**
 	 * @return The current invocation
 	 */
@@ -164,4 +172,9 @@ public class Invocation
 	 * Clears the error condition set by elog(ERROR)
 	 */
 	private native static void  _clearErrorCondition();
+
+	/* set connection mode to non atomic 
+	 * https://www.postgresql.org/docs/current/spi-spi-connect.html */
+	private static native void _setSPIConnectionNonAtomic();
+
 }

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/SPIConnection.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/SPIConnection.java
@@ -194,7 +194,9 @@ public class SPIConnection implements Connection
 	public void commit()
 	throws SQLException
 	{
-		throw new UnsupportedFeatureException("Connection.commit");
+		//throw new UnsupportedFeatureException("Connection.commit");
+		// required by VisionR
+		SPI.commit();
 	}
 
 	/**
@@ -205,7 +207,9 @@ public class SPIConnection implements Connection
 	public void rollback()
 	throws SQLException
 	{
-		throw new UnsupportedFeatureException("Connection.rollback");
+		// throw new UnsupportedFeatureException("Connection.rollback");
+		// required by VisionR
+		SPI.rollback();
 	}
 
 	/**

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/SPIConnection.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/SPIConnection.java
@@ -52,7 +52,7 @@ import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 import org.postgresql.pljava.internal.Oid;
 import org.postgresql.pljava.internal.PgSavepoint;
-
+import org.postgresql.pljava.internal.SPI;
 /**
  * Provides access to the current connection (session) the Java stored
  * procedure is running in.  It is returned from the driver manager

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/SPIConnection.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/SPIConnection.java
@@ -1077,6 +1077,9 @@ public class SPIConnection implements Connection
 	public boolean isValid( int timeout )
 	throws SQLException
 	{
+		// VisionR fix : check for interrupt
+		SPI.checkForInterrupt();
+
 		return true; // The connection is always alive and
 			     // ready, right?
 	}

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/TypeOid.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/TypeOid.java
@@ -14,6 +14,8 @@ package org.postgresql.pljava.jdbc;
 
 import org.postgresql.pljava.internal.Oid;
 
+// https://github.com/postgres/postgres/blob/master/src/include/catalog/pg_type.dat
+	
 /**
  * Provides constants for well-known backend OIDs for the types we commonly
  * use.
@@ -42,7 +44,8 @@ public class TypeOid
 	public static final int VARCHAROID     = 1043;
 	public static final int OIDOID         = 26;
 	public static final int BPCHAROID      = 1042;
-
+	public static final int UNKNOWNOID 	   = 705;
+	
 	public static final Oid INVALID     = new Oid(InvalidOid);
 	public static final Oid INT2        = new Oid(INT2OID);
 	public static final Oid INT4        = new Oid(INT4OID);
@@ -60,6 +63,8 @@ public class TypeOid
 	public static final Oid VARCHAR     = new Oid(VARCHAROID);
 	public static final Oid OID         = new Oid(OIDOID);
 	public static final Oid BPCHAR      = new Oid(BPCHAROID);
+	public static final Oid UNKNOWN 	= new Oid(UNKNOWNOID);
+
 
 	/*
 	 * Added in 2019. The numeric constant will be used, but no need is foreseen


### PR DESCRIPTION
it seems that the String literal is defined in windows wit visual studio c compiler. I had to rename the struct from String to StringPL to get the build working