### PR TITLE
Improve `NEWLINE` pattern

### DIFF
--- a/pljava-api/src/main/java/org/postgresql/pljava/sqlgen/Lexicals.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/sqlgen/Lexicals.java
@@ -279,7 +279,7 @@ public abstract class Lexicals
 	 * engine, letting it handle the details.
 	 */
 	public static final Pattern NEWLINE = Pattern.compile(
-		"(?ms:$(?:(?<!^).|(?<=\\G).){1,2}+)"
+		"(?ms:$.{1,2}?(?:^|\\z))" // fewest of 1,2 chars between $ and ^ (or \z)
 	);
 
 	/** White space <em>except</em> newline, for any Java-recognized newline.

--- a/pljava-api/src/test/java/LexicalsTest.java
+++ b/pljava-api/src/test/java/LexicalsTest.java
@@ -30,6 +30,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static
 	org.postgresql.pljava.sqlgen.Lexicals.ISO_AND_PG_IDENTIFIER_CAPTURING;
 import static
+	org.postgresql.pljava.sqlgen.Lexicals.NEWLINE;
+import static
 	org.postgresql.pljava.sqlgen.Lexicals.SEPARATOR;
 import static
 	org.postgresql.pljava.sqlgen.Lexicals.PG_OPERATOR;
@@ -44,6 +46,22 @@ import org.postgresql.pljava.sqlgen.Lexicals.Identifier.Qualified;
 public class LexicalsTest extends TestCase
 {
 	public LexicalsTest(String name) { super(name); }
+
+	public void testNewline() throws Exception
+	{
+		Matcher m = NEWLINE.matcher("abcd\nefgh");
+		m.region(4, 9);
+		assertTrue("newline 0", m.lookingAt());
+		assertTrue("newline 1", m.lookingAt());
+
+		m.reset("abcd\r\nefgh").region(4, 10);
+		assertTrue("newline 2", m.lookingAt());
+		assertEquals("\r\n", m.group());
+
+		m.reset("abcd\n\refgh").region(4, 10);
+		assertTrue("newline 3", m.lookingAt());
+		assertEquals("\n", m.group());
+	}
 
 	public void testSeparator() throws Exception
 	{


### PR DESCRIPTION
Supply a `NEWLINE` pattern in `sqlgen.Lexicals` that still meets the goal of relying on Java's regex engine for precisely what is or isn't a newline, but without the ill-thought-out sensitivity to the previous match result reported in issue #455.