### PR TITLE
Support `install_jar` from an http URL

### DIFF
--- a/.github/workflows/ci-runnerpg.yml
+++ b/.github/workflows/ci-runnerpg.yml
@@ -509,7 +509,7 @@ jobs:
               succeeding &= useTrialPolicy(n1, c2, List.of(
                 "grant codebase \"${org.postgresql.pljava.codesource}\" {",
                 "  permission",
-                "    java.net.URLPermission \"http:*\", \"GET\";",
+                "    java.net.URLPermission \"http:*\", \"GET:Accept\";",
                 "};"
               ));
 

--- a/.github/workflows/ci-runnerpg.yml
+++ b/.github/workflows/ci-runnerpg.yml
@@ -215,7 +215,7 @@ jobs:
 
         String javaHome = System.getProperty("java.home");
 
-        Path javaLibDir = get(javaHome, s_isWindows ? "bin" : "lib")
+        Path javaLibDir = get(javaHome, s_isWindows ? "bin" : "lib");
 
         Path libjvm = (
           "Mac OS X".equals(System.getProperty("os.name"))
@@ -227,6 +227,9 @@ jobs:
 
         String vmopts =
           "-enableassertions:org.postgresql.pljava... -Xcheck:jni";
+
+        if ( 17 < Runtime.version().feature() )
+          vmopts += " -Djava.security.manager=allow";
 
         Node n1 = Node.get_new_node("TestNode1");
 

--- a/.github/workflows/ci-runnerpg.yml
+++ b/.github/workflows/ci-runnerpg.yml
@@ -440,6 +440,8 @@ jobs:
                 "SELECT javatest.logmessage('INFO'," +
                 " 'jar installed from http');\n" +
                 "END INSTALL\",\n\"BEGIN REMOVE\n" +
+                "BEGIN dummy\n" +
+                "END dummy;\n" +
                 "END REMOVE\"\n}\n"
               ).getBytes(UTF_8)
             );

--- a/.github/workflows/ci-runnerpg.yml
+++ b/.github/workflows/ci-runnerpg.yml
@@ -466,8 +466,11 @@ jobs:
             )
             {
               InetSocketAddress addr = hs.getAddress();
+
+              String id = "bar", pw = "baz";
+
               URL u = new URI(
-                "http", null, addr.getHostString(), addr.getPort(),
+                "http", id+':'+pw, addr.getHostString(), addr.getPort(),
                 "/foo.jar", null, null
               ).toURL();
 
@@ -487,6 +490,17 @@ jobs:
                     try ( OutputStream os = t.getResponseBody() ) {
                       os.write(jar);
                     }
+                  }
+                }
+              );
+
+              hc.setAuthenticator(
+                new BasicAuthenticator("CI realm", UTF_8)
+                {
+                  @Override
+                  public boolean checkCredentials(String c_id, String c_pw)
+                  {
+                      return id.equals(c_id) && pw.equals(c_pw);
                   }
                 }
               );

--- a/.github/workflows/ci-runnerpg.yml
+++ b/.github/workflows/ci-runnerpg.yml
@@ -276,6 +276,42 @@ jobs:
           return true;
         }
 
+        /*
+         * Write a trial policy into a temporary file in n's data_dir,
+         * and set pljava.vmoptions accordingly over connection c.
+         * Returns the 'succeeding' flag from the state machine looking
+         * at the command results.
+         */
+        boolean useTrialPolicy(Node n, Connection c, List<String> contents)
+        throws Exception
+        {
+          Path trialPolicy =
+            createTempFile(n.data_dir().getParent(), "trial", "policy");
+
+          write(trialPolicy, contents);
+
+          PreparedStatement setVmOpts = c.prepareStatement(
+            "SELECT null::pg_catalog.void" +
+            " FROM pg_catalog.set_config('pljava.vmoptions', ?, false)"
+          );
+
+          setVmOpts.setString(1, vmopts +
+            " -Dorg.postgresql.pljava.policy.trial=" + trialPolicy.toUri());
+
+          return stateMachine(
+            "change pljava.vmoptions",
+            null,
+
+            q(setVmOpts, setVmOpts::execute)
+            .flatMap(Node::semiFlattenDiagnostics)
+            .peek(Node::peek),
+
+            (o,p,q) -> isDiagnostic(o, Set.of("error")) ? 1 : -2,
+            (o,p,q) -> isVoidResultSet(o, 1, 1) ? 3 : false,
+            (o,p,q) -> null == o
+          );
+        }
+
         try (
           AutoCloseable t1 = n1.initialized_cluster();
           AutoCloseable t2 = n1.started_server(Map.of(
@@ -351,36 +387,12 @@ jobs:
              */
             try ( Connection c2 = n1.connect() )
             {
-              Path trialPolicy =
-                createTempFile(n1.data_dir().getParent(), "trial", "policy");
-
-              write(trialPolicy, List.of(
+              succeeding &= useTrialPolicy(n1, c2, List.of(
                 "grant {",
                 "  permission",
                 "    org.postgresql.pljava.policy.TrialPolicy$Permission;",
                 "};"
               ));
-
-              PreparedStatement setVmOpts = c2.prepareStatement(
-                "SELECT null::pg_catalog.void" +
-                " FROM pg_catalog.set_config('pljava.vmoptions', ?, false)"
-              );
-
-              setVmOpts.setString(1, vmopts +
-                " -Dorg.postgresql.pljava.policy.trial=" + trialPolicy.toUri());
-
-              succeeding &= stateMachine(
-                "change pljava.vmoptions",
-                null,
-
-                q(setVmOpts, setVmOpts::execute)
-                .flatMap(Node::semiFlattenDiagnostics)
-                .peek(Node::peek),
-
-                (o,p,q) -> isDiagnostic(o, Set.of("error")) ? 1 : -2,
-                (o,p,q) -> isVoidResultSet(o, 1, 1) ? 3 : false,
-                (o,p,q) -> null == o
-              );
 
               PreparedStatement tryForbiddenRead = c2.prepareStatement(
                 "SELECT" +
@@ -476,6 +488,13 @@ jobs:
                   }
                 }
               );
+
+              succeeding &= useTrialPolicy(n1, c2, List.of(
+                "grant codebase \"${org.postgresql.pljava.codesource}\" {",
+                "  permission",
+                "    java.net.URLPermission \"http:*\", \"GET\";",
+                "};"
+              ));
 
               succeeding &= stateMachine(
                 "install a jar over http",

--- a/.github/workflows/ci-runnerpg.yml
+++ b/.github/workflows/ci-runnerpg.yml
@@ -495,7 +495,8 @@ jobs:
               );
 
               hc.setAuthenticator(
-                new BasicAuthenticator("CI realm", UTF_8)
+                new BasicAuthenticator("CI realm")
+                // ("CI realm", UTF_8) only available in Java 14 or later
                 {
                   @Override
                   public boolean checkCredentials(String c_id, String c_pw)

--- a/.github/workflows/ci-runnerpg.yml
+++ b/.github/workflows/ci-runnerpg.yml
@@ -192,7 +192,7 @@ jobs:
           -execution local \
           "-J--class-path=$packageJar$pathSep$jdbcJar" \
           "--class-path=$packageJar" \
-          "-J--add-modules=java.sql.rowset" \
+          "-J--add-modules=java.sql.rowset,jdk.httpserver" \
           "-J-Dpgconfig=$pgConfig" \
           "-J-Dcom.impossibl.shadow.io.netty.noUnsafe=true" \
           "-J-DmavenRepo=$mavenRepo" \
@@ -212,6 +212,20 @@ jobs:
         import static org.postgresql.pljava.packaging.Node.stateMachine;
         import static org.postgresql.pljava.packaging.Node.isVoidResultSet;
         import static org.postgresql.pljava.packaging.Node.s_isWindows;
+        /*
+         * Imports that will be needed to serve a jar file over http
+         * when the time comes for testing that.
+         */
+        import static java.nio.charset.StandardCharsets.UTF_8;
+        import java.util.jar.Attributes;
+        import java.util.jar.Manifest;
+        import java.util.jar.JarOutputStream;
+        import java.util.zip.ZipEntry;
+        import com.sun.net.httpserver.BasicAuthenticator;
+        import com.sun.net.httpserver.HttpContext;
+        import com.sun.net.httpserver.HttpExchange;
+        import com.sun.net.httpserver.HttpHandler;
+        import com.sun.net.httpserver.HttpServer;
 
         String javaHome = System.getProperty("java.home");
 
@@ -392,6 +406,91 @@ jobs:
                 (o,p,q) -> null == o
               );
               // done with connection c2
+            }
+
+            /*
+             * Spin up an http server with a little jar file to serve, and test
+             * that install_jar works with an http: url.
+             *
+             * First make a little jar empty but for a deployment descriptor.
+             */
+            String ddrName = "foo.ddr";
+            Attributes a = new Attributes();
+            a.putValue("SQLJDeploymentDescriptor", "TRUE");
+            Manifest m = new Manifest();
+            m.getEntries().put(ddrName, a);
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            JarOutputStream jos = new JarOutputStream(baos, m);
+            jos.putNextEntry(new ZipEntry(ddrName));
+            jos.write(
+              (
+                "SQLActions[]={\n\"BEGIN INSTALL\n" +
+                "SELECT javatest.logmessage('INFO'," +
+                " 'jar installed from http');\n" +
+                "END INSTALL\",\n\"BEGIN REMOVE\n" +
+                "END REMOVE\"\n}\n"
+              ).getBytes(UTF_8)
+            );
+            jos.closeEntry();
+            jos.close();
+            byte[] jar = baos.toByteArray();
+
+            /*
+             * Now an http server.
+             */
+            HttpServer hs =
+              HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+
+            try (
+              Connection c2 = n1.connect();
+              AutoCloseable t = ((Supplier<AutoCloseable>)() ->
+                {
+                  hs.start();
+                  return () -> hs.stop(0);
+                }
+              ).get()
+            )
+            {
+              InetSocketAddress addr = hs.getAddress();
+              URL u = new URI(
+                "http", null, addr.getHostString(), addr.getPort(),
+                "/foo.jar", null, null
+              ).toURL();
+
+              HttpContext hc = hs.createContext(
+                u.getPath(),
+                new HttpHandler()
+                {
+                  @Override
+                  public void handle(HttpExchange t) throws IOException
+                  {
+                    try ( InputStream is = t.getRequestBody() ) {
+                      is.readAllBytes();
+                    }
+                    t.getResponseHeaders().add(
+                      "Content-Type", "application/java-archive");
+                    t.sendResponseHeaders(200, jar.length);
+                    try ( OutputStream os = t.getResponseBody() ) {
+                      os.write(jar);
+                    }
+                  }
+                }
+              );
+
+              succeeding &= stateMachine(
+                "install a jar over http",
+                null,
+
+                Node.installJar(c2, u.toString(), "foo", true)
+                .flatMap(Node::semiFlattenDiagnostics)
+                .peek(Node::peek),
+
+                (o,p,q) -> isDiagnostic(o, Set.of("error", "warning")) ? 1 : -2,
+                (o,p,q) -> isVoidResultSet(o, 1, 1) ? 3 : false,
+                (o,p,q) -> null == o
+              );
+
+              // done with connection c2 again, and the http server
             }
 
             /*

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,12 @@
+# These only_commits and branches settings ought to pretty much suppress
+# Appveyor, whose runs have all been failing lately because of Maven repository
+# connection resets that don't seem reproducible locally. This can be revisited
+# later to see if things might be working again.
+only_commits:
+  message: /appveyor/
+branches:
+  only:
+    - appveyor
 image: Visual Studio 2019
 environment:
   APPVEYOR_RDP_PASSWORD: MrRobot@2020

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -106,6 +106,9 @@ test_script:
 
       String vmopts = "-enableassertions:org.postgresql.pljava... -Xcheck:jni";
 
+      if ( 17 < Runtime.version().feature() )
+        vmopts += " -Djava.security.manager=allow";
+
       Node n1 = Node.get_new_node("TestNode1");
 
       n1.use_pg_ctl(true);

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -394,7 +394,7 @@ test_script:
             succeeding &= useTrialPolicy(n1, c2, List.of(
               "grant codebase \"${org.postgresql.pljava.codesource}\" {",
               "  permission",
-              "    java.net.URLPermission \"http:*\", \"GET\";",
+              "    java.net.URLPermission \"http:*\", \"GET:Accept\";",
               "};"
             ));
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -380,7 +380,8 @@ test_script:
             );
 
             hc.setAuthenticator(
-              new BasicAuthenticator("CI realm", UTF_8)
+              new BasicAuthenticator("CI realm")
+              // ("CI realm", UTF_8) only available in Java 14 or later
               {
                 @Override
                 public boolean checkCredentials(String c_id, String c_pw)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -99,6 +99,20 @@ test_script:
       import static org.postgresql.pljava.packaging.Node.q;
       import static org.postgresql.pljava.packaging.Node.stateMachine;
       import static org.postgresql.pljava.packaging.Node.isVoidResultSet;
+      /*
+       * Imports that will be needed to serve a jar file over http
+       * when the time comes for testing that.
+       */
+      import static java.nio.charset.StandardCharsets.UTF_8;
+      import java.util.jar.Attributes;
+      import java.util.jar.Manifest;
+      import java.util.jar.JarOutputStream;
+      import java.util.zip.ZipEntry;
+      import com.sun.net.httpserver.BasicAuthenticator;
+      import com.sun.net.httpserver.HttpContext;
+      import com.sun.net.httpserver.HttpExchange;
+      import com.sun.net.httpserver.HttpHandler;
+      import com.sun.net.httpserver.HttpServer;
 
       System.setErr(System.out); // PowerShell makes a mess of stderr output
 
@@ -136,6 +150,42 @@ test_script:
           if ( ! "warning".equals(type)  ||  ! message.startsWith("[JEP 411]") )
             results.compute("ng", (k,v) -> 1 + v);
         return true;
+      }
+
+      /*
+       * Write a trial policy into a temporary file in n's data_dir,
+       * and set pljava.vmoptions accordingly over connection c.
+       * Returns the 'succeeding' flag from the state machine looking
+       * at the command results.
+       */
+      boolean useTrialPolicy(Node n, Connection c, List<String> contents)
+      throws Exception
+      {
+        Path trialPolicy =
+          createTempFile(n.data_dir().getParent(), "trial", "policy");
+
+        write(trialPolicy, contents);
+
+        PreparedStatement setVmOpts = c.prepareStatement(
+          "SELECT null::pg_catalog.void" +
+          " FROM pg_catalog.set_config('pljava.vmoptions', ?, false)"
+        );
+
+        setVmOpts.setString(1, vmopts +
+          " -Dorg.postgresql.pljava.policy.trial=" + trialPolicy.toUri());
+
+        return stateMachine(
+          "change pljava.vmoptions",
+          null,
+
+          q(setVmOpts, setVmOpts::execute)
+          .flatMap(Node::semiFlattenDiagnostics)
+          .peek(Node::peek),
+
+          (o,p,q) -> isDiagnostic(o, Set.of("error")) ? 1 : -2,
+          (o,p,q) -> isVoidResultSet(o, 1, 1) ? 3 : false,
+          (o,p,q) -> null == o
+        );
       }
 
       try (
@@ -213,36 +263,12 @@ test_script:
            */
           try ( Connection c2 = n1.connect() )
           {
-            Path trialPolicy =
-              createTempFile(n1.data_dir().getParent(), "trial", "policy");
-
-            write(trialPolicy, List.of(
+            succeeding &= useTrialPolicy(n1, c2, List.of(
               "grant {",
               "  permission",
               "    org.postgresql.pljava.policy.TrialPolicy$Permission;",
               "};"
             ));
-
-            PreparedStatement setVmOpts = c2.prepareStatement(
-              "SELECT null::pg_catalog.void" +
-              " FROM pg_catalog.set_config('pljava.vmoptions', ?, false)"
-            );
-
-            setVmOpts.setString(1, vmopts +
-              " -Dorg.postgresql.pljava.policy.trial=" + trialPolicy.toUri());
-
-            succeeding &= stateMachine(
-              "change pljava.vmoptions",
-              null,
-
-              q(setVmOpts, setVmOpts::execute)
-              .flatMap(Node::semiFlattenDiagnostics)
-              .peek(Node::peek),
-
-              (o,p,q) -> isDiagnostic(o, Set.of("error")) ? 1 : -2,
-              (o,p,q) -> isVoidResultSet(o, 1, 1) ? 3 : false,
-              (o,p,q) -> null == o
-            );
 
             PreparedStatement tryForbiddenRead = c2.prepareStatement(
               "SELECT" +
@@ -268,6 +294,114 @@ test_script:
               (o,p,q) -> null == o
             );
             // done with connection c2
+          }
+
+          /*
+           * Spin up an http server with a little jar file to serve, and test
+           * that install_jar works with an http: url.
+           *
+           * First make a little jar empty but for a deployment descriptor.
+           */
+          String ddrName = "foo.ddr";
+          Attributes a = new Attributes();
+          a.putValue("SQLJDeploymentDescriptor", "TRUE");
+          Manifest m = new Manifest();
+          m.getEntries().put(ddrName, a);
+          ByteArrayOutputStream baos = new ByteArrayOutputStream();
+          JarOutputStream jos = new JarOutputStream(baos, m);
+          jos.putNextEntry(new ZipEntry(ddrName));
+          jos.write(
+            (
+              "SQLActions[]={\n\"BEGIN INSTALL\n" +
+              "SELECT javatest.logmessage('INFO'," +
+              " 'jar installed from http');\n" +
+              "END INSTALL\",\n\"BEGIN REMOVE\n" +
+              "BEGIN dummy\n" +
+              "END dummy;\n" +
+              "END REMOVE\"\n}\n"
+            ).getBytes(UTF_8)
+          );
+          jos.closeEntry();
+          jos.close();
+          byte[] jar = baos.toByteArray();
+
+          /*
+           * Now an http server.
+           */
+          HttpServer hs =
+            HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+
+          try (
+            Connection c2 = n1.connect();
+            AutoCloseable t = ((Supplier<AutoCloseable>)() ->
+              {
+                hs.start();
+                return () -> hs.stop(0);
+              }
+            ).get()
+          )
+          {
+            InetSocketAddress addr = hs.getAddress();
+
+            String id = "bar", pw = "baz";
+
+            URL u = new URI(
+              "http", id+':'+pw, addr.getHostString(), addr.getPort(),
+              "/foo.jar", null, null
+            ).toURL();
+
+            HttpContext hc = hs.createContext(
+              u.getPath(),
+              new HttpHandler()
+              {
+                @Override
+                public void handle(HttpExchange t) throws IOException
+                {
+                  try ( InputStream is = t.getRequestBody() ) {
+                    is.readAllBytes();
+                  }
+                  t.getResponseHeaders().add(
+                    "Content-Type", "application/java-archive");
+                  t.sendResponseHeaders(200, jar.length);
+                  try ( OutputStream os = t.getResponseBody() ) {
+                    os.write(jar);
+                  }
+                }
+              }
+            );
+
+            hc.setAuthenticator(
+              new BasicAuthenticator("CI realm", UTF_8)
+              {
+                @Override
+                public boolean checkCredentials(String c_id, String c_pw)
+                {
+                    return id.equals(c_id) && pw.equals(c_pw);
+                }
+              }
+            );
+
+            succeeding &= useTrialPolicy(n1, c2, List.of(
+              "grant codebase \"${org.postgresql.pljava.codesource}\" {",
+              "  permission",
+              "    java.net.URLPermission \"http:*\", \"GET\";",
+              "};"
+            ));
+
+            succeeding &= stateMachine(
+              "install a jar over http",
+              null,
+
+              Node.installJar(c2, u.toString(), "foo", true)
+              .flatMap(Node::semiFlattenDiagnostics)
+              .peek(Node::peek),
+
+              (o,p,q) -> isDiagnostic(o, Set.of("error", "warning")) ? 1 : -2,
+              (o,p,q) -> isVoidResultSet(o, 1, 1) ? 3 : false,
+              (o,p,q) -> null == o
+            );
+
+            // done with connection c2 again, and the http server
           }
 
           /*
@@ -445,7 +579,7 @@ test_script:
         -execution local `
         "-J--class-path=$packageJar;$jdbcJar" `
         "--class-path=$packageJar" `
-        "-J--add-modules=java.sql.rowset" `
+        "-J--add-modules=java.sql.rowset,jdk.httpserver" `
         "-J-Dcom.impossibl.shadow.io.netty.noUnsafe=true" `
         "-J-Dpgconfig=$pgConfig" `
         "-J-DmavenRepo=$mavenRepo" `

--- a/pljava-packaging/src/main/java/Node.java
+++ b/pljava-packaging/src/main/java/Node.java
@@ -1122,7 +1122,7 @@ public class Node extends JarX {
 			"  )" +
 			" )" +
 			"FROM" +
-			" (VALUES (?, ?)) AS p(schema, jar)," +
+			" (VALUES (?, CAST (? AS pg_catalog.text))) AS p(schema, jar)," +
 			" COALESCE(" +
 			"  pg_catalog.regexp_split_to_array(" +
 			"   sqlj.get_classpath(schema)," +

--- a/pljava-packaging/src/main/java/Node.java
+++ b/pljava-packaging/src/main/java/Node.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2015-2023 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -1103,6 +1103,42 @@ public class Node extends JarX {
 	}
 
 	/**
+	 * Append a jar to a schema's class path if not already included.
+	 * @return a {@link #q(Statement,Callable) result stream} that includes, on
+	 * success, a one-column {@code void} result set with a single row if the
+	 * jar was added to the path, and no rows if the jar was already included.
+	 */
+	public static Stream<Object> appendClasspathIf(
+		Connection c, String schema, String jarName)
+	throws Exception
+	{
+		PreparedStatement ps = c.prepareStatement(
+			"SELECT" +
+			" sqlj.set_classpath(" +
+			"  schema," +
+			"  pg_catalog.concat_ws(" +
+			"   ':'," +
+			"   VARIADIC oldpath OPERATOR(pg_catalog.||) ARRAY[jar]" +
+			"  )" +
+			" )" +
+			"FROM" +
+			" (VALUES (?, ?)) AS p(schema, jar)," +
+			" COALESCE(" +
+			"  pg_catalog.regexp_split_to_array(" +
+			"   sqlj.get_classpath(schema)," +
+			"  ':'" +
+			"  )," +
+			"  CAST (ARRAY[] AS pg_catalog.text[])" +
+			" ) AS t(oldpath)" +
+			"WHERE" +
+			" jar OPERATOR(pg_catalog.<>) ALL (oldpath)"
+		);
+		ps.setString(1, schema);
+		ps.setString(2, jarName);
+		return q(ps, ps::execute);
+	}
+
+	/**
 	 * Execute some arbitrary SQL
 	 * @return a {@link #q(Statement,Callable) result stream} from executing
 	 * the statement
@@ -1551,8 +1587,8 @@ public class Node extends JarX {
 	}
 
 	/**
-	 * Install the examples jar, under the name {@code examples}, and place it
-	 * on the class path for schema {@code public}.
+	 * Install the examples jar, under the name {@code examples}, and append it
+	 * to the class path for schema {@code public}.
 	 *<p>
 	 * The return of a concatenated result stream from two consecutive
 	 * statements might be likely to fail in cases where the first
@@ -1567,7 +1603,7 @@ public class Node extends JarX {
 	throws Exception
 	{
 		Stream<Object> s1 = installExamples(c, deploy);
-		Stream<Object> s2 = setClasspath(c, "public", "examples");
+		Stream<Object> s2 = appendClasspathIf(c, "public", "examples");
 		return Stream.concat(s1, s2);
 	}
 
@@ -1589,7 +1625,7 @@ public class Node extends JarX {
 	}
 
 	/**
-	 * Install a Saxon jar under the name {@code saxon}, and place it on the
+	 * Install a Saxon jar under the name {@code saxon}, and append it to the
 	 * class path for schema {@code public}.
 	 * @return a combined {@link #q(Statement,Callable) result stream} from
 	 * executing the statements
@@ -1599,7 +1635,7 @@ public class Node extends JarX {
 	throws Exception
 	{
 		Stream<Object> s1 = installSaxon(c, repo, version);
-		Stream<Object> s2 = setClasspath(c, "public", "saxon");
+		Stream<Object> s2 = appendClasspathIf(c, "public", "saxon");
 		return Stream.concat(s1, s2);
 	}
 

--- a/pljava-packaging/src/main/resources/pljava.policy
+++ b/pljava-packaging/src/main/resources/pljava.policy
@@ -78,8 +78,9 @@ grant codebase "${org.postgresql.pljava.codesource}" {
 	//
 	// There would be nothing wrong with restricting this permission to
 	// a specific directory, if all jar files to be loaded will be found there,
-	// or replacing it with a URLPermission if they will be hosted on a remote
-	// server, etc.
+	// or, if they will be hosted on a remote server, a permission like
+	// java.net.URLPermission "https://example.com/jars/*", "GET:Accept"
+	// etc.
 	//
 	permission java.io.FilePermission
 		"<<ALL FILES>>", "read";

--- a/pljava/src/main/java/org/postgresql/pljava/management/Commands.java
+++ b/pljava/src/main/java/org/postgresql/pljava/management/Commands.java
@@ -450,6 +450,12 @@ public class Commands
 		{
 			URL url = new URL(urlString);
 			URLConnection uc = url.openConnection();
+			uc.setRequestProperty("Accept",
+				"application/java-archive, " +
+				"application/jar;q=0.9, application/jar-archive;q=0.9, " +
+				"application/x-java-archive;q=0.9, " +
+				"application/*;q=0.3, */*;q=0.2"
+			);
 			long[] sz = new long[1];
 			Permission[] least = { uc.getPermission() };
 
@@ -465,7 +471,7 @@ public class Commands
 				 */
 				least = new Permission[] {
 					least[0],
-					new URLPermission(urlString, "GET")
+					new URLPermission(urlString, "GET:Accept")
 				};
 
 				/*

--- a/pljava/src/main/java/org/postgresql/pljava/management/Commands.java
+++ b/pljava/src/main/java/org/postgresql/pljava/management/Commands.java
@@ -495,8 +495,8 @@ public class Commands
 		}
 		catch(IOException e)
 		{
-			throw new SQLException("I/O exception reading jar file: " +
-				e.getMessage());
+			throw new SQLException("reading jar file: " +
+				e.toString(), "58030", e);
 		}
 	}
 
@@ -602,8 +602,8 @@ public class Commands
 		}
 		catch(IOException e)
 		{
-			throw new SQLException("I/O exception reading jar file: "
-				+ e.getMessage(), "58030", e);
+			throw new SQLException("reading jar file: "
+				+ e.toString(), "58030", e);
 		}
 	}
 

--- a/pljava/src/main/java/org/postgresql/pljava/management/Commands.java
+++ b/pljava/src/main/java/org/postgresql/pljava/management/Commands.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2021 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2023 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -18,12 +18,18 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.net.Authenticator;
+import java.net.HttpURLConnection;
+import java.net.PasswordAuthentication;
+import java.net.URI;
 import java.net.URL;
 import java.net.URLConnection;
+import java.net.URLPermission;
 import java.nio.ByteBuffer;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CharacterCodingException;
+import java.security.Permission;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -36,6 +42,7 @@ import java.sql.SQLSyntaxErrorException;
 import java.sql.Statement;
 import java.text.ParseException;
 import java.util.ArrayList;
+import static java.util.Arrays.fill;
 import java.util.jar.Attributes;
 import java.util.jar.JarEntry;
 import java.util.jar.JarInputStream;
@@ -388,6 +395,48 @@ public class Commands
 		Identifier.Simple.fromCatalog("public");
 
 	/**
+	 * An {@link Authenticator} that will try the {@code userinfo} of the
+	 * requesting URL if present.
+	 *<p>
+	 * Beware that such URLs will appear in
+	 * {@code sqlj.jar_repository.jarorigin} if used to install a jar!
+	 */
+	private static class EmbeddedPwdAuthenticator extends Authenticator
+	{
+		private EmbeddedPwdAuthenticator() { }
+
+		static final EmbeddedPwdAuthenticator INSTANCE =
+			new EmbeddedPwdAuthenticator();
+
+		@Override
+		protected PasswordAuthentication getPasswordAuthentication()
+		{
+			String userinfo =
+				URI.create(getRequestingURL().toString()).getUserInfo();
+			if ( null == userinfo )
+				return null;
+			int len = userinfo.length();
+			int uend = userinfo.indexOf(':');
+			int pstart;
+			if ( -1 == uend )
+				uend = pstart = len;
+			else
+				pstart = 1 + uend;
+			String u = userinfo.substring(0, uend);
+			char[] p = new char[len - pstart];
+			try
+			{
+				userinfo.getChars(pstart, len, p, 0);
+				return new PasswordAuthentication(u, p);
+			}
+			finally
+			{
+				fill(p, '\245'); // PasswordAuthentication clones it
+			}
+		}
+	}
+
+	/**
 	 * Reads the jar found at the specified URL and stores the entries in the
 	 * jar_entry table.
 	 * 
@@ -402,6 +451,31 @@ public class Commands
 			URL url = new URL(urlString);
 			URLConnection uc = url.openConnection();
 			long[] sz = new long[1];
+			Permission[] least = { uc.getPermission() };
+
+			if ( uc instanceof HttpURLConnection )
+			{
+				/*
+				 * Augment what uc returned as the least privilege set needed
+				 * to connect. HttpURLConnection's getPermission method is older
+				 * than URLPermission, and it only returns a SocketPermission.
+				 * Set up 'least' to include both, so as not to end up with an
+				 * empty permission set when 'least' includes one and the policy
+				 * granted the other.
+				 */
+				least = new Permission[] {
+					least[0],
+					new URLPermission(urlString, "GET")
+				};
+
+				/*
+				 * In case authentication is needed, set an Authenticator that
+				 * will try userinfo from the URL if present. (Beware that jar
+				 * origin URLs are stored in sqlj.jar_repository.jarorigin!)
+				 */
+				((HttpURLConnection)uc).setAuthenticator(
+					EmbeddedPwdAuthenticator.INSTANCE);
+			}
 
 			/*
 			 * Do uc.connect() with PL/Java implementation's permissions, but
@@ -413,7 +487,7 @@ public class Commands
 					uc.connect();
 					sz[0] = uc.getContentLengthLong();
 					return uc.getInputStream();
-				}, null, uc.getPermission())
+				}, null, least)
 			)
 			{
 				addClassImages(jarId, urlStream, sz[0]);

--- a/pljava/src/main/java/org/postgresql/pljava/management/SQLDeploymentDescriptor.java
+++ b/pljava/src/main/java/org/postgresql/pljava/management/SQLDeploymentDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2016 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2023 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -332,7 +332,7 @@ public class SQLDeploymentDescriptor
 			default:
 				if(inQuote == 0 && Character.isWhitespace((char)c))
 				{
-					// Change multiple whitespace into one singe space.
+					// Change multiple whitespace into one single space.
 					//
 					m_buffer.append(' ');
 					c = this.skipWhite();
@@ -345,7 +345,7 @@ public class SQLDeploymentDescriptor
 			}
 		}
 		if(inQuote != 0)
-			throw this.parseError("Untermintated " + (char)inQuote +
+			throw this.parseError("Unterminated " + (char)inQuote +
 					" starting at position " + startQuotePos);
 
 		throw this.parseError("Unexpected EOF. Expecting ';' to end command");


### PR DESCRIPTION
Fix some issues identified in #425 that kept `install_jar` from working with an http URL.

* `HttpURLConnection` has a `getPermission` method that is supposed to return the least permission needed to retrieve the resource. But it should be possible to use either a suitable `SocketPermission` or the newer `URLPermission`, and that old method only returns the first. If the policy grants a `URLPermission` and the permissions are intersected with the set containing just `SocketPermission`, an empty set results. Make sure the `URLPermission` is also included.
* Java does not automatically use authentication info in the URL if the server sends a password authentication challenge. An `Authenticator` instance that will do that has to be set on the `HttpURLConnection` first.

Update the GitHub Actions and Appveyor CI scripts to include a test of `install_jar` over an authenticated http connection. (And then cherrypick, from the recent CI pull request, the changes to suppress Appveyor, because it keeps falling over for what seem to be reasons of its own.)

`Node.java` gets a new `appendClasspathIf` method, and `SQLDeploymentDescriptor` gets some typos fixed, in the process of adding the new tests.