### PR TITLE
Fix bogus out-of-date Javadoc comments

### DIFF
--- a/pljava-api/src/main/java/org/postgresql/pljava/annotation/package-info.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/annotation/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2016 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2015-2023 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -33,11 +33,10 @@
  * <p>
  * Automatic descriptor generation requires attention to a few things.
  * <ul>
- * <li>A Java 6 or later Java compiler is required, and at least the
- * <code>pljava-api</code> jar must be on its class path. (The full
- * <code>pljava.jar</code> would also work, but only <code>pljava-api</code>
- * is required.) The jar must be on the class path in any case in order to
- * compile PL/Java code.
+ * <li>The {@code pljava-api} jar must be on the Java compiler's class path.
+ * (All but the simplest PL/Java functions probably refer to some class in
+ * PL/Java's API anyway, in which case the jar would already have to be on
+ * the class path.)
  * <li>When recompiling after changing only a few sources, it is possible the
  * Java compiler will only process a subset of the source files containing
  * annotations. If so, it may generate an incomplete deployment descriptor,

--- a/pljava/src/main/java/org/postgresql/pljava/internal/VarlenaWrapper.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/VarlenaWrapper.java
@@ -1182,12 +1182,11 @@ public interface VarlenaWrapper extends Closeable
 		 * wraps a {@code ByteBuffer} and the {@link Output.State Output.State}
 		 * that protects it.
 		 *<p>
-		 * {@code BufferWrapper} installs <em>itself</em> as the inherited
-		 * {@code m_state} field, so {@code ByteBufferInputStream}'s methods
-		 * synchronize on it rather than the {@code State} object, for no
-		 * interference with the writing thread. The {@code pin} and
-		 * {@code unpin} methods, of course, forward to those of the
-		 * native state object.
+		 * {@code BufferWrapper} installs <em>itself</em> as the
+		 * {@code ByteBufferInputStream}'s lock object, so its methods
+		 * synchronize on this rather than anything that would interfere with
+		 * the writing thread. The {@code pin} and {@code unpin} methods,
+		 * of course, forward to those of the native state object.
 		 */
 		static class BufferWrapper
 		extends ByteBufferInputStream


### PR DESCRIPTION
Discovered one that had been rendered rather incoherent by a later change to the code, and another still referring to a Java 1.6 requirement from a PL/Java version that requires Java 9.