### PR TITLE
Fix struct name collision caused by upstream PostgreSQL change

### DIFF
--- a/pljava-so/src/main/c/type/String.c
+++ b/pljava-so/src/main/c/type/String.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2021 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2023 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -9,6 +9,7 @@
  * Contributors:
  *   Tada AB - Thomas Hallgren
  *   Chapman Flack
+ *   Francisco Miguel Biete Banon
  */
 #include "pljava/type/String_priv.h"
 #include "pljava/HashMap.h"
@@ -59,9 +60,9 @@ jvalue _String_coerceDatum(Type self, Datum arg)
 {
 	jvalue result;
 	char* tmp = DatumGetCString(FunctionCall3(
-					&((String)self)->textOutput,
+					&((PLJString)self)->textOutput,
 					arg,
-					ObjectIdGetDatum(((String)self)->elementType),
+					ObjectIdGetDatum(((PLJString)self)->elementType),
 					Int32GetDatum(-1)));
 	result.l = String_createJavaStringFromNTS(tmp);
 	pfree(tmp);
@@ -83,19 +84,19 @@ Datum _String_coerceObject(Type self, jobject jstr)
 	JNI_deleteLocalRef(jstr);
 
 	ret = FunctionCall3(
-					&((String)self)->textInput,
+					&((PLJString)self)->textInput,
 					CStringGetDatum(tmp),
-					ObjectIdGetDatum(((String)self)->elementType),
+					ObjectIdGetDatum(((PLJString)self)->elementType),
 					Int32GetDatum(-1));
 	pfree(tmp);
 	return ret;
 }
 
-static String String_create(TypeClass cls, Oid typeId)
+static PLJString String_create(TypeClass cls, Oid typeId)
 {
 	HeapTuple    typeTup = PgObject_getValidTuple(TYPEOID, typeId, "type");
 	Form_pg_type pgType  = (Form_pg_type)GETSTRUCT(typeTup);
-	String self = (String)TypeClass_allocInstance(cls, typeId);
+	PLJString self = (PLJString)TypeClass_allocInstance(cls, typeId);
 	MemoryContext ctx = GetMemoryChunkContext(self);
 	fmgr_info_cxt(pgType->typoutput, &self->textOutput, ctx);
 	fmgr_info_cxt(pgType->typinput,  &self->textInput,  ctx);
@@ -109,7 +110,7 @@ Type String_obtain(Oid typeId)
 	return (Type)StringClass_obtain(s_StringClass, typeId);
 }
 
-String StringClass_obtain(TypeClass self, Oid typeId)
+PLJString StringClass_obtain(TypeClass self, Oid typeId)
 {
 	return String_create(self, typeId);
 }
@@ -126,7 +127,7 @@ jstring String_createJavaString(text* t)
 		Size srcLen = VARSIZE(t) - VARHDRSZ;
 		if(srcLen == 0)
 			return s_the_empty_string;
-	
+
 		if ( s_two_step_conversion )
 		{
 			utf8 = (char*)pg_do_encoding_conversion((unsigned char*)src,

--- a/pljava-so/src/main/include/pljava/type/String.h
+++ b/pljava-so/src/main/include/pljava/type/String.h
@@ -1,10 +1,15 @@
 /*
- * Copyright (c) 2004, 2005, 2006 TADA AB - Taby Sweden
- * Distributed under the terms shown in the file COPYRIGHT
- * found in the root folder of this project or at
- * http://eng.tada.se/osprojects/COPYRIGHT.html
+ * Copyright (c) 2004-2023 Tada AB and other contributors, as listed below.
  *
- * @author Thomas Hallgren
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Tada AB - Thomas Hallgren
+ *   Chapman Flack
+ *   Francisco Miguel Biete Banon
  */
 #ifndef __pljava_type_String_h
 #define __pljava_type_String_h
@@ -19,17 +24,21 @@ extern "C" {
  * The String class extends the Type and adds the members necessary to
  * perform standard Postgres textin/textout conversion. An instance of this
  * class will be used for all types that are not explicitly mapped.
- * 
+ *
  * The class also has some convenience routings for Java String manipulation.
- * 
+ *
  * @author Thomas Hallgren
+ *
+ * Since commit 639a86e in PostgreSQL upstream, this struct can no longer
+ * have the name String, which is why it is now PLJString but in files still
+ * named String.[hc].
  *
  **************************************************************************/
 
 extern jclass s_Object_class;
 extern jclass s_String_class;
 struct String_;
-typedef struct String_* String;
+typedef struct String_* PLJString;
 
 /*
  * Create a Java String object from a null terminated string. Conversion is
@@ -73,7 +82,7 @@ extern text* String_createText(jstring javaString);
 
 extern Type String_obtain(Oid typeId);
 
-extern String StringClass_obtain(TypeClass self, Oid typeId);
+extern PLJString StringClass_obtain(TypeClass self, Oid typeId);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Addresses #410. In postgres/postgres@639a86e, the `Value` flavor of `Node` struct was retired, and `Integer`, `Float`, `String`, and `BitString` became `Node` structs in their own right; the name `String` collides with the one in PL/Java's `String.c`. An easy solution is to change the name of the latter.

Thanks to Francisco Miguel Biete Banon; tested by Christoph Berg, tayalrun1, Frank Blanning, aadrian, Yuril Rashkovskii.

The upstream change made changes in `nodeToString` in `outfuncs.c`, but only as needed to preserve the original `pg_node_tree` syntax, so no attention to `PgNodeTreeAsXML` is needed. (It would be good for that to have a regression test, on general principles.)