### PR TITLE
CI chore: fetch key for PGDG apt repository

### DIFF
--- a/.github/workflows/ci-runnerpg.yml
+++ b/.github/workflows/ci-runnerpg.yml
@@ -61,7 +61,7 @@ jobs:
       run: |
         curl -s -S https://www.postgresql.org/media/keys/ACCC4CF8.asc |
         gpg --dearmor |
-	sudo dd of=/etc/apt/trusted.gpg.d/apt.postgresql.org.gpg
+        sudo dd of=/etc/apt/trusted.gpg.d/apt.postgresql.org.gpg
         echo  \
           deb \
           http://apt.postgresql.org/pub/repos/apt \

--- a/.github/workflows/ci-runnerpg.yml
+++ b/.github/workflows/ci-runnerpg.yml
@@ -28,7 +28,7 @@ jobs:
 #           cc: msvc
 #         - os: windows-latest
 #           cc: mingw
-        java: [9, 11, 12, 13, 14, 15]
+        java: [9, 11, 12, 17, 18, 19]
 
     steps:
 
@@ -59,8 +59,9 @@ jobs:
     - name: Obtain PG development files (Ubuntu, PGDG)
       if: ${{ 'Linux' == runner.os }}
       run: |
-        curl https://www.postgresql.org/media/keys/ACCC4CF8.asc |
-        sudo apt-key add -
+        curl -s -S https://www.postgresql.org/media/keys/ACCC4CF8.asc |
+        gpg --dearmor |
+	sudo dd of=/etc/apt/trusted.gpg.d/apt.postgresql.org.gpg
         echo  \
           deb \
           http://apt.postgresql.org/pub/repos/apt \
@@ -217,7 +218,7 @@ jobs:
 
         String javaHome = System.getProperty("java.home");
 
-        Path javaLibDir = get(javaHome, s_isWindows ? "bin" : "lib")
+        Path javaLibDir = get(javaHome, s_isWindows ? "bin" : "lib");
 
         Path libjvm = (
           "Mac OS X".equals(System.getProperty("os.name"))
@@ -229,6 +230,9 @@ jobs:
 
         String vmopts =
           "-enableassertions:org.postgresql.pljava... -Xcheck:jni";
+
+        if ( 17 < Runtime.version().feature() )
+          vmopts += " -Djava.security.manager=allow";
 
         Node n1 = Node.get_new_node("TestNode1");
 

--- a/.github/workflows/ci-runnerpg.yml
+++ b/.github/workflows/ci-runnerpg.yml
@@ -59,6 +59,8 @@ jobs:
     - name: Obtain PG development files (Ubuntu, PGDG)
       if: ${{ 'Linux' == runner.os }}
       run: |
+        curl https://www.postgresql.org/media/keys/ACCC4CF8.asc |
+        sudo apt-key add -
         echo  \
           deb \
           http://apt.postgresql.org/pub/repos/apt \

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,5 @@
+only_commits:
+  message: /appveyor/
 image: Visual Studio 2019
 environment:
   APPVEYOR_RDP_PASSWORD: MrRobot@2020
@@ -9,51 +11,51 @@ environment:
 #   - SYS: MINGW
 #     JDK: 10
 #     PG: 12
- #  - SYS: MINGW
- #    JDK: 11
- #    PG: 12
- #  - SYS: MINGW
- #    JDK: 12
- #    PG: 12
- #  - SYS: MINGW
- #    JDK: 13
- #    PG: 12
- #  - SYS: MINGW
- #    JDK: 14
- #    PG: 12
- #  - SYS: MINGW
- #    JDK: 15
- #    PG: 12
- #  - SYS: MSVC
- #    JDK: 15
- #    PG: 12
- #  - SYS: MSVC
- #    JDK: 14
- #    PG: 12
- #  - SYS: MSVC
- #    JDK: 13
- #    PG: 12
- #  - SYS: MSVC
- #    JDK: 12
- #    PG: 12
- #  - SYS: MSVC
- #    JDK: 11
- #    PG: 12
+    - SYS: MINGW
+      JDK: 11
+      PG: 12
+    - SYS: MINGW
+      JDK: 12
+      PG: 12
+    - SYS: MINGW
+      JDK: 13
+      PG: 12
+    - SYS: MINGW
+      JDK: 14
+      PG: 12
+    - SYS: MINGW
+      JDK: 15
+      PG: 12
+    - SYS: MSVC
+      JDK: 15
+      PG: 12
+    - SYS: MSVC
+      JDK: 14
+      PG: 12
+    - SYS: MSVC
+      JDK: 13
+      PG: 12
+    - SYS: MSVC
+      JDK: 12
+      PG: 12
+    - SYS: MSVC
+      JDK: 11
+      PG: 12
 #   - SYS: MSVC
 #     JDK: 10
 #     PG: 12
 #   - SYS: MSVC
 #     JDK: 9
 #     PG: 12
- #  - SYS: MSVC
- #    JDK: 14
- #    PG: 11
- #  - SYS: MSVC
- #    JDK: 14
- #    PG: 10
- #  - SYS: MSVC
- #    JDK: 14
- #    PG: 9.6
+    - SYS: MSVC
+      JDK: 14
+      PG: 11
+    - SYS: MSVC
+      JDK: 14
+      PG: 10
+    - SYS: MSVC
+      JDK: 14
+      PG: 9.6
 before_build:
   - ps: .appveyor/appveyor_download_java.ps1
   - set JAVA_HOME=%ProgramFiles%\Java\jdk%JDK%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,12 @@
+# These only_commits and branches settings ought to pretty much suppress
+# Appveyor, whose runs have all been failing lately because of Maven repository
+# connection resets that don't seem reproducible locally. This can be revisited
+# later to see if things might be working again.
 only_commits:
   message: /appveyor/
+branches:
+  only:
+    - appveyor
 image: Visual Studio 2019
 environment:
   APPVEYOR_RDP_PASSWORD: MrRobot@2020

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,51 +9,51 @@ environment:
 #   - SYS: MINGW
 #     JDK: 10
 #     PG: 12
-    - SYS: MINGW
-      JDK: 11
-      PG: 12
-    - SYS: MINGW
-      JDK: 12
-      PG: 12
-    - SYS: MINGW
-      JDK: 13
-      PG: 12
-    - SYS: MINGW
-      JDK: 14
-      PG: 12
-    - SYS: MINGW
-      JDK: 15
-      PG: 12
-    - SYS: MSVC
-      JDK: 15
-      PG: 12
-    - SYS: MSVC
-      JDK: 14
-      PG: 12
-    - SYS: MSVC
-      JDK: 13
-      PG: 12
-    - SYS: MSVC
-      JDK: 12
-      PG: 12
-    - SYS: MSVC
-      JDK: 11
-      PG: 12
+ #  - SYS: MINGW
+ #    JDK: 11
+ #    PG: 12
+ #  - SYS: MINGW
+ #    JDK: 12
+ #    PG: 12
+ #  - SYS: MINGW
+ #    JDK: 13
+ #    PG: 12
+ #  - SYS: MINGW
+ #    JDK: 14
+ #    PG: 12
+ #  - SYS: MINGW
+ #    JDK: 15
+ #    PG: 12
+ #  - SYS: MSVC
+ #    JDK: 15
+ #    PG: 12
+ #  - SYS: MSVC
+ #    JDK: 14
+ #    PG: 12
+ #  - SYS: MSVC
+ #    JDK: 13
+ #    PG: 12
+ #  - SYS: MSVC
+ #    JDK: 12
+ #    PG: 12
+ #  - SYS: MSVC
+ #    JDK: 11
+ #    PG: 12
 #   - SYS: MSVC
 #     JDK: 10
 #     PG: 12
 #   - SYS: MSVC
 #     JDK: 9
 #     PG: 12
-    - SYS: MSVC
-      JDK: 14
-      PG: 11
-    - SYS: MSVC
-      JDK: 14
-      PG: 10
-    - SYS: MSVC
-      JDK: 14
-      PG: 9.6
+ #  - SYS: MSVC
+ #    JDK: 14
+ #    PG: 11
+ #  - SYS: MSVC
+ #    JDK: 14
+ #    PG: 10
+ #  - SYS: MSVC
+ #    JDK: 14
+ #    PG: 9.6
 before_build:
   - ps: .appveyor/appveyor_download_java.ps1
   - set JAVA_HOME=%ProgramFiles%\Java\jdk%JDK%


### PR DESCRIPTION
... thanks to a tip from Rodrigo Alvarado a little tidier than what's on the wiki.postgresql.org Apt page.

And update the list of Java versions tested to cover more recent ones.

Also, for now, suppress the Appveyor tests that have been reliably falling over for some reason of their own.