### PR TITLE
Support PostgreSQL 16

### DIFF
--- a/pljava-so/src/main/c/Backend.c
+++ b/pljava-so/src/main/c/Backend.c
@@ -28,7 +28,7 @@
 #include <catalog/pg_type.h>
 
 #if PG_VERSION_NUM >= 120000
- #ifdef HAVE_DLOPEN
+ #if defined(HAVE_DLOPEN)  ||  PG_VERSION_NUM >= 160000 && ! defined(WIN32)
  #include <dlfcn.h>
  #endif
  #define pg_dlopen(f) dlopen((f), RTLD_NOW | RTLD_GLOBAL)

--- a/pljava-so/src/main/c/Function.c
+++ b/pljava-so/src/main/c/Function.c
@@ -34,6 +34,10 @@
 #include <funcapi.h>
 #include <utils/typcache.h>
 
+#if PG_VERSION_NUM >= 160000
+#define PG_FUNCNAME_MACRO __func__
+#endif
+
 #ifdef _MSC_VER
 #	define strcasecmp _stricmp
 #	define strncasecmp _strnicmp

--- a/pljava-so/src/main/c/Function.c
+++ b/pljava-so/src/main/c/Function.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2023 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License

--- a/pljava-so/src/main/c/type/AclId.c
+++ b/pljava-so/src/main/c/type/AclId.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2019 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2023 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -21,6 +21,12 @@
 #include "pljava/type/Type_priv.h"
 #include "org_postgresql_pljava_internal_AclId.h"
 #include "pljava/Exception.h"
+
+#if PG_VERSION_NUM >= 160000
+#include <catalog/pg_namespace.h>
+#define pg_namespace_aclcheck(oid,rid,mode) \
+	object_aclcheck(NamespaceRelationId, (oid), (rid), (mode))
+#endif
 
 static jclass    s_AclId_class;
 static jmethodID s_AclId_init;


### PR DESCRIPTION
Accommodate upstream changes postgres/postgres@ca1e855, postgres/postgres@320f92b, and postgres/postgres@c727f51 to permit building on PG 16 (beta 3).

May keep this PR open until PG 16 GA, in case of any late-breaking changes.