### PR TITLE
Document the use of --add-modules

### DIFF
--- a/src/site/markdown/install/vmoptions.md
+++ b/src/site/markdown/install/vmoptions.md
@@ -7,6 +7,31 @@ options are likely to be worth setting.
 If using [the OpenJ9 JVM][hsj9], be sure to look also at the
 [VM options specific to OpenJ9][vmoptJ9].
 
+## Adding to the set of readable modules
+
+By default, a small set of Java modules (including `java.base`,
+`org.postgresql.pljava`, and `java.sql` and its transitive dependencies,
+which include `java.xml`) will be readable to any Java code installed with
+`install_jar`.
+
+While those modules may be enough for many uses, other modules are easily added
+using `--add-modules` within `pljava.vmoptions`. For example,
+`--add-modules=java.net.http,java.rmi` would make the HTTP Client and WebSocket
+APIs readable, along with the Remote Method Invocation API.
+
+For convenience, the module `java.se` simply transitively requires all the
+modules that make up the full Java SE API, so `--add-modules=java.se` will make
+that full API available to PL/Java code without further thought. The cost,
+however, may be that PL/Java uses more memory and starts more slowly than if
+only a few needed modules were named.
+
+Third-party modular code can be made available by adding the modular jars
+to `pljava.module_path` (see [configuration variables](../use/variables.html))
+and naming those modules in `--add-modules`. PL/Java currently treats all jars
+loaded with `install_jar` as unnamed-module, legacy classpath code.
+
+For more, see [PL/Java and the Java Platform Module System](../use/jpms.html).
+
 ## Byte order for PL/Java-implemented user-defined types
 
 PL/Java is free of byte-order issues except when using its features for building

--- a/src/site/markdown/use/use.md
+++ b/src/site/markdown/use/use.md
@@ -34,6 +34,14 @@ Several [configuration variables](variables.html) can affect PL/Java's
 operation, including some common PostgreSQL variables as well as
 PL/Java's own.
 
+### Enabling additional Java modules
+
+By default, PL/Java code can see a small set of Java modules, including
+`java.base` and `java.sql` and a few others. To include others, use
+[`--add-modules` in `pljava.vmoptions`][addm].
+
+[addm]: ../install/vmoptions.html#Adding_to_the_set_of_readable_modules
+
 ## Special topics
 
 ### Configuring permissions

--- a/src/site/markdown/use/variables.md
+++ b/src/site/markdown/use/variables.md
@@ -101,6 +101,11 @@ These PostgreSQL configuration variables can influence PL/Java's operation:
     PL/Java API jar file and the PL/Java internals jar file. To determine the
     proper setting, see
     [finding the files produced by a PL/Java build](../install/locate.html).
+
+    If additional modular jars are added to the module path,
+    `--add-modules` in [`pljava.vmoptions`][addm] will make them readable by
+    PL/Java code.
+
     For more on PL/Java's "module path" and "class path", see
     [PL/Java and the Java Platform Module System](jpms.html).
 
@@ -181,3 +186,4 @@ These PostgreSQL configuration variables can influence PL/Java's operation:
 [jou]: https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html
 [vmop]: ../install/vmoptions.html
 [sqlascii]: charsets.html#Using_PLJava_with_server_encoding_SQL_ASCII
+[addm]: ../install/vmoptions.html#Adding_to_the_set_of_readable_modules


### PR DESCRIPTION
PL/Java code loaded with `install_jar` is treated as unnamed-module, legacy classpath code. Such code is advertised as having access to all readable modules, without having to declare dependencies (as it can't declare dependencies; it would have to be a named module to do that).

Ah, but what are "all _readable_ modules"? Only the ones enumerated at JVM startup, using as root modules PL/Java itself and anything named with `--add-modules`. So that option must be used if any Java modules will be needed beyond the ones PL/Java itself depends on. PL/Java's documentation didn't explain this.

This added documentation addresses #419.