### PR TITLE
Drop PG < 9.5 conditional code from PL/Java 1.6.x

### DIFF
--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/ConditionalDDR.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/ConditionalDDR.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2015-2023 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -64,7 +64,7 @@ import org.postgresql.pljava.annotation.SQLAction;
  * local, so it is reverted when the transaction completes.
  * <p>
  * In addition to the goodness-of-life examples, this file also generates
- * several statements setting PostgreSQL-version-based implementor tags that
+ * one or more statements setting PostgreSQL-version-based implementor tags that
  * are relied on by various other examples in this directory.
  */
 @SQLAction(provides={"LifeIsGood","LifeIsNotGood"}, install=
@@ -78,51 +78,12 @@ import org.postgresql.pljava.annotation.SQLAction;
 )
 
 @SQLAction(implementor="LifeIsGood", install=
-	"SELECT javatest.logmessage('INFO', 'Looking good!')"
+	"SELECT javatest.logmessage('INFO', 'ConditionlDDR looking good!')"
 )
 
 @SQLAction(implementor="LifeIsNotGood", install=
-	"SELECT javatest.logmessage('WARNING', 'This should not be executed')"
-)
-
-@SQLAction(provides="postgresql_ge_80300", install=
-	"SELECT CASE WHEN" +
-	" 80300 <= CAST(current_setting('server_version_num') AS integer)" +
-	" THEN set_config('pljava.implementors', 'postgresql_ge_80300,' || " +
-	" current_setting('pljava.implementors'), true) " +
-	"END"
-)
-
-@SQLAction(provides="postgresql_ge_80400", install=
-	"SELECT CASE WHEN" +
-	" 80400 <= CAST(current_setting('server_version_num') AS integer)" +
-	" THEN set_config('pljava.implementors', 'postgresql_ge_80400,' || " +
-	" current_setting('pljava.implementors'), true) " +
-	"END"
-)
-
-@SQLAction(provides="postgresql_ge_90000", install=
-	"SELECT CASE WHEN" +
-	" 90000 <= CAST(current_setting('server_version_num') AS integer)" +
-	" THEN set_config('pljava.implementors', 'postgresql_ge_90000,' || " +
-	" current_setting('pljava.implementors'), true) " +
-	"END"
-)
-
-@SQLAction(provides="postgresql_ge_90100", install=
-	"SELECT CASE WHEN" +
-	" 90100 <= CAST(current_setting('server_version_num') AS integer)" +
-	" THEN set_config('pljava.implementors', 'postgresql_ge_90100,' || " +
-	" current_setting('pljava.implementors'), true) " +
-	"END"
-)
-
-@SQLAction(provides="postgresql_ge_90300", install=
-	"SELECT CASE WHEN" +
-	" 90300 <= CAST(current_setting('server_version_num') AS integer)" +
-	" THEN set_config('pljava.implementors', 'postgresql_ge_90300,' || " +
-	" current_setting('pljava.implementors'), true) " +
-	"END"
+	"SELECT javatest.logmessage('WARNING', " +
+	" 'ConditionalDDR: This should not be executed')"
 )
 
 @SQLAction(provides="postgresql_ge_100000", install=

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/Enumeration.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/Enumeration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2015-2023 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -21,16 +21,12 @@ import org.postgresql.pljava.annotation.Function;
 /**
  * Confirms the mapping of PG enum and Java String, and arrays of each, as
  * parameter and return types.
- *<p>
- * This example relies on {@code implementor} tags reflecting the PostgreSQL
- * version, set up in the {@link ConditionalDDR} example. PostgreSQL before 8.3
- * did not have enum types.
  */
-@SQLAction(provides="mood type", implementor="postgresql_ge_80300",
+@SQLAction(provides="mood type",
 	install="CREATE TYPE mood AS ENUM ('sad', 'ok', 'happy')",
 	remove="DROP TYPE mood"
 )
-@SQLAction(implementor="postgresql_ge_80300",
+@SQLAction(
 	requires={"textToMood", "moodToText", "textsToMoods", "moodsToTexts"},
 	install={
 		"SELECT textToMood('happy')",
@@ -41,26 +37,22 @@ import org.postgresql.pljava.annotation.Function;
 )
 public class Enumeration
 {
-	@Function(requires="mood type", provides="textToMood", type="mood",
-			  implementor="postgresql_ge_80300")
+	@Function(requires="mood type", provides="textToMood", type="mood")
 	public static String textToMood(String s)
 	{
 		return s;
 	}
-	@Function(requires="mood type", provides="moodToText",
-			  implementor="postgresql_ge_80300")
+	@Function(requires="mood type", provides="moodToText")
 	public static String moodToText(@SQLType("mood")String s)
 	{
 		return s;
 	}
-	@Function(requires="mood type", provides="textsToMoods", type="mood",
-			  implementor="postgresql_ge_80300")
+	@Function(requires="mood type", provides="textsToMoods", type="mood")
 	public static Iterator<String> textsToMoods(String[] ss)
 	{
 		return Arrays.asList(ss).iterator();
 	}
-	@Function(requires="mood type", provides="moodsToTexts",
-			  implementor="postgresql_ge_80300")
+	@Function(requires="mood type", provides="moodsToTexts")
 	public static Iterator<String> moodsToTexts(@SQLType("mood[]")String[] ss)
 	{
 		return Arrays.asList(ss).iterator();

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/JDBC42_21.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/JDBC42_21.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2022 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2018-2023 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -14,20 +14,15 @@ package org.postgresql.pljava.example.annotation;
 import org.postgresql.pljava.annotation.Function;
 import org.postgresql.pljava.annotation.SQLAction;
 
-import org.postgresql.pljava.example.annotation.ConditionalDDR; // for javadoc
-
 /**
  * Exercise new mappings between date/time types and java.time classes
  * (JDBC 4.2 change 21).
  *<p>
  * Defines a method {@link #javaSpecificationGE javaSpecificationGE} that may be
  * of use for other examples.
- *<p>
- * Relies on PostgreSQL-version-specific implementor tags set up in the
- * {@link ConditionalDDR} example.
  */
 @SQLAction(
-	implementor="postgresql_ge_90300",requires="TypeRoundTripper.roundTrip",
+	requires="TypeRoundTripper.roundTrip",
 	install={
 	" SELECT" +
 	"  CASE WHEN every(orig = roundtripped)" +

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/PGF1010962.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/PGF1010962.java
@@ -10,12 +10,8 @@ import org.postgresql.pljava.annotation.SQLAction;
 /**
  * A gnarly test of TupleDesc reference management, crafted by Johann Oskarsson
  * for bug report 1010962 on pgFoundry.
- *<p>
- * This example relies on {@code implementor} tags reflecting the PostgreSQL
- * version, set up in the {@link ConditionalDDR} example. Before PostgreSQL 8.4,
- * there is no array of {@code RECORD}, which this test requires.
  */
-@SQLAction(requires="1010962 func", implementor="postgresql_ge_80400",
+@SQLAction(requires="1010962 func",
 	install={
 		"CREATE TYPE javatest.B1010962 AS ( b1_val float8, b2_val int)",
 
@@ -51,8 +47,7 @@ public class PGF1010962
 	 * @param receiver Looks polymorphic, but expects an array of A1010962
 	 * @return 0
 	 */
-	@Function(schema="javatest", provides="1010962 func",
-				implementor="postgresql_ge_80400")
+	@Function(schema="javatest", provides="1010962 func")
 	public static int complexParam( ResultSet receiver[] )
 	throws SQLException
 	{

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/PassXML.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/PassXML.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2021 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2018-2023 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -112,16 +112,7 @@ import org.w3c.dom.bootstrap.DOMImplementationRegistry;
 	"END"
 )
 
-@SQLAction(implementor="postgresql_ge_80400",
-	provides="postgresql_xml_ge84",
-	install=
-	"SELECT CASE (SELECT 1 FROM pg_type WHERE typname = 'xml') WHEN 1" +
-	" THEN set_config('pljava.implementors', 'postgresql_xml_ge84,' || " +
-	" current_setting('pljava.implementors'), true) " +
-	"END"
-)
-
-@SQLAction(implementor="postgresql_xml_ge84", requires="echoXMLParameter",
+@SQLAction(implementor="postgresql_xml", requires="echoXMLParameter",
 	install=
 	"WITH" +
 	" s(how) AS (SELECT generate_series(1, 7))," +
@@ -146,7 +137,7 @@ import org.w3c.dom.bootstrap.DOMImplementationRegistry;
 	" r"
 )
 
-@SQLAction(implementor="postgresql_xml_ge84", requires="proxiedXMLEcho",
+@SQLAction(implementor="postgresql_xml", requires="proxiedXMLEcho",
 	install=
 	"WITH" +
 	" s(how) AS (SELECT unnest('{1,2,4,5,6,7}'::int[]))," +
@@ -170,7 +161,7 @@ import org.w3c.dom.bootstrap.DOMImplementationRegistry;
 	" r"
 )
 
-@SQLAction(implementor="postgresql_xml_ge84", requires="lowLevelXMLEcho",
+@SQLAction(implementor="postgresql_xml", requires="lowLevelXMLEcho",
 	install={
 	"SELECT" +
 	" preparexmlschema('schematest', $$" +
@@ -702,7 +693,7 @@ public class PassXML implements SQLData
 	 * still be exercised by calling this method, explicitly passing
 	 * {@code adjust => NULL}.
 	 */
-	@Function(schema="javatest", implementor="postgresql_xml_ge84",
+	@Function(schema="javatest", implementor="postgresql_xml",
 		provides="lowLevelXMLEcho")
 	public static SQLXML lowLevelXMLEcho(
 		SQLXML sx, int how, @SQLType(defaultValue={}) ResultSet adjust)
@@ -1046,12 +1037,9 @@ public class PassXML implements SQLData
 
 	/**
 	 * Text-typed variant of lowLevelXMLEcho (does not require XML type).
-	 *<p>
-	 * It does declare a parameter default, limiting it to PostgreSQL 8.4 or
-	 * later.
 	 */
 	@Function(schema="javatest", name="lowLevelXMLEcho",
-		type="text", implementor="postgresql_ge_80400")
+		type="text")
 	public static SQLXML lowLevelXMLEcho_(@SQLType("text") SQLXML sx, int how,
 		@SQLType(defaultValue={}) ResultSet adjust)
 	throws SQLException

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/PreJSR310.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/PreJSR310.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2021 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2018-2023 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -29,9 +29,6 @@ import org.postgresql.pljava.annotation.SQLAction;
  * Some tests of pre-JSR 310 date/time/timestamp conversions.
  *<p>
  * For now, just {@code java.sql.Date}, thanks to issue #199.
- *<p>
- * This example relies on {@code implementor} tags reflecting the PostgreSQL
- * version, set up in the {@link ConditionalDDR} example.
  */
 @SQLAction(provides="language java_tzset", install={
 	"SELECT sqlj.alias_java_language('java_tzset', true)"
@@ -39,7 +36,7 @@ import org.postgresql.pljava.annotation.SQLAction;
 	"DROP LANGUAGE java_tzset"
 })
 
-@SQLAction(implementor="postgresql_ge_90300", // needs LATERAL
+@SQLAction(
 	requires="issue199", install={
 	"SELECT javatest.issue199()"
 })

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/RecordParameterDefaults.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/RecordParameterDefaults.java
@@ -19,7 +19,6 @@ import static java.util.Arrays.fill;
 
 import org.postgresql.pljava.ResultSetProvider;
 import org.postgresql.pljava.annotation.Function;
-import org.postgresql.pljava.annotation.SQLAction;
 import org.postgresql.pljava.annotation.SQLType;
 
 /**
@@ -29,17 +28,6 @@ import org.postgresql.pljava.annotation.SQLType;
  *<p>
  * Also tests the proper DDR generation of defaults for such parameters.
  */
-@SQLAction(
-	provides = "paramtypeinfo type", // created in Triggers.java
-	install = {
-		"CREATE TYPE javatest.paramtypeinfo AS (" +
-		" name text, pgtypename text, javaclass text, tostring text" +
-		")"
-	},
-	remove = {
-		"DROP TYPE javatest.paramtypeinfo"
-	}
-)
 public class RecordParameterDefaults implements ResultSetProvider
 {
 	/**
@@ -59,10 +47,11 @@ public class RecordParameterDefaults implements ResultSetProvider
 	 *</pre>
 	 */
 	@Function(
-		requires = "paramtypeinfo type",
 		schema = "javatest",
-		type = "javatest.paramtypeinfo"
-		)
+		out = {
+			"name text", "pgtypename text", "javaclass text", "tostring text"
+		}
+	)
 	public static ResultSetProvider paramDefaultsRecord(
 		@SQLType(defaultValue={})ResultSet params)
 	throws SQLException

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/RecordParameterDefaults.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/RecordParameterDefaults.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2018-2023 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -28,9 +28,6 @@ import org.postgresql.pljava.annotation.SQLType;
  * function.
  *<p>
  * Also tests the proper DDR generation of defaults for such parameters.
- *<p>
- * This example relies on {@code implementor} tags reflecting the PostgreSQL
- * version, set up in the {@link ConditionalDDR} example.
  */
 @SQLAction(
 	provides = "paramtypeinfo type", // created in Triggers.java
@@ -64,7 +61,6 @@ public class RecordParameterDefaults implements ResultSetProvider
 	@Function(
 		requires = "paramtypeinfo type",
 		schema = "javatest",
-		implementor = "postgresql_ge_80400", // supports function param DEFAULTs
 		type = "javatest.paramtypeinfo"
 		)
 	public static ResultSetProvider paramDefaultsRecord(
@@ -87,7 +83,6 @@ public class RecordParameterDefaults implements ResultSetProvider
 	 */
 	@Function(
 		requires = "foobar tables", // created in Triggers.java
-		implementor = "postgresql_ge_80400", // supports function param DEFAULTs
 		schema = "javatest"
 		)
 	public static String paramDefaultsNamedRow(

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/SetOfRecordTest.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/SetOfRecordTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2020 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2023 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -26,12 +26,8 @@ import org.postgresql.pljava.annotation.SQLAction;
  * Example implementing the {@code ResultSetHandle} interface, to return
  * the {@link ResultSet} from any SQL {@code SELECT} query passed as a string
  * to the {@link #executeSelect executeSelect} function.
- *<p>
- * This example relies on {@code implementor} tags reflecting the PostgreSQL
- * version, set up in the {@link ConditionalDDR} example. Before PostgreSQL 8.4,
- * there was no {@code =} or {@code DISTINCT FROM} operator between row types.
  */
-@SQLAction(requires="selecttorecords fn", implementor="postgresql_ge_80400",
+@SQLAction(requires="selecttorecords fn",
 install=
 " SELECT " +
 "  CASE WHEN r IS DISTINCT FROM ROW('Foo'::varchar, 1::integer, 1.5::float, " +

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/Triggers.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/Triggers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2020 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2023 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -38,8 +38,8 @@ import static org.postgresql.pljava.example.LoggerTest.logMessage;
  * also create a function and trigger that uses transition tables.
  *<p>
  * This example relies on {@code implementor} tags reflecting the PostgreSQL
- * version, set up in the {@link ConditionalDDR} example. Constraint triggers
- * appear in PG 9.1, transition tables in PG 10.
+ * version, set up in the {@link ConditionalDDR} example. Transition tables
+ * appear in PG 10.
  */
 @SQLAction(
 	provides = "foobar tables",
@@ -135,10 +135,8 @@ public class Triggers
 
 	/**
 	 * Throw exception if value to be inserted is 44.
-	 * Constraint triggers first became available in PostgreSQL 9.1.
 	 */
 	@Function(
-		implementor = "postgresql_ge_90100",
 		requires = "foobar tables",
 		provides = "constraint triggers",
 		schema = "javatest",

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/TypeRoundTripper.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/TypeRoundTripper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2018-2023 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -35,8 +35,6 @@ import java.util.Arrays;
 import org.postgresql.pljava.annotation.Function;
 import org.postgresql.pljava.annotation.SQLAction;
 import org.postgresql.pljava.annotation.SQLType;
-
-import org.postgresql.pljava.example.annotation.ConditionalDDR; // for javadoc
 
 /**
  * A class to simplify testing of PL/Java's mappings between PostgreSQL and
@@ -94,11 +92,8 @@ import org.postgresql.pljava.example.annotation.ConditionalDDR; // for javadoc
  *  (VALUES (timestamptz '2017-08-21 18:25:29.900005Z')) AS p(orig),
  *  roundtrip(p) AS (roundtripped timestamptz);
  *</pre>
- *<p>
- * This example relies on {@code implementor} tags reflecting the PostgreSQL
- * version, set up in the {@link ConditionalDDR} example.
  */
-@SQLAction(implementor = "postgresql_ge_90300", // funcs see earlier FROM items
+@SQLAction(
 	requires = {"TypeRoundTripper.roundTrip", "point mirror type"},
 	install = {
 	" SELECT" +
@@ -309,8 +304,7 @@ public class TypeRoundTripper
 	@Function(
 		schema = "javatest",
 		type = "RECORD",
-		provides = "TypeRoundTripper.roundTrip",
-		implementor = "postgresql_ge_80400" // supports function param DEFAULTs
+		provides = "TypeRoundTripper.roundTrip"
 		)
 	public static boolean roundTrip(
 		ResultSet in, @SQLType(defaultValue="") String classname,

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/UnicodeRoundTripTest.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/UnicodeRoundTripTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2020 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2015-2023 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -35,11 +35,10 @@ import org.postgresql.pljava.annotation.Function;
  * if {@code matched} is false or the original and returned arrays or strings
  * do not match as seen in SQL.
  * <p>
- * This example relies on {@code implementor} tags reflecting the PostgreSQL
- * version, set up in the {@link ConditionalDDR} example, and also sets its own.
+ * This example sets an {@code implementor} tag based on a PostgreSQL condition,
+ * as further explained in the {@link ConditionalDDR} example.
  */
-@SQLAction(provides="postgresql_unicodetest",
-	implementor="postgresql_ge_90000", install=
+@SQLAction(provides="postgresql_unicodetest", install=
 	"SELECT CASE" +
 	" WHEN 'UTF8' = current_setting('server_encoding')" +
 	" THEN set_config('pljava.implementors', 'postgresql_unicodetest,' ||" +

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/UnicodeRoundTripTest.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/UnicodeRoundTripTest.java
@@ -48,50 +48,43 @@ import org.postgresql.pljava.annotation.Function;
 @SQLAction(requires="unicodetest fn",
 implementor="postgresql_unicodetest",
 install=
-"   with " +
-"    usable_codepoints ( cp ) as ( " +
-"     select generate_series(1,x'd7ff'::int) " +
-"     union all " +
-"     select generate_series(x'e000'::int,x'10ffff'::int) " +
+"   WITH " +
+"    usable_codepoints ( cp ) AS ( " +
+"     SELECT generate_series(1,x'd7ff'::int) " +
+"     UNION ALL " +
+"     SELECT generate_series(x'e000'::int,x'10ffff'::int) " +
 "    ), " +
-"    test_inputs ( groupnum, cparray, s ) as ( " +
-"     select " +
-"       cp / 1024 as groupnum, " +
-"       array_agg(cp order by cp), string_agg(chr(cp), '' order by cp) " +
-"     from usable_codepoints " +
-"     group by groupnum " +
+"    test_inputs ( groupnum, cparray, s ) AS ( " +
+"     SELECT " +
+"       cp / 1024 AS groupnum, " +
+"       array_agg(cp ORDER BY cp), string_agg(chr(cp), '' ORDER BY cp) " +
+"     FROM usable_codepoints " +
+"     GROUP BY groupnum " +
 "    ), " +
-"    test_outputs as ( " +
-"     select groupnum, cparray, s, unicodetest(s, cparray) as roundtrip " +
-"     from test_inputs " +
+"    test_outputs AS ( " +
+"     SELECT groupnum, cparray, s, unicodetest(s, cparray) AS roundtrip " +
+"     FROM test_inputs " +
 "    ), " +
-"    test_failures as ( " +
-"     select * " +
-"     from test_outputs " +
-"     where " +
-"      cparray != (roundtrip).cparray or s != (roundtrip).s " +
-"      or not (roundtrip).matched " +
+"    test_failures AS ( " +
+"     SELECT * " +
+"     FROM test_outputs " +
+"     WHERE " +
+"      cparray != (roundtrip).cparray OR s != (roundtrip).s " +
+"      OR NOT (roundtrip).matched " +
 "    ), " +
-"    test_summary ( n_failing_groups, first_failing_group ) as ( " +
-"     select count(*), min(groupnum) from test_failures " +
+"    test_summary ( n_failing_groups, first_failing_group ) AS ( " +
+"     SELECT count(*), min(groupnum) FROM test_failures " +
 "    ) " +
-"   select " +
-"    case when n_failing_groups > 0 then " +
+"   SELECT " +
+"    CASE WHEN n_failing_groups > 0 THEN " +
 "     javatest.logmessage('WARNING', n_failing_groups || " +
 "      ' 1k codepoint ranges had mismatches, first is block starting 0x' || " +
 "      to_hex(1024 * first_failing_group)) " +
-"    else " +
+"    ELSE " +
 "     javatest.logmessage('INFO', " +
 "        'all Unicode codepoint ranges roundtripped successfully.') " +
-"    end " +
-"    from test_summary"
-)
-@SQLAction(
-	install=
-		"CREATE TYPE unicodetestrow AS " +
-		"(matched boolean, cparray integer[], s text)",
-	remove="DROP TYPE unicodetestrow",
-	provides="unicodetestrow type"
+"    END " +
+"    FROM test_summary"
 )
 public class UnicodeRoundTripTest {
 	/**
@@ -110,8 +103,8 @@ public class UnicodeRoundTripTest {
 	 * @param rs OUT (matched, cparray, s) as described above
 	 * @return true to indicate the OUT tuple is not null
 	 */
-	@Function(type="unicodetestrow",
-		requires="unicodetestrow type", provides="unicodetest fn")
+	@Function(out={"matched boolean", "cparray integer[]", "s text"},
+		provides="unicodetest fn")
 	public static boolean unicodetest(String s, int[] ints, ResultSet rs)
 	throws SQLException {
 		boolean ok = true;

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/VarlenaUDTTest.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/VarlenaUDTTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015- Tada AB and other contributors, as listed below.
+ * Copyright (c) 2015-2023 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -29,14 +29,12 @@ import static org.postgresql.pljava.annotation.Function.Effects.IMMUTABLE;
  * characters. That makes it easy to test how big a value gets correctly stored
  * and retrieved. It should be about a GB, but in issue 52 was failing at 32768
  * because of a narrowing assignment in the native code.
- *<p>
- * This example relies on {@code implementor} tags reflecting the PostgreSQL
- * version, set up in the {@link ConditionalDDR} example.
  */
-@SQLAction(requires="varlena UDT", implementor="postgresql_ge_80300", install=
+@SQLAction(requires="varlena UDT", install=
 "  SELECT CASE v::text = v::javatest.VarlenaUDTTest::text " +
-"   WHEN true THEN javatest.logmessage('INFO', 'works for ' || v) " +
-"   ELSE javatest.logmessage('WARNING', 'fails for ' || v) " +
+"   WHEN true " +
+"   THEN javatest.logmessage('INFO', 'VarlenaUDTTest works for ' || v) " +
+"   ELSE javatest.logmessage('WARNING', 'VarlenaUDTTest fails for ' || v) " +
 "   END " +
 "   FROM (VALUES (('32767')), (('32768')), (('65536')), (('1048576'))) " +
 "   AS t ( v )"

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/XMLRenderedTypes.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/XMLRenderedTypes.java
@@ -28,9 +28,22 @@ import static org.postgresql.pljava.example.LoggerTest.logMessage;
  * Everything mentioning the type XML here needs a conditional implementor tag
  * in case of being loaded into a PostgreSQL instance built without that type.
  */
+@SQLAction(implementor="postgresql_xml", requires="pgNodeTreeAsXML", install=
+"WITH" +
+"  a(t) AS (SELECT adbin FROM pg_catalog.pg_attrdef LIMIT 1)" +
+" SELECT" +
+"   CASE WHEN pgNodeTreeAsXML(t) IS DOCUMENT" +
+"    THEN javatest.logmessage('INFO', 'pgNodeTreeAsXML ok')" +
+"    ELSE javatest.logmessage('WARNING', 'pgNodeTreeAsXML ng')" +
+"   END" +
+"  FROM a"
+)
 public class XMLRenderedTypes
 {
-	@Function(schema="javatest", implementor="postgresql_xml")
+	@Function(
+		schema="javatest", implementor="postgresql_xml",
+		provides="pgNodeTreeAsXML"
+	)
 	public static SQLXML pgNodeTreeAsXML(@SQLType("pg_node_tree") SQLXML pgt)
 	throws SQLException
 	{

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/XMLRenderedTypes.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/XMLRenderedTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2020 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2019-2023 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -27,19 +27,10 @@ import static org.postgresql.pljava.example.LoggerTest.logMessage;
  *<p>
  * Everything mentioning the type XML here needs a conditional implementor tag
  * in case of being loaded into a PostgreSQL instance built without that type.
- * The {@code pg_node_tree} type appears in 9.1.
  */
-@SQLAction(implementor="postgresql_ge_90100",
-	provides="postgresql_xml_ge91",
-	install=
-	"SELECT CASE (SELECT 1 FROM pg_type WHERE typname = 'xml') WHEN 1" +
-	" THEN set_config('pljava.implementors', 'postgresql_xml_ge91,' || " +
-	" current_setting('pljava.implementors'), true) " +
-	"END"
-)
 public class XMLRenderedTypes
 {
-	@Function(schema="javatest", implementor="postgresql_xml_ge91")
+	@Function(schema="javatest", implementor="postgresql_xml")
 	public static SQLXML pgNodeTreeAsXML(@SQLType("pg_node_tree") SQLXML pgt)
 	throws SQLException
 	{

--- a/pljava-so/src/main/c/Backend.c
+++ b/pljava-so/src/main/c/Backend.c
@@ -23,6 +23,7 @@
 #include <fmgr.h>
 #include <access/heapam.h>
 #include <utils/syscache.h>
+#include <utils/timeout.h>
 #include <catalog/catalog.h>
 #include <catalog/pg_proc.h>
 #include <catalog/pg_type.h>
@@ -57,10 +58,6 @@
 #include "pljava/Session.h"
 #include "pljava/SPI.h"
 #include "pljava/type/String.h"
-
-#if PG_VERSION_NUM >= 90300
-#include "utils/timeout.h"
-#endif
 
 /* Include the 'magic block' that PostgreSQL 8.2 and up will use to ensure
  * that a module is not loaded into an incompatible server.
@@ -250,152 +247,133 @@ static bool javaGE17 = false;
 
 static void initsequencer(enum initstage is, bool tolerant);
 
-#if PG_VERSION_NUM >= 90100
-	static bool check_libjvm_location(
-		char **newval, void **extra, GucSource source);
-	static bool check_vmoptions(
-		char **newval, void **extra, GucSource source);
-	static bool check_modulepath(
-		char **newval, void **extra, GucSource source);
-	static bool check_policy_urls(
-		char **newval, void **extra, GucSource source);
-	static bool check_enabled(
-		bool *newval, void **extra, GucSource source);
-	static bool check_java_thread_pg_entry(
-		int *newval, void **extra, GucSource source);
+static bool check_libjvm_location(
+	char **newval, void **extra, GucSource source);
+static bool check_vmoptions(
+	char **newval, void **extra, GucSource source);
+static bool check_modulepath(
+	char **newval, void **extra, GucSource source);
+static bool check_policy_urls(
+	char **newval, void **extra, GucSource source);
+static bool check_enabled(
+	bool *newval, void **extra, GucSource source);
+static bool check_java_thread_pg_entry(
+	int *newval, void **extra, GucSource source);
 
-	/* Check hooks will always allow "setting" a value that is the same as
-	 * current; otherwise, it would be frustrating to have just found settings
-	 * that work, and be unable to save them with ALTER DATABASE SET ... because
-	 * the check hook is called for that too, and would say it is too late....
-	 */
+/* Check hooks will always allow "setting" a value that is the same as
+ * current; otherwise, it would be frustrating to have just found settings
+ * that work, and be unable to save them with ALTER DATABASE SET ... because
+ * the check hook is called for that too, and would say it is too late....
+ */
 
-	static bool check_libjvm_location(
-		char **newval, void **extra, GucSource source)
-	{
-		if ( initstage < IS_CAND_JVMOPENED )
-			return true;
-		if ( libjvmlocation == *newval )
-			return true;
-		if ( libjvmlocation && *newval && 0 == strcmp(libjvmlocation, *newval) )
-			return true;
-		GUC_check_errmsg(
-			"too late to change \"pljava.libjvm_location\" setting");
-		GUC_check_errdetail(
-			"Changing the setting can have no effect after "
-			"PL/Java has found and opened the library it points to.");
-		GUC_check_errhint(
-			"To try a different value, exit this session and start a new one.");
-		return false;
-	}
+static bool check_libjvm_location(
+	char **newval, void **extra, GucSource source)
+{
+	if ( initstage < IS_CAND_JVMOPENED )
+		return true;
+	if ( libjvmlocation == *newval )
+		return true;
+	if ( libjvmlocation && *newval && 0 == strcmp(libjvmlocation, *newval) )
+		return true;
+	GUC_check_errmsg(
+		"too late to change \"pljava.libjvm_location\" setting");
+	GUC_check_errdetail(
+		"Changing the setting can have no effect after "
+		"PL/Java has found and opened the library it points to.");
+	GUC_check_errhint(
+		"To try a different value, exit this session and start a new one.");
+	return false;
+}
 
-	static bool check_vmoptions(
-		char **newval, void **extra, GucSource source)
-	{
-		if ( initstage < IS_JAVAVM_OPTLIST )
-			return true;
-		if ( vmoptions == *newval )
-			return true;
-		if ( vmoptions && *newval && 0 == strcmp(vmoptions, *newval) )
-			return true;
-		GUC_check_errmsg(
-			"too late to change \"pljava.vmoptions\" setting");
-		GUC_check_errdetail(
-			"Changing the setting can have no effect after "
-			"PL/Java has started the Java virtual machine.");
-		GUC_check_errhint(
-			"To try a different value, exit this session and start a new one.");
-		return false;
-	}
+static bool check_vmoptions(
+	char **newval, void **extra, GucSource source)
+{
+	if ( initstage < IS_JAVAVM_OPTLIST )
+		return true;
+	if ( vmoptions == *newval )
+		return true;
+	if ( vmoptions && *newval && 0 == strcmp(vmoptions, *newval) )
+		return true;
+	GUC_check_errmsg(
+		"too late to change \"pljava.vmoptions\" setting");
+	GUC_check_errdetail(
+		"Changing the setting can have no effect after "
+		"PL/Java has started the Java virtual machine.");
+	GUC_check_errhint(
+		"To try a different value, exit this session and start a new one.");
+	return false;
+}
 
-	static bool check_modulepath(
-		char **newval, void **extra, GucSource source)
-	{
-		if ( initstage < IS_JAVAVM_OPTLIST )
-			return true;
-		if ( modulepath == *newval )
-			return true;
-		if ( modulepath && *newval && 0 == strcmp(modulepath, *newval) )
-			return true;
-		GUC_check_errmsg(
-			"too late to change \"pljava.module_path\" setting");
-		GUC_check_errdetail(
-			"Changing the setting has no effect after "
-			"PL/Java has started the Java virtual machine.");
-		GUC_check_errhint(
-			"To try a different value, exit this session and start a new one.");
-		return false;
-	}
+static bool check_modulepath(
+	char **newval, void **extra, GucSource source)
+{
+	if ( initstage < IS_JAVAVM_OPTLIST )
+		return true;
+	if ( modulepath == *newval )
+		return true;
+	if ( modulepath && *newval && 0 == strcmp(modulepath, *newval) )
+		return true;
+	GUC_check_errmsg(
+		"too late to change \"pljava.module_path\" setting");
+	GUC_check_errdetail(
+		"Changing the setting has no effect after "
+		"PL/Java has started the Java virtual machine.");
+	GUC_check_errhint(
+		"To try a different value, exit this session and start a new one.");
+	return false;
+}
 
-	static bool check_policy_urls(
-		char **newval, void **extra, GucSource source)
-	{
-		if ( initstage < IS_JAVAVM_OPTLIST )
-			return true;
-		if ( policy_urls == *newval )
-			return true;
-		if ( policy_urls && *newval && 0 == strcmp(policy_urls, *newval) )
-			return true;
-		GUC_check_errmsg(
-			"too late to change \"pljava.policy_urls\" setting");
-		GUC_check_errdetail(
-			"Changing the setting has no effect after "
-			"PL/Java has started the Java virtual machine.");
-		GUC_check_errhint(
-			"To try a different value, exit this session and start a new one.");
-		return false;
-	}
+static bool check_policy_urls(
+	char **newval, void **extra, GucSource source)
+{
+	if ( initstage < IS_JAVAVM_OPTLIST )
+		return true;
+	if ( policy_urls == *newval )
+		return true;
+	if ( policy_urls && *newval && 0 == strcmp(policy_urls, *newval) )
+		return true;
+	GUC_check_errmsg(
+		"too late to change \"pljava.policy_urls\" setting");
+	GUC_check_errdetail(
+		"Changing the setting has no effect after "
+		"PL/Java has started the Java virtual machine.");
+	GUC_check_errhint(
+		"To try a different value, exit this session and start a new one.");
+	return false;
+}
 
-	static bool check_enabled(
-		bool *newval, void **extra, GucSource source)
-	{
-		if ( initstage < IS_PLJAVA_ENABLED )
-			return true;
-		if ( *newval )
-			return true;
-		GUC_check_errmsg(
-			"too late to change \"pljava.enable\" setting");
-		GUC_check_errdetail(
-			"Start-up has progressed past the point where it is checked.");
-		GUC_check_errhint(
-			"For another chance, exit this session and start a new one.");
-		return false;
-	}
+static bool check_enabled(
+	bool *newval, void **extra, GucSource source)
+{
+	if ( initstage < IS_PLJAVA_ENABLED )
+		return true;
+	if ( *newval )
+		return true;
+	GUC_check_errmsg(
+		"too late to change \"pljava.enable\" setting");
+	GUC_check_errdetail(
+		"Start-up has progressed past the point where it is checked.");
+	GUC_check_errhint(
+		"For another chance, exit this session and start a new one.");
+	return false;
+}
 
-	static bool check_java_thread_pg_entry(
-		int *newval, void **extra, GucSource source)
-	{
-		if ( initstage < IS_PLJAVA_FOUND )
-			return true;
-		if ( java_thread_pg_entry == *newval )
-			return true;
-		GUC_check_errmsg(
-			"too late to change \"pljava.java_thread_pg_entry\" setting");
-		GUC_check_errdetail(
-			"Start-up has progressed past the point where it is checked.");
-		GUC_check_errhint(
-			"For another chance, exit this session and start a new one.");
-		return false;
-	}
-#endif
+static bool check_java_thread_pg_entry(
+	int *newval, void **extra, GucSource source)
+{
+	if ( initstage < IS_PLJAVA_FOUND )
+		return true;
+	if ( java_thread_pg_entry == *newval )
+		return true;
+	GUC_check_errmsg(
+		"too late to change \"pljava.java_thread_pg_entry\" setting");
+	GUC_check_errdetail(
+		"Start-up has progressed past the point where it is checked.");
+	GUC_check_errhint(
+		"For another chance, exit this session and start a new one.");
+	return false;
+}
 
-#if PG_VERSION_NUM < 90100
-#define errdetail_internal errdetail
-#define ASSIGNHOOK(name,type) \
-	static bool \
-	CppConcat(assign_,name)(type newval, bool doit, GucSource source); \
-	static bool \
-	CppConcat(assign_,name)(type newval, bool doit, GucSource source)
-#define ASSIGNRETURN(thing) return (thing)
-#define ASSIGNRETURNIFCHECK(thing) if (doit) ; else return (thing)
-#define ASSIGNRETURNIFNXACT(thing) \
-	if (! deferInit && pljavaViableXact()) ; else return (thing)
-#define ASSIGNSTRINGHOOK(name) \
-	static const char * \
-	CppConcat(assign_,name)(const char *newval, bool doit, GucSource source); \
-	static const char * \
-	CppConcat(assign_,name)(const char *newval, bool doit, GucSource source)
-#else
 #define ASSIGNHOOK(name,type) \
 	static void \
 	CppConcat(assign_,name)(type newval, void *extra); \
@@ -406,7 +384,6 @@ static void initsequencer(enum initstage is, bool tolerant);
 #define ASSIGNRETURNIFNXACT(thing) \
 	if (! deferInit && pljavaViableXact()) ; else return
 #define ASSIGNSTRINGHOOK(name) ASSIGNHOOK(name, const char *)
-#endif
 
 #define ASSIGNENUMHOOK(name) ASSIGNHOOK(name,int)
 #define ENUMBOOTVAL(entry) ((entry).val)
@@ -796,18 +773,13 @@ static void initsequencer(enum initstage is, bool tolerant)
 			 * are just function parameters with evaluation order unknown.
 			 */
 			StringInfoData buf;
-#if PG_VERSION_NUM >= 90200
-#define MOREHINT \
-				appendStringInfo(&buf, \
-					"using ALTER DATABASE %s SET ... FROM CURRENT or ", \
-					pljavaDbName()),
-#else
-#define MOREHINT
-#endif
+
 			ereport(NOTICE, (
 				errmsg("PL/Java successfully started after adjusting settings"),
 				(initStringInfo(&buf),
-				MOREHINT
+				appendStringInfo(&buf, \
+					"using ALTER DATABASE %s SET ... FROM CURRENT or ", \
+					pljavaDbName()),
 				errhint("The settings that worked should be saved (%s"
 					"in the \"%s\" file). For a reminder of what has been set, "
 					"try: SELECT name, setting FROM pg_settings WHERE name LIKE"
@@ -816,7 +788,7 @@ static void initsequencer(enum initstage is, bool tolerant)
 					superuser()
 						? PG_GETCONFIGOPTION("config_file")
 						: "postgresql.conf"))));
-#undef MOREHINT
+
 			if ( loadAsExtensionFailed )
 			{
 #if PG_VERSION_NUM < 130000
@@ -902,7 +874,7 @@ static void reLogWithChangedLevel(int level)
 	else if ( ERRCODE_WARNING == category || ERRCODE_NO_DATA == category ||
 		ERRCODE_SUCCESSFUL_COMPLETION == category )
 		sqlstate = ERRCODE_INTERNAL_ERROR;
-#if PG_VERSION_NUM >= 90500
+
 	edata->elevel = level;
 	edata->sqlerrcode = sqlstate;
 	PG_TRY();
@@ -916,43 +888,6 @@ static void reLogWithChangedLevel(int level)
 	}
 	PG_END_TRY();
 	FreeErrorData(edata);
-#else
-	if (!errstart(level, edata->filename, edata->lineno,
-				  edata->funcname, NULL))
-	{
-		FreeErrorData(edata);
-		return;
-	}
-
-	errcode(sqlstate);
-	if (edata->message)
-		errmsg("%s", edata->message);
-	if (edata->detail)
-		errdetail("%s", edata->detail);
-	if (edata->detail_log)
-		errdetail_log("%s", edata->detail_log);
-	if (edata->hint)
-		errhint("%s", edata->hint);
-	if (edata->context)
-		errcontext("%s", edata->context); /* this may need to be trimmed */
-#if PG_VERSION_NUM >= 90300
-	if (edata->schema_name)
-		err_generic_string(PG_DIAG_SCHEMA_NAME, edata->schema_name);
-	if (edata->table_name)
-		err_generic_string(PG_DIAG_TABLE_NAME, edata->table_name);
-	if (edata->column_name)
-		err_generic_string(PG_DIAG_COLUMN_NAME, edata->column_name);
-	if (edata->datatype_name)
-		err_generic_string(PG_DIAG_DATATYPE_NAME, edata->datatype_name);
-	if (edata->constraint_name)
-		err_generic_string(PG_DIAG_CONSTRAINT_NAME, edata->constraint_name);
-#endif
-	if (edata->internalquery)
-		internalerrquery(edata->internalquery);
-
-	FreeErrorData(edata);
-	errfinish(0);
-#endif
 }
 
 void _PG_init()
@@ -969,8 +904,7 @@ void _PG_init()
 	 * preparing the launch options before it is launched. PostgreSQL knows what
 	 * it is, but won't directly say; give it some choices and it'll pick one.
 	 * Alternatively, let Maven or Ant determine and add a -D at build time from
-	 * the path.separator property. Maybe that's cleaner? This only works for
-	 * PG_VERSION_NUM >= 90100.
+	 * the path.separator property. Maybe that's cleaner?
 	 */
 	sep = first_path_var_separator(":;");
 	if ( NULL == sep )
@@ -1340,12 +1274,7 @@ static void pljavaQuickDieHandler(int signum)
 }
 
 static sigjmp_buf recoverBuf;
-static void terminationTimeoutHandler(
-#if PG_VERSION_NUM >= 90300
-#else
-	int signum
-#endif
-)
+static void terminationTimeoutHandler()
 {
 	kill(MyProcPid, SIGQUIT);
 	
@@ -1387,12 +1316,7 @@ static void _destroyJavaVM(int status, Datum dummy)
 	{
 		Invocation ctx;
 #ifdef USE_PLJAVA_SIGHANDLERS
-
-#if PG_VERSION_NUM >= 90300
 		TimeoutId tid;
-#else
-		pqsigfunc saveSigAlrm;
-#endif
 
 		Invocation_pushBootContext(&ctx);
 		if(sigsetjmp(recoverBuf, 1) != 0)
@@ -1404,24 +1328,13 @@ static void _destroyJavaVM(int status, Datum dummy)
 			return;
 		}
 
-#if PG_VERSION_NUM >= 90300
 		tid = RegisterTimeout(USER_TIMEOUT, terminationTimeoutHandler);
 		enable_timeout_after(tid, 5000);
-#else
-		saveSigAlrm = pqsignal(SIGALRM, terminationTimeoutHandler);
-		enable_sig_alarm(5000, false);
-#endif
 
 		elog(DEBUG2, "shutting down the Java virtual machine");
 		JNI_destroyVM(s_javaVM);
 
-#if PG_VERSION_NUM >= 90300
 		disable_timeout(tid, false);
-#else
-		disable_sig_alarm(false);
-		pqsignal(SIGALRM, saveSigAlrm);
-#endif
-
 #else
 		Invocation_pushBootContext(&ctx);
 		elog(DEBUG2, "shutting down the Java virtual machine");
@@ -1646,12 +1559,7 @@ static jint initializeJavaVM(JVMOptList *optList)
 #define GUCBOOTVAL(v) (v),
 #define GUCBOOTASSIGN(a, v)
 #define GUCFLAGS(f) (f),
-
-#if PG_VERSION_NUM >= 90100
 #define GUCCHECK(h) (h),
-#else
-#define GUCCHECK(h)
-#endif
 
 #define BOOL_GUC(name, short_desc, long_desc, valueAddr, bootValue, context, \
                  flags, check_hook, assign_hook, show_hook) \
@@ -1685,11 +1593,7 @@ static jint initializeJavaVM(JVMOptList *optList)
 #define PLJAVA_LIBJVMDEFAULT "libjvm"
 #endif
 
-#if PG_VERSION_NUM >= 90200
 #define PLJAVA_ENABLE_DEFAULT true
-#else
-#define PLJAVA_ENABLE_DEFAULT false
-#endif
 
 #if PG_VERSION_NUM < 110000
 #define PLJAVA_IMPLEMENTOR_FLAGS GUC_LIST_INPUT | GUC_LIST_QUOTE

--- a/pljava-so/src/main/c/DualState.c
+++ b/pljava-so/src/main/c/DualState.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2019 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2018-2023 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -43,10 +43,6 @@ extern void pljava_ExecutionPlan_initialize(void);
 #include "pljava/type/TupleDesc.h"
 #include "pljava/SQLInputFromTuple.h"
 #include "pljava/VarlenaWrapper.h"
-
-#if PG_VERSION_NUM < 80400
-#include <access/heapam.h> /* heap_freetuple was there then */
-#endif
 
 static jclass s_DualState_class;
 

--- a/pljava-so/src/main/c/Exception.c
+++ b/pljava-so/src/main/c/Exception.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2021 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2023 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -59,7 +59,13 @@ Exception_featureNotSupported(const char* requestedFeature, const char* introVer
 		appendStringInfoString(&buf, requestedFeature);
 		appendStringInfoString(&buf, " lacks support in PostgreSQL version ");
 		appendStringInfo(&buf, "%d.%d",
-						PG_VERSION_NUM / 10000, (PG_VERSION_NUM / 100) % 100);
+						PG_VERSION_NUM / 10000,
+#if PG_VERSION_NUM >= 100000
+						(PG_VERSION_NUM) % 10000
+#else
+						(PG_VERSION_NUM / 100) % 100
+#endif
+		);
 		appendStringInfoString(&buf, ". It was introduced in version ");
 		appendStringInfoString(&buf, introVersion);
 	

--- a/pljava-so/src/main/c/ExecutionPlan.c
+++ b/pljava-so/src/main/c/ExecutionPlan.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2019 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2023 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -278,9 +278,7 @@ JNIEXPORT jobject JNICALL
 Java_org_postgresql_pljava_internal_ExecutionPlan__1prepare(JNIEnv* env, jclass clazz, jobject key, jstring jcmd, jobjectArray paramTypes)
 {
 	jobject result = 0;
-#if PG_VERSION_NUM >= 90200
 	int spi_ret;
-#endif
 	BEGIN_NATIVE
 	STACK_BASE_VARS
 	STACK_BASE_PUSH(env)
@@ -321,16 +319,12 @@ Java_org_postgresql_pljava_internal_ExecutionPlan__1prepare(JNIEnv* env, jclass 
 			/* Make the plan durable
 			 */
 			p2l.longVal = 0L; /* ensure that the rest is zeroed out */
-#if PG_VERSION_NUM >= 90200
 			spi_ret = SPI_keepplan(ePlan);
 			if ( 0 == spi_ret )
 				p2l.ptrVal = ePlan;
 			else
 				Exception_throwSPI("keepplan", spi_ret);
-#else
-			p2l.ptrVal = SPI_saveplan(ePlan);
-			SPI_freeplan(ePlan); /* Get rid of original, nobody can see it */
-#endif
+
 			result = JNI_newObjectLocked(
 				s_ExecutionPlan_class, s_ExecutionPlan_init,
 				/* (jlong)0 as resource owner: the saved plan isn't transient */

--- a/pljava-so/src/main/c/Function.c
+++ b/pljava-so/src/main/c/Function.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2023 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -40,15 +40,6 @@
 #endif
 
 #define PARAM_OIDS(procStruct) (procStruct)->proargtypes.values
-
-#if 90305<=PG_VERSION_NUM || \
-	90209<=PG_VERSION_NUM && PG_VERSION_NUM<90300 || \
-	90114<=PG_VERSION_NUM && PG_VERSION_NUM<90200 || \
-	90018<=PG_VERSION_NUM && PG_VERSION_NUM<90100 || \
-	80422<=PG_VERSION_NUM && PG_VERSION_NUM<90000
-#else
-#error "Need fallback for heap_copy_tuple_as_datum"
-#endif
 
 #define COUNTCHECK(refs, prims) ((jshort)(((refs) << 8) | ((prims) & 0xff)))
 

--- a/pljava-so/src/main/c/SPI.c
+++ b/pljava-so/src/main/c/SPI.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2019 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2023 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -94,13 +94,18 @@ void SPI_initialize(void)
 	CONFIRMCONST(SPI_OK_INSERT_RETURNING);
 	CONFIRMCONST(SPI_OK_DELETE_RETURNING);
 	CONFIRMCONST(SPI_OK_UPDATE_RETURNING);
-#if PG_VERSION_NUM >= 80400
 	CONFIRMCONST(SPI_OK_REWRITTEN);
-#endif
 #if PG_VERSION_NUM >= 100000
 	CONFIRMCONST(SPI_OK_REL_REGISTER);
 	CONFIRMCONST(SPI_OK_REL_UNREGISTER);
 	CONFIRMCONST(SPI_OK_TD_REGISTER);
+#endif
+#if PG_VERSION_NUM >= 150000
+	CONFIRMCONST(SPI_OK_MERGE);
+#endif
+
+#if PG_VERSION_NUM >= 110000
+	CONFIRMCONST(SPI_OPT_NONATOMIC);
 #endif
 }
 

--- a/pljava-so/src/main/c/Session.c
+++ b/pljava-so/src/main/c/Session.c
@@ -1,10 +1,14 @@
 /*
- * Copyright (c) 2004, 2005, 2006 TADA AB - Taby Sweden
- * Distributed under the terms shown in the file COPYRIGHT
- * found in the root folder of this project or at
- * http://eng.tada.se/osprojects/COPYRIGHT.html
+ * Copyright (c) 2004-2023 Tada AB and other contributors, as listed below.
  *
- * @author Thomas Hallgren
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Tada AB
+ *   Chapman Flack
  */
 #include <postgres.h>
 #include <miscadmin.h>
@@ -45,9 +49,6 @@ Java_org_postgresql_pljava_internal_Session__1setUser(
 	 * a finally block after an exception.
 	 */
 	BEGIN_NATIVE_NO_ERRCHECK
-#if 80402<=PG_VERSION_NUM || \
-	80309<=PG_VERSION_NUM && PG_VERSION_NUM<80400 || \
-	80215<=PG_VERSION_NUM && PG_VERSION_NUM<80300
 	if (InSecurityRestrictedOperation())
 		ereport(ERROR,	(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE), errmsg(
 			"cannot set parameter \"%s\" within security-restricted operation",
@@ -59,15 +60,6 @@ Java_org_postgresql_pljava_internal_Session__1setUser(
 	else
 		secContext &= ~SECURITY_LOCAL_USERID_CHANGE;
 	SetUserIdAndSecContext(AclId_getAclId(aclId), secContext);
-#elif PG_VERSION_NUM>=80206
-	(void)secContext; /* away with your unused-variable warnings! */
-	GetUserIdAndContext(&dummy, &wasLocalChange);
-	SetUserIdAndContext(AclId_getAclId(aclId), (bool)isLocalChange);
-#else
-	(void)secContext;
-	(void)dummy;
-	SetUserId(AclId_getAclId(aclId));
-#endif
 	END_NATIVE
 	return wasLocalChange ? JNI_TRUE : JNI_FALSE;
 }

--- a/pljava-so/src/main/c/TypeOid.c
+++ b/pljava-so/src/main/c/TypeOid.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2019-2023 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -50,10 +50,6 @@ JNIEXPORT void JNICALL Java_org_postgresql_pljava_jdbc_TypeOid__1dummy(JNIEnv * 
 	CONFIRMCONST(VARCHAROID);
 	CONFIRMCONST(OIDOID);
 	CONFIRMCONST(BPCHAROID);
-
-#if PG_VERSION_NUM >= 90100
 	CONFIRMCONST(PG_NODE_TREEOID);
-#endif
-
 	CONFIRMCONST(TRIGGEROID);
 }

--- a/pljava-so/src/main/c/XactListener.c
+++ b/pljava-so/src/main/c/XactListener.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2020 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2023 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -41,11 +41,9 @@ case XACT_EVENT_##c: \
 		CASE( PREPARE );
 		CASE( PRE_COMMIT );
 		CASE( PRE_PREPARE );
-#if PG_VERSION_NUM >= 90500
 		CASE( PARALLEL_COMMIT );
 		CASE( PARALLEL_ABORT );
 		CASE( PARALLEL_PRE_COMMIT );
-#endif
 	}
 
 	JNI_callStaticVoidMethod(s_XactListener_class,

--- a/pljava-so/src/main/c/type/AclId.c
+++ b/pljava-so/src/main/c/type/AclId.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2019 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2023 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -184,11 +184,7 @@ Java_org_postgresql_pljava_internal_AclId__1getName(JNIEnv* env, jobject aclId)
 	{
 		result = String_createJavaStringFromNTS(
 			GetUserNameFromId(
-#if PG_VERSION_NUM >= 90500
 				AclId_getAclId(aclId), /* noerr= */ false
-#else
-				AclId_getAclId(aclId)
-#endif
 			)
 		);
 	}

--- a/pljava-so/src/main/c/type/Array.c
+++ b/pljava-so/src/main/c/type/Array.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2020 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2023 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -51,11 +51,7 @@ ArrayType* createArrayType(jsize nElems, size_t elemSize, Oid elemType, bool wit
 	v->dataoffset = (int32)dataoffset;
 	MemoryContextSwitchTo(currCtx);
 
-#if PG_VERSION_NUM < 80300
-	ARR_SIZE(v) = nBytes;
-#else
 	SET_VARSIZE(v, nBytes);
-#endif
 	ARR_NDIM(v) = 1;
 	ARR_ELEMTYPE(v) = elemType;
 	*((int*)ARR_DIMS(v)) = nElems;
@@ -88,14 +84,8 @@ static jvalue _Array_coerceDatum(Type self, Datum arg)
 			JNI_setObjectArrayElement(objArray, idx, obj.l);
 			JNI_deleteLocalRef(obj.l);
 
-#if PG_VERSION_NUM < 80300
-			values = att_addlength(values, elemLength, PointerGetDatum(values));
-			values = (char*)att_align(values, elemAlign);
-#else
 			values = att_addlength_datum(values, elemLength, PointerGetDatum(values));
 			values = (char*)att_align_nominal(values, elemAlign);
-#endif
-
 		}
 	}
 	result.l = (jobject)objArray;

--- a/pljava-so/src/main/c/type/Oid.c
+++ b/pljava-so/src/main/c/type/Oid.c
@@ -1,10 +1,14 @@
 /*
- * Copyright (c) 2004, 2005, 2006 TADA AB - Taby Sweden
- * Distributed under the terms shown in the file COPYRIGHT
- * found in the root folder of this project or at
- * http://eng.tada.se/osprojects/COPYRIGHT.html
+ * Copyright (c) 2004-2023 Tada AB and other contributors, as listed below.
  *
- * @author Thomas Hallgren
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Tada AB
+ *   Chapman Flack
  */
 #include <postgres.h>
 
@@ -256,11 +260,7 @@ Java_org_postgresql_pljava_internal_Oid__1forTypeName(JNIEnv* env, jclass cls, j
 		PG_TRY();
 		{
 			int32 typmod = 0;
-#if PG_VERSION_NUM < 90400
-			parseTypeString(typeNameOrOid, &typeId, &typmod);
-#else
 			parseTypeString(typeNameOrOid, &typeId, &typmod, 0);
-#endif
 		}
 		PG_CATCH();
 		{

--- a/pljava-so/src/main/c/type/SQLXMLImpl.c
+++ b/pljava-so/src/main/c/type/SQLXMLImpl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2021 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2018-2023 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -50,9 +50,7 @@ static bool _SQLXML_canReplaceType(Type self, Type other)
 #if defined(XMLOID)
 		Type_getOid(other) == XMLOID  ||
 #endif
-#if PG_VERSION_NUM >= 90100
 		Type_getOid(other) == PG_NODE_TREEOID  ||  /* a synthetic rendering */
-#endif
 		Type_getOid(other) == TEXTOID;
 }
 
@@ -86,17 +84,12 @@ static Datum _SQLXML_coerceObject(Type self, jobject sqlxml)
 		s_SQLXML_class, s_SQLXML_adopt, sqlxml, Type_getOid(self));
 	Datum d = pljava_VarlenaWrapper_adopt(vw);
 	JNI_deleteLocalRef(vw);
-#if PG_VERSION_NUM >= 90500
 	if ( VARATT_IS_EXTERNAL_EXPANDED_RW(DatumGetPointer(d)) )
 		return TransferExpandedObject(d, CurrentMemoryContext);
-#endif
-#if PG_VERSION_NUM >= 90200
+
 	MemoryContextSetParent(
 		GetMemoryChunkContext(DatumGetPointer(d)), CurrentMemoryContext);
-#else
-	if ( CurrentMemoryContext != GetMemoryChunkContext(DatumGetPointer(d)) )
-		d = PointerGetDatum(PG_DETOAST_DATUM_COPY(d));
-#endif
+
 	return d;
 }
 
@@ -134,18 +127,15 @@ static Type _SQLXML_obtain(Oid typeId)
 #if defined(XMLOID)
 	static Type xmlInstance;
 #endif
-#if PG_VERSION_NUM >= 90100
 	static Type pgNodeTreeInstance;
-#endif
+
 	switch ( typeId )
 	{
-#if PG_VERSION_NUM >= 90100
 	case PG_NODE_TREEOID:
 		allowedId = PG_NODE_TREEOID;
 		synthetic = true;
 		cache = &pgNodeTreeInstance;
 		break;
-#endif
 	default:
 		if ( TEXTOID == typeId )
 		{

--- a/pljava-so/src/main/c/type/String.c
+++ b/pljava-so/src/main/c/type/String.c
@@ -226,11 +226,7 @@ text* String_createText(jstring javaString)
 		/* Allocate and initialize the text structure.
 		 */
 		result = (text*)palloc(varSize);
-#if PG_VERSION_NUM < 80300
-		VARATT_SIZEP(result) = varSize;	/* Total size of structure, not just data */
-#else
 		SET_VARSIZE(result, varSize);	/* Total size of structure, not just data */
-#endif
 		memcpy(VARDATA(result), denc, dencLen);
 
 		if(denc != sid.data)

--- a/pljava-so/src/main/c/type/Timestamp.c
+++ b/pljava-so/src/main/c/type/Timestamp.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2019 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2023 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -405,23 +405,7 @@ static Datum _Timestamptz_coerceObject(Type self, jobject ts)
  */
 static int32 Timestamp_getTimeZone(pg_time_t time)
 {
-#if defined(_MSC_VER) && ( \
-	100000<=PG_VERSION_NUM && PG_VERSION_NUM<100002 || \
-	 90600<=PG_VERSION_NUM && PG_VERSION_NUM< 90607 || \
-	 90500<=PG_VERSION_NUM && PG_VERSION_NUM< 90511 || \
-	 90400<=PG_VERSION_NUM && PG_VERSION_NUM< 90416 || \
-	PG_VERSION_NUM < 90321 )
-	/* This is gross, but pg_tzset has a cache, so not as gross as you think.
-	 * There is some renewed interest on pgsql-hackers to find a good answer for
-	 * the MSVC PGDLLIMPORT nonsense, so this may not have to stay gross.
-	 */
-	char const *tzname = PG_GETCONFIGOPTION("timezone");
-	struct pg_tm* tx = pg_localtime(&time, pg_tzset(tzname));
-#elif PG_VERSION_NUM < 80300
-	struct pg_tm* tx = pg_localtime(&time, global_timezone);
-#else
 	struct pg_tm* tx = pg_localtime(&time, session_timezone);
-#endif
 	if ( NULL == tx )
 		ereport(ERROR, (
 			errcode(ERRCODE_DATA_EXCEPTION),

--- a/pljava-so/src/main/c/type/Type.c
+++ b/pljava-so/src/main/c/type/Type.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2023 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -30,42 +30,11 @@
 #include "pljava/HashMap.h"
 #include "pljava/SPI.h"
 
-#if PG_VERSION_NUM < 80300
-typedef enum CoercionPathType
-{
-	COERCION_PATH_NONE, 		/* failed to find any coercion pathway */
-	COERCION_PATH_FUNC, 		/* apply the specified coercion function */
-	COERCION_PATH_RELABELTYPE,  /* binary-compatible cast, no function */
-	COERCION_PATH_ARRAYCOERCE,  /* need an ArrayCoerceExpr node */
-	COERCION_PATH_COERCEVIAIO	/* need a CoerceViaIO node */
-} CoercionPathType;
-
-static CoercionPathType fcp(Oid targetTypeId, Oid sourceTypeId,
-							CoercionContext ccontext, Oid *funcid);
-static CoercionPathType fcp(Oid targetTypeId, Oid sourceTypeId,
-							CoercionContext ccontext, Oid *funcid)
-{
-	if ( find_coercion_pathway(targetTypeId, sourceTypeId, ccontext, funcid) )
-		return *funcid != InvalidOid ?
-			COERCION_PATH_FUNC : COERCION_PATH_RELABELTYPE;
-	else
-		return COERCION_PATH_NONE;
-}
-#define find_coercion_pathway fcp
-#endif
-
-#if PG_VERSION_NUM < 90500
-#define DomainHasConstraints(x) true
-#endif
-
 #if PG_VERSION_NUM < 110000
 static Oid BOOLARRAYOID;
 static Oid CHARARRAYOID;
 static Oid FLOAT8ARRAYOID;
 static Oid INT8ARRAYOID;
-#if PG_VERSION_NUM < 80400
-static Oid INT2ARRAYOID;
-#endif
 #endif
 
 static HashMap s_typeByOid;
@@ -1055,9 +1024,6 @@ void Type_initialize(void)
 	CHARARRAYOID   = get_array_type(CHAROID);
 	FLOAT8ARRAYOID = get_array_type(FLOAT8OID);
 	INT8ARRAYOID   = get_array_type(INT8OID);
-#if PG_VERSION_NUM < 80400
-	INT2ARRAYOID   = get_array_type(INT2OID);
-#endif
 #endif
 
 	initializeTypeBridges();

--- a/pljava-so/src/main/c/type/UDT.c
+++ b/pljava-so/src/main/c/type/UDT.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2021 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2023 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -15,6 +15,7 @@
 #include <postgres.h>
 #include <catalog/pg_namespace.h>
 #include <utils/builtins.h>
+#include <utils/bytea.h>
 #include <utils/typcache.h>
 #include <libpq/pqformat.h>
 #include <funcapi.h>
@@ -28,10 +29,6 @@
 #include "pljava/SQLOutputToChunk.h"
 #include "pljava/SQLInputFromTuple.h"
 #include "pljava/SQLOutputToTuple.h"
-
-#if PG_VERSION_NUM >= 90000
-#include <utils/bytea.h>
-#endif
 
 /*
  * This code, as currently constituted, makes these assumptions that limit how
@@ -183,11 +180,7 @@ static Datum coerceScalarObject(UDT self, jobject value)
 		{
 			/* Assign the correct length.
 			 */
-#if PG_VERSION_NUM < 80300
-			VARATT_SIZEP(buffer.data) = buffer.len;
-#else
 			SET_VARSIZE(buffer.data, buffer.len);
-#endif
 		}
 		else if(dataLen != buffer.len)
 		{

--- a/pljava-so/src/main/c/type/byte_array.c
+++ b/pljava-so/src/main/c/type/byte_array.c
@@ -1,10 +1,14 @@
 /*
- * Copyright (c) 2004, 2005, 2006 TADA AB - Taby Sweden
- * Distributed under the terms shown in the file COPYRIGHT
- * found in the root folder of this project or at
- * http://eng.tada.se/osprojects/COPYRIGHT.html
+ * Copyright (c) 2004-2023 Tada AB and other contributors, as listed below.
  *
- * @author Thomas Hallgren
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Tada AB
+ *   Chapman Flack
  */
 #include "pljava/Exception.h"
 #include "pljava/type/Type_priv.h"
@@ -40,11 +44,7 @@ static Datum _byte_array_coerceObject(Type self, jobject byteArray)
 		int32  byteaSize = length + VARHDRSZ;
 
 		bytes = (bytea*)palloc(byteaSize);
-#if PG_VERSION_NUM < 80300
-		VARATT_SIZEP(bytes) = byteaSize;
-#else
 		SET_VARSIZE(bytes, byteaSize);
-#endif
 		JNI_getByteArrayRegion((jbyteArray)byteArray, 0, length, (jbyte*)VARDATA(bytes));
 	}
 	else if(JNI_isInstanceOf(byteArray, s_BlobValue_class))
@@ -55,11 +55,7 @@ static Datum _byte_array_coerceObject(Type self, jobject byteArray)
 
 		byteaSize = (int32)(length + VARHDRSZ);
 		bytes = (bytea*)palloc(byteaSize);
-#if PG_VERSION_NUM < 80300
-		VARATT_SIZEP(bytes) = byteaSize;
-#else
 		SET_VARSIZE(bytes, byteaSize);
-#endif
 
 		byteBuffer = JNI_newDirectByteBuffer((void*)VARDATA(bytes), length);
 		if(byteBuffer != 0)

--- a/pljava-so/src/main/include/pljava/Backend.h
+++ b/pljava-so/src/main/include/pljava/Backend.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2021 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2023 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -53,13 +53,7 @@ void Backend_warnJEP411(bool isCommit);
 #error The macro PG_GETCONFIGOPTION needs to be renamed.
 #endif
 
-#if PG_VERSION_NUM >= 90100
 #define PG_GETCONFIGOPTION(key) GetConfigOption(key, false, true)
-#elif PG_VERSION_NUM >= 90000
-#define PG_GETCONFIGOPTION(key) GetConfigOption(key, true)
-#else
-#define PG_GETCONFIGOPTION(key) GetConfigOption(key)
-#endif
 
 #ifdef __cplusplus
 }

--- a/pljava-so/src/main/include/pljava/Exception.h
+++ b/pljava-so/src/main/include/pljava/Exception.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2021 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2023 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -16,14 +16,6 @@
 #define __pljava_Exception_h
 
 #include "pljava/PgObject.h"
-
-#if PG_VERSION_NUM < 90500
-#ifdef __GNUC__
-#define pg_attribute_printf(f,a) __attribute__((format(printf, f, a)))
-#else
-#define pg_attribute_printf(f,a)
-#endif
-#endif
 
 #ifdef __cplusplus
 extern "C" {

--- a/pljava-so/src/main/include/pljava/pljava.h
+++ b/pljava-so/src/main/include/pljava/pljava.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2021 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2023 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -37,6 +37,7 @@ extern int vsnprintf(char* buf, size_t count, const char* format, va_list arg);
 #include <utils/syscache.h>
 #include <utils/memutils.h>
 #include <tcop/tcopprot.h>
+#include <access/htup_details.h>
 
 /*
  * AssertVariableIsOfType appeared in PG9.3. Can test for the macro directly.
@@ -63,23 +64,6 @@ extern int vsnprintf(char* buf, size_t count, const char* format, va_list arg);
 	ALLOCSET_SMALL_MINSIZE, ALLOCSET_SMALL_INITSIZE, ALLOCSET_SMALL_MAXSIZE
 #define ALLOCSET_START_SMALL_SIZES \
 	ALLOCSET_SMALL_MINSIZE, ALLOCSET_SMALL_INITSIZE, ALLOCSET_DEFAULT_MAXSIZE
-#endif
-
-/*
- * GETSTRUCT require "access/htup_details.h" to be included in PG9.3
- */
-#if PG_VERSION_NUM >= 90300
-#include "access/htup_details.h"
-#endif
-
-/*
- * PG_*_{MIN,MAX} macros (which happen, conveniently, to match Java's datatypes
- * (the signed ones, anyway), appear in PG 9.5. Could test for them directly,
- * but explicit version conditionals may be easier to find and prune when the
- * back-compatibility horizon passes them. Here are only the ones being used.
- */
-#if PG_VERSION_NUM < 90500
-#define PG_INT32_MAX    (0x7FFFFFFF)
 #endif
 
 /*
@@ -118,28 +102,10 @@ extern MemoryContext JavaMemoryContext;
  * stack_base_ptr was static before PG 8.1. By executive decision, PL/Java now
  * has 8.1 as a back compatibility limit; no empty #defines here for earlier.
  */
-#if 90104<=PG_VERSION_NUM || \
-	90008<=PG_VERSION_NUM && PG_VERSION_NUM<90100 || \
-	80412<=PG_VERSION_NUM && PG_VERSION_NUM<90000 || \
-	80319<=PG_VERSION_NUM && PG_VERSION_NUM<80400
 #define NEED_MISCADMIN_FOR_STACK_BASE
 #define _STACK_BASE_TYPE pg_stack_base_t
 #define _STACK_BASE_SET saveStackBasePtr = set_stack_base()
 #define _STACK_BASE_RESTORE restore_stack_base(saveStackBasePtr)
-#else
-extern
-#if PG_VERSION_NUM < 80300
-DLLIMPORT
-#else
-PGDLLIMPORT
-#endif
-char* stack_base_ptr;
-#define _STACK_BASE_TYPE char*
-#define _STACK_BASE_SET \
-	saveStackBasePtr = stack_base_ptr; \
-	stack_base_ptr = (char*)&saveMainThreadId
-#define _STACK_BASE_RESTORE stack_base_ptr = saveStackBasePtr
-#endif
 
 #define STACK_BASE_VARS \
 	void* saveMainThreadId = 0; \

--- a/pljava/src/main/java/org/postgresql/pljava/internal/SPI.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/SPI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2019 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2023 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -53,6 +53,9 @@ public class SPI
 	public static final int OK_REL_REGISTER     = 15;
 	public static final int OK_REL_UNREGISTER   = 16;
 	public static final int OK_TD_REGISTER      = 17;
+	public static final int OK_MERGE            = 18;
+
+	public static final int OPT_NONATOMIC       = 1 << 0;
 
 	/**
 	 * Execute a command using the internal <code>SPI_exec</code> function.

--- a/src/site/markdown/build/versions.md
+++ b/src/site/markdown/build/versions.md
@@ -62,7 +62,7 @@ versions 4.3.0 or later are recommended in order to avoid a
 
 ## PostgreSQL
 
-The PL/Java 1.6 series does not commit to support PostgreSQL earlier than 9.5.
+The PL/Java 1.6 series does not support PostgreSQL earlier than 9.5.
 
 More current PostgreSQL versions, naturally, are the focus of development
 and receive more attention in testing.


### PR DESCRIPTION
PostgreSQL 9.5 has been advertised as the oldest supported version for PL/Java 1.6.x since 1.6.0. Declutter by removing conditional code lingering from PL/Java 1.5.x, which goes back to PG 8.2.
    
In passing, add a couple SPI constants that showed up later while my back was turned, update some code in the examples, and make another one of them run as a CI test that was not already.