### PR TITLE
Add Java 17 names for XML implementation props

### DIFF
--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/PassXML.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/PassXML.java
@@ -809,7 +809,9 @@ public class PassXML implements SQLData
 		for ( int i = 1; i <= n; ++i )
 		{
 			String k = rsmd.getColumnLabel(i);
-			if ( "allowDTD".equalsIgnoreCase(k) )
+			if ( "lax".equalsIgnoreCase(k) )
+				axp.lax(adjust.getBoolean(i));
+			else if ( "allowDTD".equalsIgnoreCase(k) )
 				axp.allowDTD(adjust.getBoolean(i));
 			else if ( "externalGeneralEntities".equalsIgnoreCase(k) )
 				axp.externalGeneralEntities(adjust.getBoolean(i));

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/PassXML.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/PassXML.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2021 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2018-2023 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -36,6 +36,7 @@ import java.io.Writer;
 
 import java.io.IOException;
 
+import java.util.List;
 import java.util.Map;
 import java.util.HashMap;
 
@@ -65,6 +66,7 @@ import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
 
 import org.postgresql.pljava.Adjusting;
+import static org.postgresql.pljava.Adjusting.XML.setFirstSupported;
 import org.postgresql.pljava.annotation.Function;
 import org.postgresql.pljava.annotation.MappedUDT;
 import org.postgresql.pljava.annotation.SQLAction;
@@ -518,33 +520,51 @@ public class PassXML implements SQLData
 			builtin
 			? TransformerFactory.newDefaultInstance()
 			: TransformerFactory.newInstance();
-		String exf =
-		  "http://www.oracle.com/xml/jaxp/properties/enableExtensionFunctions";
-		String ecl = "jdk.xml.transform.extensionClassLoader";
+
+		String legacy_pfx = "http://www.oracle.com/xml/jaxp/properties/";
+		String java17_pfx = "jdk.xml.";
+		String exf_sfx = "enableExtensionFunctions";
+
+		String ecl_legacy = "jdk.xml.transform.extensionClassLoader";
+		String ecl_java17 = "jdk.xml.extensionClassLoader";
+
 		Source src = sxToSource(source, how, adjust);
+
 		try
 		{
-			try
+			Exception e;
+
+			e = setFirstSupported(tf::setFeature, enableExtensionFunctions,
+				List.of(TransformerConfigurationException.class), null,
+				java17_pfx + exf_sfx, legacy_pfx + exf_sfx);
+
+			if ( null != e )
 			{
-				tf.setFeature(exf, enableExtensionFunctions);
-			}
-			catch ( TransformerConfigurationException e )
-			{
-				logMessage("WARNING",
-					"non-builtin transformer: ignoring " + e.getMessage());
+				if ( builtin )
+					throw new SQLException(
+						"Configuring XML transformation: " + e.getMessage(), e);
+				else
+					logMessage("WARNING",
+						"non-builtin transformer: ignoring " + e.getMessage());
 			}
 
 			if ( withJava )
 			{
-				try
+				e = setFirstSupported(tf::setAttribute,
+					Thread.currentThread().getContextClassLoader(),
+					List.of(IllegalArgumentException.class), null,
+					ecl_java17, ecl_legacy);
+
+				if ( null != e )
 				{
-					tf.setAttribute(ecl,
-						Thread.currentThread().getContextClassLoader());
-				}
-				catch ( IllegalArgumentException e )
-				{
-					logMessage("WARNING",
-					"non-builtin transformer: ignoring " + e.getMessage());
+					if ( builtin )
+						throw new SQLException(
+							"Configuring XML transformation: " + 
+								e.getMessage(), e);
+					else
+						logMessage("WARNING",
+							"non-builtin transformer: ignoring " + 
+								e.getMessage());
 				}
 			}
 


### PR DESCRIPTION
Java 17 adds (and prominently documents in the `java.xml` module-info javadocs), new, standardized, easy-to-remember names for a dozen or so of the XML implementation-specific properties and features.

And the standardized names are ... different from the old ones.

More names to feed into `setFirstSupported{Feature,Property}` when trying to adjust things.

The naming headaches are now visible outside of just the implementation module, because there are new standardized names for a `Transformer` property and feature also, which are used in the XSLT example code in `PassXML`.

So this is a good time to factor a `setFirstSupported(...)` generic function out of the various copies buried in `SQLXMLImpl`, and expose it in the `Adjusting.XML` API so client code can use it too, and use it that way in that example.

The `Adjusting.XML` API was added in some haste, and it used to say "the adjusting methods are best-effort and do not provide an indication of whether the requested adjustment was made". In fact it was pushed with some debug code doing exception stacktraces to standard error, which may have been an annoyance at any site that was using the feature heavily.

Take this opportunity to do something more systematic, and add a `lax(boolean)` method allowing it to be tailored. Stacktraces will still be logged if no tailoring is done, but may be more concise, as all of the exceptions that might be encountered in a chain of adjustments will be chained together with `addSuppressed()`, and common stacktrace elements should be elided when those are logged.

In passing, copyedit some `Adjusting.XML` javadoc to use styleguide-favored third-person rather than second-person phrasing.