### PR TITLE
Relax the check of a function's enclosing type

### DIFF
--- a/pljava-api/src/main/java/org/postgresql/pljava/annotation/processing/DDRProcessor.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/annotation/processing/DDRProcessor.java
@@ -2287,7 +2287,7 @@ hunt:	for ( ExecutableElement ee : ees )
 			case  ONEOUT | OTHERTYPE:
 				msg( Kind.ERROR, func,
 					"no type= allowed here (the out parameter " +
-					"declares its own type");
+					"declares its own type)");
 				return;
 			case MOREOUT | RECORDTYPE:
 			case MOREOUT | OTHERTYPE:

--- a/pljava-api/src/main/java/org/postgresql/pljava/annotation/processing/DDRProcessor.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/annotation/processing/DDRProcessor.java
@@ -2503,7 +2503,7 @@ hunt:	for ( ExecutableElement ee : ees )
 				sb.append( typu.erasure( func.getReturnType())).append( '=');
 			Element e = func.getEnclosingElement();
 			// e was earlier checked and ensured to be a class or interface
-			sb.append( e.toString()).append( '.');
+			sb.append( elmu.getBinaryName((TypeElement)e)).append( '.');
 			sb.append( trigger ? func.getSimpleName() : func.toString());
 			return sb.toString();
 		}
@@ -2833,7 +2833,7 @@ hunt:	for ( ExecutableElement ee : ees )
 			return deployStrings(
 				qnameFrom(name(), schema()),
 				null, // parameter iterable unused in appendParams below
-				"UDT[" + te + "] " + id.name(),
+				"UDT[" + elmu.getBinaryName(te) + "] " + id.name(),
 				comment());
 		}
 
@@ -3053,7 +3053,7 @@ hunt:	for ( ExecutableElement ee : ees )
 			}
 			al.add( "SELECT sqlj.add_type_mapping(" +
 				DDRWriter.eQuote( qname.toString()) + ", " +
-				DDRWriter.eQuote( tclass.toString()) + ')');
+				DDRWriter.eQuote( elmu.getBinaryName(tclass)) + ')');
 			addComment( al);
 			return al.toArray( new String [ al.size() ]);
 		}

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/OnInterface.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/OnInterface.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2023 Tada AB and other contributors, as listed below.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Chapman Flack
+ */
+package org.postgresql.pljava.example.annotation;
+
+import org.postgresql.pljava.annotation.Function;
+
+/**
+ * Illustrates PL/Java functions on an interface instead of a class.
+ *<p>
+ * The SQL/JRT standard has always just said "class", but there is no technical
+ * obstacle to permitting a PL/Java function to be a static interface method, so
+ * that earlier restriction has been relaxed.
+ */
+public interface OnInterface
+{
+	/**
+	 * Returns the answer.
+	 */
+	@Function(schema = "javatest")
+	static int answer()
+	{
+		return 42;
+	}
+
+	interface A
+	{
+		/**
+		 * Again the answer.
+		 */
+		@Function(schema = "javatest")
+		static int nestedAnswer()
+		{
+			return 42;
+		}
+	}
+
+	class B
+	{
+		/**
+		 * Still the answer.
+		 */
+		@Function(schema = "javatest")
+		public static int nestedClassAnswer()
+		{
+			return 42;
+		}
+
+		public static class C
+		{
+			/**
+			 * That answer again.
+			 */
+			@Function(schema = "javatest")
+			public static int moreNestedAnswer()
+			{
+				return 42;
+			}
+		}
+	}
+}

--- a/pljava/src/main/java/org/postgresql/pljava/internal/Function.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/Function.java
@@ -1839,7 +1839,7 @@ public class Function
 	 * Uncompiled pattern to recognize a Java identifier.
 	 */
 	private static final String javaIdentifier = String.format(
-		"\\p{%1$sStart}\\p{%1sPart}++", "javaJavaIdentifier"
+		"\\p{%1$sStart}\\p{%1sPart}*+", "javaJavaIdentifier"
 	);
 
 	/**

--- a/pljava/src/main/java/org/postgresql/pljava/internal/Function.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/Function.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2022 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2016-2023 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License


### PR DESCRIPTION
The SQL/JRT standard has always just said class, but it's debatable whether it intended to mean 'class' strictly (and rule out SQL use of a static method on an interface), or simply used 'class' in a broader sense not excluding interfaces. As there is no technical obstacle to using static methods that have been supplied on an interface, relax the annotation-processing-time check that needlessly prevented that.

Add an example that tests that, and also the declaration of methods on nested classes and interfaces (as long as everything is `public` on the way).

Addresses https://github.com/tada/pljava/issues/426.