### PR TITLE
Restore "installed by `LOAD` then packaged as extension"

### DIFF
--- a/.github/workflows/ci-runnerpg.yml
+++ b/.github/workflows/ci-runnerpg.yml
@@ -477,14 +477,13 @@ jobs:
            * pljava.module_path set to the right locations of the jars, and the
            * correct shared-object path given to LOAD.
            *
-           * For now, until issue #434 has a fix, DO NOT
-           * also test the after-the-fact packaging up with CREATE EXTENSION
+           * Also test the after-the-fact packaging up with CREATE EXTENSION
            * FROM unpackaged. That officially goes away in PG 13, where the
            * equivalent sequence
            *  CREATE EXTENSION pljava VERSION unpackaged
            *  \c
            *  ALTER EXTENSION pljava UPDATE
-           * should (for now, also NOT) be tested instead.
+           * should be tested instead.
            */
           try ( Connection c = n1.connect() )
           {
@@ -523,7 +522,6 @@ jobs:
            * PG >= 13 CREATE EXTENSION VERSION unpackaged;ALTER EXTENSION UPDATE
            * sequence) has to happen over a new connection.
            */
-          if ( false ) { // pending issue 434 fix
           try ( Connection c = n1.connect() )
           {
             int majorVersion = c.getMetaData().getDatabaseMajorVersion();
@@ -557,7 +555,6 @@ jobs:
               (o,p,q) -> null == o
             );
           }
-          } // pending issue 434 fix
         } catch ( Throwable t )
         {
           succeeding = false;

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -356,14 +356,13 @@ test_script:
          * pljava.module_path set to the right locations of the jars, and the
          * correct shared-object path given to LOAD.
          *
-         * For now, until issue #434 has a fix, DO NOT
-         * also test the after-the-fact packaging up with CREATE EXTENSION
+         * Also test the after-the-fact packaging up with CREATE EXTENSION
          * FROM unpackaged. That officially goes away in PG 13, where the
          * equivalent sequence
          *  CREATE EXTENSION pljava VERSION unpackaged
          *  \c
          *  ALTER EXTENSION pljava UPDATE
-         * should (for now, also NOT) be tested instead.
+         * should be tested instead.
          */
         try ( Connection c = n1.connect() )
         {
@@ -402,7 +401,6 @@ test_script:
          * PG >= 13 CREATE EXTENSION VERSION unpackaged;ALTER EXTENSION UPDATE
          * sequence) has to happen over a new connection.
          */
-        if ( false ) { // pending issue 434 fix
         try ( Connection c = n1.connect() )
         {
           int majorVersion = c.getMetaData().getDatabaseMajorVersion();
@@ -436,7 +434,6 @@ test_script:
             (o,p,q) -> null == o
           );
         }
-        } // pending issue 434 fix
       } catch ( Throwable t )
       {
         succeeding = false;


### PR DESCRIPTION
PL/Java supports a pre-extension, legacy installation method just using the `LOAD` command. It can still have some uses, such as when a DBA does not have write access to the directories where official extension files have to go. And PL/Java has supported later packaging such an 'unpackaged' installation into extension form. (The old PostgreSQL syntax for that, `CREATE EXTENSION FROM unpackaged`, was dropped in PG 13, but an equivalent sequence of steps still works).

That packaging used to rely on `CREATE OR REPLACE` silently absorbing a preexisting object into the current extension. However, since postgres/postgres@b9b21ac, `CREATE OR REPLACE` instead fails if the object exists and is not yet an extension member. Therefore, the few objects for which PL/Java does `CREATE OR REPLACE` within the `InstallHelper.groundwork` method also need to have conditional `ALTER EXTENSION ADD` done in that method first. (Conditional, because in the case where the unpackaged installation might also be an older PL/Java version, some objects we'll `CREATE OR REPLACE` for the current version might not be there yet.)

Only those few objects must be treated that way; `ALTER EXTENSION ADD` for the rest can still be done in the extension update script where anyone would expect.