### PR TITLE
Skip `handleFirstOptions` for javadoc >= 19

### DIFF
--- a/pljava-examples/pom.xml
+++ b/pljava-examples/pom.xml
@@ -230,11 +230,13 @@ function executeReport(report, locale)
 		 * A special file manager that will rewrite the RELDOTS seen in
 		 * -linkoffline above. The options a file manager recognizes must be the
 		 * first ones in args; handleFirstOptions below returns at the first one
-		 * the file manager doesn't know what to do with.
+		 * the file manager doesn't know what to do with. Java 19 seems to have
+		 * learned to pass the args to the file manager without the fuss here.
 		 */
 		var rmgr = new org.postgresql.pljava.pgxs.RelativizingFileManager(
 			smgr, Charset.forName(report.outputEncoding));
-		rmgr.handleFirstOptions(args);
+		if ( 0 > v.compareTo(java.lang.Runtime.Version.parse("19-ea")) )
+			rmgr.handleFirstOptions(args);
 
 		var task = tool.getTask(null, rmgr, diagListener, null, args, null);
 		if (task.call())

--- a/pljava/pom.xml
+++ b/pljava/pom.xml
@@ -182,11 +182,15 @@ function executeReport(report, locale)
 		 * A special file manager that will rewrite the RELDOTS seen in
 		 * -linkoffline above. The options a file manager recognizes must be the
 		 * first ones in args; handleFirstOptions below returns at the first one
-		 * the file manager doesn't know what to do with.
+		 * the file manager doesn't know what to do with. Java 19 seems to have
+		 * learned to pass the args to the file manager without the fuss here.
 		 */
 		var rmgr = new org.postgresql.pljava.pgxs.RelativizingFileManager(
 			smgr, Charset.forName(report.outputEncoding));
-		rmgr.handleFirstOptions(args);
+
+		var v = java.lang.Runtime.version();
+		if ( 0 > v.compareTo(java.lang.Runtime.Version.parse("19-ea")) )
+			rmgr.handleFirstOptions(args);
 
 		var task = tool.getTask(null, rmgr, diagListener, null, args, null);
 		if (task.call())


### PR DESCRIPTION
In older Java versions, it was necessary to pass along the initial javadoc arguments (the ones a file manager would care about) in a separate step before calling the tool. Starting in 19, that's not only no longer necessary, but fails with "--module-source-path specified more than once", so omit that step when building the javadoc on Java 19 or later.