### PR TITLE
Quiet warnings about casts of function types

### DIFF
--- a/pljava-so/src/main/c/PgObject.c
+++ b/pljava-so/src/main/c/PgObject.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2020 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2023 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -64,11 +64,6 @@ PgObjectClass PgObject_getClass(PgObject self)
 const char* PgObjectClass_getName(PgObjectClass self)
 {
 	return self->name;
-}
-
-void _PgObject_pureVirtualCalled(PgObject object)
-{
-	ereport(ERROR, (errmsg("Pure virtual method called")));
 }
 
 char* PgObject_getClassName(jclass cls)

--- a/pljava-so/src/main/include/pljava/PgObject_priv.h
+++ b/pljava-so/src/main/include/pljava/PgObject_priv.h
@@ -1,10 +1,14 @@
 /*
- * Copyright (c) 2004, 2005, 2006 TADA AB - Taby Sweden
- * Distributed under the terms shown in the file COPYRIGHT
- * found in the root folder of this project or at
- * http://eng.tada.se/osprojects/COPYRIGHT.html
+ * Copyright (c) 2004-2023 Tada AB and other contributors, as listed below.
  *
- * @author Thomas Hallgren
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Tada AB
+ *   Chapman Flack
  */
 #ifndef __pljava_PgObject_priv_h
 #define __pljava_PgObject_priv_h
@@ -53,12 +57,6 @@ struct PgObject_
 {
 	PgObjectClass m_class;
 };
-
-/*
- * Internal bogus. Someone forgot to replace a function
- * pointer somewhere.
- */
-extern void _PgObject_pureVirtualCalled(PgObject self);
 
 /*
  * Throw an exception indicating that wanted member could not be


### PR DESCRIPTION
It is easy enough to stop casting `_PgObject_pureVirtualCalled` to incompatible function types, as it makes modern compilers suspicious, and was only done in three places anyway.