### PR TITLE
Changes to build/use PL/Java on Java 22

### DIFF
--- a/pljava-api/src/main/java/org/postgresql/pljava/annotation/processing/DDRProcessor.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/annotation/processing/DDRProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2023 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2024 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -173,7 +173,7 @@ public class DDRProcessor extends AbstractProcessor
 		 * Update latest_tested to be the latest Java release on which this
 		 * annotation processor has been tested without problems.
 		 */
-		int latest_tested = 21;
+		int latest_tested = 22;
 		int ordinal_9 = SourceVersion.RELEASE_9.ordinal();
 		int ordinal_latest = latest_tested - 9 + ordinal_9;
 

--- a/pljava-pgxs/pom.xml
+++ b/pljava-pgxs/pom.xml
@@ -42,7 +42,7 @@
 		<profile>
 			<id>nashorngone</id>
 			<activation>
-				<jdk>[15,)</jdk>
+				<jdk>[15,22)</jdk>
 			</activation>
 			<dependencies>
 				<dependency>
@@ -54,6 +54,19 @@
 					<groupId>org.graalvm.js</groupId>
 					<artifactId>js-scriptengine</artifactId>
 					<version>20.1.0</version>
+				</dependency>
+			</dependencies>
+		</profile>
+		<profile>
+			<id>nashornmod</id>
+			<activation>
+				<jdk>[22,)</jdk>
+			</activation>
+			<dependencies>
+				<dependency>
+					<groupId>org.openjdk.nashorn</groupId>
+					<artifactId>nashorn-core</artifactId>
+					<version>15.4</version>
 				</dependency>
 			</dependencies>
 		</profile>

--- a/pljava-pgxs/pom.xml
+++ b/pljava-pgxs/pom.xml
@@ -40,27 +40,9 @@
 
 	<profiles>
 		<profile>
-			<id>nashorngone</id>
-			<activation>
-				<jdk>[15,22)</jdk>
-			</activation>
-			<dependencies>
-				<dependency>
-					<groupId>org.graalvm.js</groupId>
-					<artifactId>js</artifactId>
-					<version>20.1.0</version>
-				</dependency>
-				<dependency>
-					<groupId>org.graalvm.js</groupId>
-					<artifactId>js-scriptengine</artifactId>
-					<version>20.1.0</version>
-				</dependency>
-			</dependencies>
-		</profile>
-		<profile>
 			<id>nashornmod</id>
 			<activation>
-				<jdk>[22,)</jdk>
+				<jdk>[15,)</jdk>
 			</activation>
 			<dependencies>
 				<dependency>

--- a/pljava-so/src/main/c/Backend.c
+++ b/pljava-so/src/main/c/Backend.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2023 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2024 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License

--- a/pljava-so/src/main/c/Backend.c
+++ b/pljava-so/src/main/c/Backend.c
@@ -1941,10 +1941,10 @@ void Backend_warnJEP411(bool isCommit)
 			"Java features that will be phased out in future Java versions. "
 			"Those changes will come in releases after Java 17."),
 		errhint(
-			"For migration planning, Java versions up to and including 17 "
-			"remain fully usable with this version of PL/Java, and Java 17 "
-			"is positioned as a long-term support release. For details on "
-			"how PL/Java will adapt, please bookmark "
+			"For migration planning, this version of PL/Java can still "
+			"enforce policy in Java versions up to and including 22, "
+			"and Java 17 and 21 are positioned as long-term support releases. "
+			"For details on how PL/Java will adapt, please bookmark "
 			"https://github.com/tada/pljava/wiki/JEP-411")
 	));
 }

--- a/pom.xml
+++ b/pom.xml
@@ -70,55 +70,9 @@
 
 	<profiles>
 		<profile>
-			<id>nashorngone</id>
-			<activation>
-				<jdk>[15,22)</jdk>
-			</activation>
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>org.codehaus.mojo</groupId>
-						<artifactId>properties-maven-plugin</artifactId>
-						<version>1.0.0</version>
-						<executions>
-							<execution>
-								<phase>initialize</phase>
-								<goals>
-									<goal>set-system-properties</goal>
-								</goals>
-								<configuration>
-									<properties>
-										<polyglot.js.nashorn-compat>
-											true
-										</polyglot.js.nashorn-compat>
-									</properties>
-								</configuration>
-							</execution>
-						</executions>
-					</plugin>
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-antrun-plugin</artifactId>
-						<dependencies>
-							<dependency>
-								<groupId>org.graalvm.js</groupId>
-								<artifactId>js</artifactId>
-								<version>20.1.0</version>
-							</dependency>
-							<dependency>
-								<groupId>org.graalvm.js</groupId>
-								<artifactId>js-scriptengine</artifactId>
-								<version>20.1.0</version>
-							</dependency>
-						</dependencies>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
-		<profile>
 			<id>nashornmod</id>
 			<activation>
-				<jdk>[22,)</jdk>
+				<jdk>[15,)</jdk>
 			</activation>
 			<build>
 				<plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
 		<profile>
 			<id>nashorngone</id>
 			<activation>
-				<jdk>[15,)</jdk>
+				<jdk>[15,22)</jdk>
 			</activation>
 			<build>
 				<plugins>
@@ -109,6 +109,27 @@
 								<groupId>org.graalvm.js</groupId>
 								<artifactId>js-scriptengine</artifactId>
 								<version>20.1.0</version>
+							</dependency>
+						</dependencies>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+		<profile>
+			<id>nashornmod</id>
+			<activation>
+				<jdk>[22,)</jdk>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-antrun-plugin</artifactId>
+						<dependencies>
+							<dependency>
+								<groupId>org.openjdk.nashorn</groupId>
+								<artifactId>nashorn-core</artifactId>
+								<version>15.4</version>
 							</dependency>
 						</dependencies>
 					</plugin>

--- a/src/site/markdown/use/policy.md
+++ b/src/site/markdown/use/policy.md
@@ -372,11 +372,16 @@ release, so relying on it is not recommended.
 
 The developers of Java have elected to phase out important language features
 used by PL/Java to enforce policy. The changes will come in releases after
-Java 17. For migration planning, Java versions up to and including 17
-remain fully usable with this version of PL/Java, and Java 17
-is positioned as a long-term support release. For details on
-how PL/Java will adapt, please bookmark [the JEP 411 topic][jep411]
-on the PL/Java wiki.
+Java 17. For migration planning, this version of PL/Java can still enable
+policy enforcement in Java versions up to and including 22, and Java 17 and 21
+are positioned as long-term support releases. (There is a likelihood,
+increasing with later Java versions, even before policy stops being enforceable,
+that some internal privileged operations by Java itself, or other libraries,
+will cease to work transparently, and may have to be manually added to a site's
+PL/Java policy.)
+
+For details on how PL/Java will adapt, please bookmark
+[the JEP 411 topic][jep411] on the PL/Java wiki.
 
 
 [pfsyn]: https://docs.oracle.com/en/java/javase/14/security/permissions-jdk1.html#GUID-7942E6F8-8AAB-4404-9FE9-E08DD6FFCFFA


### PR DESCRIPTION
These changes take care of building and using PL/Java on Java 22.

A separate patch will address new Java 22 features that can be exposed in PL/Java's API for use by user code.

Naturally, no patch will begin using Java 22 features within PL/Java _itself_ until a future major release adopts a newer minimum build version.