### PR TITLE
Simply reject a Java version affected by JDK-8309515

### DIFF
--- a/pljava-api/src/main/java/org/postgresql/pljava/annotation/processing/DDRProcessor.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/annotation/processing/DDRProcessor.java
@@ -173,7 +173,7 @@ public class DDRProcessor extends AbstractProcessor
 		 * Update latest_tested to be the latest Java release on which this
 		 * annotation processor has been tested without problems.
 		 */
-		int latest_tested = 19;
+		int latest_tested = 20;
 		int ordinal_9 = SourceVersion.RELEASE_9.ordinal();
 		int ordinal_latest = latest_tested - 9 + ordinal_9;
 


### PR DESCRIPTION
The Java bug [JDK-8309515][bug] first appears in Java 20, and has been quickly fixed for 21 (in openjdk/jdk@90027ff) and will presumably be backpatched to some update of 20.

Therefore, rather than bending over backward to include a workaround, simply include a test for the bug, with advice to use a working (pre-20, or recent, fixed) Java version.

Addresses #435.

[bug]: https://bugs.openjdk.org/browse/JDK-8309515