### PR TITLE
Build on FreeBSD (PR #475 rebased)

### DIFF
--- a/pljava-so/pom.xml
+++ b/pljava-so/pom.xml
@@ -121,6 +121,47 @@
 		},
 
 		{
+			name : "FreeBSD",
+
+			object_extension : ".o",
+
+			probe: function(os_name) {
+				return os_name.toLowerCase().contains("freebsd");
+			},
+
+			compile : function(cc, files, output_dir, includes, defines, flags) {
+				includes.add(java_include.resolve("freebsd").toString());
+				defines.put("FreeBSD", null);
+				flags.add("-c");
+				if(isDebugEnabled)
+					flags.add("-g");
+				var compileProcess = utils.processBuilder(function(l) {
+					l.add(cc);
+					l.addAll(pgxs.formatDefines(defines));
+					l.addAll(pgxs.formatIncludes(includes));
+					l.addAll(flags);
+					l.addAll(files);
+				});
+				compileProcess.directory(output_dir.toFile());
+				return runCommand(compileProcess);
+			},
+
+			link : function(cc, flags, files, target_path) {
+				if(isDebugEnabled)
+					flags.add("-g");
+				flags.add("-shared-libgcc");
+				var linkingProcess = utils.processBuilder(function(l) {
+					l.add(cc);
+					l.addAll(flags);
+					l.addAll(of("-shared", "-o", "lib" + library_name + ".so"));
+					l.addAll(files);
+				});
+				linkingProcess.directory(target_path.toFile());
+				return runCommand(linkingProcess);
+			}
+		},
+								
+		{
 			name : "Mac OS X",
 
 			object_extension : ".o",

--- a/src/site/markdown/build/freebsd.md
+++ b/src/site/markdown/build/freebsd.md
@@ -1,23 +1,7 @@
 # Building on FreeBSD
 
-At one time, [FreeBSD][]'s threading library would malfunction if it was
-dynamically loaded after the start of a program that did not use threads
-itself. That was a problem for PL/Java on FreeBSD, because PostgreSQL
-itself does not use threads, but Java does. The only known workaround was
-to build PostgreSQL itself from source, with the thread library included
-in linking.
-
-The same problem was [reported to affect other PostgreSQL extensions][rep]
-such as `plv8` and `imcs` also.
-
-The [manual page for FreeBSD's libthr][manthr] was edited
-[in February 2015][thrdif] to remove the statement of that limitation,
-and the updated manual page appears first in [FreeBSD 10.2][rel102],
-so in FreeBSD 10.2 or later, PL/Java (and other affected extensions)
-may work without the need to build PostgreSQL from source.
+Building on [FreeBSD][] should proceed just as it does on Linux,
+as of late 2023, according to Achilleos Mantzios, who provided the patch
+adding the necessary build rules.
 
 [FreeBSD]: https://www.freebsd.org/
-[rep]: https://lists.freebsd.org/pipermail/freebsd-hackers/2014-April/044961.html
-[manthr]: https://www.freebsd.org/cgi/man.cgi?query=libthr&amp;apropos=0&amp;sektion=3&amp;manpath=FreeBSD+10.2-RELEASE&amp;arch=default&amp;format=html
-[thrdif]: https://svnweb.freebsd.org/base/head/lib/libthr/libthr.3?r1=272153&amp;r2=278627
-[rel102]: https://www.freebsd.org/releases/10.2R/announce.html


### PR DESCRIPTION
Patch for building on FreeBSD supplied by Achilleas Mantzios in PR #475, rebased here and with the appropriate doc update in `build/freebsd.md`.