### PR TITLE
Expose Java 22 features to PL/Java user code

### DIFF
--- a/pljava-api/src/main/java/org/postgresql/pljava/Adjusting.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/Adjusting.java
@@ -302,6 +302,17 @@ public final class Adjusting
 			T allowDTD(boolean v);
 
 			/**
+			 * Specifies that any DTD should be ignored (neither processed nor
+			 * rejected as an error).
+			 *<p>
+			 * This treatment is available in Java 22 and later.
+			 * In earlier Java versions, this will not succeed. Where it is
+			 * supported, the most recent call of this method or of
+			 * {@link #allowDTD allowDTD} will be honored.
+			 */
+			T ignoreDTD();
+
+			/**
 			 * Whether to retrieve external "general" entities (those
 			 * that can be used in the document body) declared in the DTD.
 			 */

--- a/pljava-api/src/main/java/org/postgresql/pljava/Adjusting.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/Adjusting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2019-2024 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -147,10 +147,10 @@ public final class Adjusting
 		 * {@link Exception#getSuppressed getSuppressed}. The return is
 		 * immediate, without any remaining names being tried, if an exception
 		 * is caught that is not assignable to a class in the
-		 * <var>expected</var> list. Such an exception will be passed to the
-		 * <var>onUnexpected</var> handler if that is non-null; otherwise,
-		 * it will be returned (or added to the suppressed list of the
-		 * exception to be returned) just as expected exceptions are.
+		 * <var>expected</var> list. Such an exception is returned (or added to
+		 * the suppressed list of an exception already to be returned) only if
+		 * the <var>onUnexpected</var> handler is null; otherwise, it is passed
+		 * to the handler and does not affect the method's return.
 		 * @param setter typically a method reference for a method that
 		 * takes a string key and some value.
 		 * @param value the value to pass to the setter
@@ -165,8 +165,10 @@ public final class Adjusting
 		 * immediate, without trying remaining names, if any.
 		 * @param names one or more String keys to be tried in order until
 		 * the action succeeds.
-		 * @return null if any attempt succeeded, otherwise an exception,
-		 * which may have further exceptions in its suppressed list.
+		 * @return null if any attempt succeeded, or if the first exception
+		 * caught was passed to the onUnexpected handler; otherwise the first
+		 * exception caught, which may have further exceptions in its suppressed
+		 * list.
 		 */
 		public static <T, V extends T> Exception setFirstSupported(
 			SetMethod<? super T> setter, V value,

--- a/pljava-api/src/main/java/org/postgresql/pljava/Adjusting.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/Adjusting.java
@@ -151,12 +151,30 @@ public final class Adjusting
 		 * the suppressed list of an exception already to be returned) only if
 		 * the <var>onUnexpected</var> handler is null; otherwise, it is passed
 		 * to the handler and does not affect the method's return.
+		 *<p>
+		 * For some purposes, a single call of this method may not suffice: if
+		 * alternate means to establish a desired configuration have existed and
+		 * are not simply alternate property names that will accept the same
+		 * value. For such a case, this method may be called more than once. The
+		 * caller abandons the sequence of calls after the first call that
+		 * returns null (indicating that it either succeeded, or incurred an
+		 * unexpected exception and passed it to the <var>onUnexpected</var>
+		 * handler. Otherwise, the exception returned by the first call can be
+		 * passed as <var>caught</var> to the next call, instead of passing the
+		 * usual null. (When a non-null <var>caught</var> is passed, it will be
+		 * returned on failure, even if an unexpected exception has been caught;
+		 * therefore, should it ever be necessary to chain more than two of
+		 * these calls, the caller should abandon the sequence as soon as a call
+		 * returns null <em>or</em> returns its <var>caught</var> argument with
+		 * no growth of its suppressed list.)
 		 * @param setter typically a method reference for a method that
 		 * takes a string key and some value.
 		 * @param value the value to pass to the setter
 		 * @param expected a list of exception classes that can be foreseen
 		 * to indicate that a key was not recognized, and the operation
 		 * should be retried with the next possible key.
+		 * @param caught null, or an exception returned by a preceding call if
+		 * an operation cannot be implemented with one call of this method
 		 * @param onUnexpected invoked, if non-null, on an {@code Exception}
 		 * that is caught and matches nothing in the expected list, instead
 		 * of returning it. If this parameter is null, such an exception is
@@ -167,16 +185,17 @@ public final class Adjusting
 		 * the action succeeds.
 		 * @return null if any attempt succeeded, or if the first exception
 		 * caught was passed to the onUnexpected handler; otherwise the first
-		 * exception caught, which may have further exceptions in its suppressed
-		 * list.
+		 * exception caught (if the caller supplied a non-null
+		 * <var>caught</var>, then that exception), which may have further
+		 * exceptions in its suppressed list.
 		 */
 		public static <T, V extends T> Exception setFirstSupported(
 			SetMethod<? super T> setter, V value,
 			List<Class<? extends Exception>> expected,
+			Exception caught,
 			Consumer<? super Exception> onUnexpected, String... names)
 		{
 			requireNonNull(expected);
-			Exception caught = null;
 			for ( String name : names )
 			{
 				try
@@ -204,6 +223,18 @@ public final class Adjusting
 				}
 			}
 			return caught;
+		}
+
+		/**
+		 * Calls the six-argument overload passing null for <var>caught</var>.
+		 */
+		public static <T, V extends T> Exception setFirstSupported(
+			SetMethod<? super T> setter, V value,
+			List<Class<? extends Exception>> expected,
+			Consumer<? super Exception> onUnexpected, String... names)
+		{
+			return setFirstSupported(
+				setter, value, expected, null, onUnexpected, names);
 		}
 
 		/**

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/SQLXMLImpl.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/SQLXMLImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2018-2024 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -4154,6 +4154,10 @@ public abstract class SQLXMLImpl<V extends VarlenaWrapper> implements SQLXML
 		private static final String JDK17 = "jdk.xml.";
 		private static final String LIMIT =
 			"http://www.oracle.com/xml/jaxp/properties/"; // "legacy" since 17
+		protected static final String DTDSUPPORT = "jdk.xml.dtd.support";
+		protected static final String ALLOW = "allow";
+		protected static final String IGNORE = "ignore";
+		protected static final String DENY = "deny";
 
 		private Exception m_signaling;
 		private Exception m_quiet;
@@ -4328,12 +4332,29 @@ public abstract class SQLXMLImpl<V extends VarlenaWrapper> implements SQLXML
 	abstract static class SAXDOMCommon<T extends Adjusting.XML.Parsing<T>>
 	extends AdjustingJAXPParser<T>
 	{
+		protected abstract Exception tryFirstSupportedFeature(
+			Exception caught, boolean value, String... names);
+
+		protected abstract Exception tryFirstSupportedProperty(
+			Exception caught, Object value, String... names);
+
+		protected abstract T self();
+
 		@Override
 		public T allowDTD(boolean v) {
-			return setFirstSupportedFeature( !v,
+			Exception caught =
+				tryFirstSupportedProperty(null, v ? ALLOW : DENY, DTDSUPPORT);
+
+			if ( null == caught )
+				return self();
+
+			caught = tryFirstSupportedFeature(caught, !v,
 				"http://apache.org/xml/features/disallow-doctype-decl",
 				"http://xerces.apache.org/xerces2-j/features.html" +
 					"#disallow-doctype-decl");
+
+			addQuiet(caught);
+			return self();
 		}
 
 		@Override
@@ -4967,17 +4988,17 @@ public abstract class SQLXMLImpl<V extends VarlenaWrapper> implements SQLXML
 			private Dummy() { }
 
 			@Override
-			public AdjustingSAXSource setFirstSupportedFeature(
-				boolean value, String... names)
+			protected Exception tryFirstSupportedFeature(
+				Exception caught, boolean value, String... names)
 			{
-				return this;
+				return caught;
 			}
 
 			@Override
-			public AdjustingSAXSource setFirstSupportedProperty(
-				Object value, String... names)
+			protected Exception tryFirstSupportedProperty(
+				Exception caught, Object value, String... names)
 			{
-				return this;
+				return caught;
 			}
 
 			@Override
@@ -5127,18 +5148,44 @@ public abstract class SQLXMLImpl<V extends VarlenaWrapper> implements SQLXML
 		}
 
 		@Override
-		public AdjustingSAXSource setFirstSupportedFeature(
-			boolean value, String... names)
+		protected Exception tryFirstSupportedFeature(
+			Exception caught, boolean value, String... names)
 		{
 			XMLReader r = theReader();
 			if ( null == r ) // pending exception, nothing to be done
-				return this;
+				return caught;
 
-			addQuiet(setFirstSupported(r::setFeature, value,
+			return setFirstSupported(r::setFeature, value,
 				List.of(SAXNotRecognizedException.class,
 					SAXNotSupportedException.class),
-				this::addSignaling, names));
+				caught, this::addSignaling, names);
+		}
 
+		@Override
+		protected Exception tryFirstSupportedProperty(
+			Exception caught, Object value, String... names)
+		{
+			XMLReader r = theReader();
+			if ( null == r ) // pending exception, nothing to be done
+				return caught;
+
+			return setFirstSupported(r::setProperty, value,
+				List.of(SAXNotRecognizedException.class,
+					SAXNotSupportedException.class),
+				caught, this::addSignaling, names);
+		}
+
+		@Override
+		protected AdjustingSAXSource self()
+		{
+			return this;
+		}
+
+		@Override
+		public AdjustingSAXSource setFirstSupportedFeature(
+			boolean value, String... names)
+		{
+			addQuiet(tryFirstSupportedFeature(null, value, names));
 			return this;
 		}
 
@@ -5146,15 +5193,7 @@ public abstract class SQLXMLImpl<V extends VarlenaWrapper> implements SQLXML
 		public AdjustingSAXSource setFirstSupportedProperty(
 			Object value, String... names)
 		{
-			XMLReader r = theReader();
-			if ( null == r ) // pending exception, nothing to be done
-				return this;
-
-			addQuiet(setFirstSupported(r::setProperty, value,
-				List.of(SAXNotRecognizedException.class,
-					SAXNotSupportedException.class),
-				this::addSignaling, names));
-
+			addQuiet(tryFirstSupportedProperty(null, value, names));
 			return this;
 		}
 
@@ -5243,6 +5282,28 @@ public abstract class SQLXMLImpl<V extends VarlenaWrapper> implements SQLXML
 		public AdjustingSAXResult expandEntityReferences(boolean v)
 		{
 			return checkedNoOp();
+		}
+
+		@Override
+		protected Exception tryFirstSupportedFeature(
+			Exception caught, boolean value, String... names)
+		{
+			checkedNoOp();
+			return null;
+		}
+
+		@Override
+		protected Exception tryFirstSupportedProperty(
+			Exception caught, Object value, String... names)
+		{
+			checkedNoOp();
+			return null;
+		}
+
+		@Override
+		protected AdjustingSAXResult self()
+		{
+			return this;
 		}
 
 		@Override
@@ -5351,7 +5412,16 @@ public abstract class SQLXMLImpl<V extends VarlenaWrapper> implements SQLXML
 
 		@Override
 		public AdjustingStAXSource allowDTD(boolean v) {
-			return setFirstSupportedFeature( v, XMLInputFactory.SUPPORT_DTD);
+			Exception caught =
+				tryFirstSupported(null, v ? ALLOW : DENY, DTDSUPPORT);
+
+			if ( null == caught )
+				return this;
+
+			caught = tryFirstSupported(caught, v, XMLInputFactory.SUPPORT_DTD);
+
+			addQuiet(caught);
+			return this;
 		}
 
 		@Override
@@ -5388,14 +5458,20 @@ public abstract class SQLXMLImpl<V extends VarlenaWrapper> implements SQLXML
 				XMLInputFactory.IS_REPLACING_ENTITY_REFERENCES);
 		}
 
+		private Exception tryFirstSupported(
+			Exception caught, Object value, String... names)
+		{
+			XMLInputFactory xif = theFactory();
+			return setFirstSupported(xif::setProperty, value,
+				List.of(IllegalArgumentException.class),
+				caught, this::addSignaling, names);
+		}
+
 		@Override
 		public AdjustingStAXSource setFirstSupportedFeature(
 			boolean value, String... names)
 		{
-			XMLInputFactory xif = theFactory();
-			addQuiet(setFirstSupported(xif::setProperty, value,
-				List.of(IllegalArgumentException.class),
-				this::addSignaling, names));
+			addQuiet(tryFirstSupported(null, value, names));
 			return this;
 		}
 
@@ -5403,10 +5479,7 @@ public abstract class SQLXMLImpl<V extends VarlenaWrapper> implements SQLXML
 		public AdjustingStAXSource setFirstSupportedProperty(
 			Object value, String... names)
 		{
-			XMLInputFactory xif = theFactory();
-			addQuiet(setFirstSupported(xif::setProperty, value,
-				List.of(IllegalArgumentException.class),
-				this::addSignaling, names));
+			addQuiet(tryFirstSupported(null, value, names));
 			return this;
 		}
 	}
@@ -5504,13 +5577,36 @@ public abstract class SQLXMLImpl<V extends VarlenaWrapper> implements SQLXML
 		}
 
 		@Override
+		protected Exception tryFirstSupportedFeature(
+			Exception caught, boolean value, String... names)
+		{
+			DocumentBuilderFactory dbf = theFactory();
+			return setFirstSupported(dbf::setFeature, value,
+				List.of(ParserConfigurationException.class),
+				caught, this::addSignaling, names);
+		}
+
+		@Override
+		protected Exception tryFirstSupportedProperty(
+			Exception caught, Object value, String... names)
+		{
+			DocumentBuilderFactory dbf = theFactory();
+			return setFirstSupported(dbf::setAttribute, value,
+				List.of(IllegalArgumentException.class),
+				caught, this::addSignaling, names);
+		}
+
+		@Override
+		protected AdjustingDOMSource self()
+		{
+			return this;
+		}
+
+		@Override
 		public AdjustingDOMSource setFirstSupportedFeature(
 			boolean value, String... names)
 		{
-			DocumentBuilderFactory dbf = theFactory();
-			addQuiet(setFirstSupported(dbf::setFeature, value,
-				List.of(ParserConfigurationException.class),
-				this::addSignaling, names));
+			addQuiet(tryFirstSupportedFeature(null, value, names));
 			return this;
 		}
 
@@ -5518,10 +5614,7 @@ public abstract class SQLXMLImpl<V extends VarlenaWrapper> implements SQLXML
 		public AdjustingDOMSource setFirstSupportedProperty(
 			Object value, String... names)
 		{
-			DocumentBuilderFactory dbf = theFactory();
-			addQuiet(setFirstSupported(dbf::setAttribute, value,
-				List.of(IllegalArgumentException.class),
-				this::addSignaling, names));
+			addQuiet(tryFirstSupportedProperty(null, value, names));
 			return this;
 		}
 

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/SQLXMLImpl.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/SQLXMLImpl.java
@@ -4232,6 +4232,12 @@ public abstract class SQLXMLImpl<V extends VarlenaWrapper> implements SQLXML
 		}
 
 		@Override
+		public T ignoreDTD()
+		{
+			return setFirstSupportedProperty(IGNORE, DTDSUPPORT);
+		}
+
+		@Override
 		public T elementAttributeLimit(int limit)
 		{
 			return setFirstSupportedProperty(limit,

--- a/src/site/markdown/use/sqlxml.md
+++ b/src/site/markdown/use/sqlxml.md
@@ -419,6 +419,12 @@ only existing methods for setting features/properties, as described
 `setFirstSupportedFeature` and `setFirstSupportedProperty` methods
 in PL/Java's `Adjusting` API.
 
+When running on Java 22 or later, there is also a fallback catalog that can
+satisfy requests for a small number of DTDs that are defined by the Java
+platform. The behavior when this fallback resolver cannot satisfy a request
+can be configured by setting the `jdk.xml.jdkcatalog.resolve` property, for
+which, again, the `setFirstSupportedProperty` method can be used.
+
 ### Extended API to set the content of a PL/Java `SQLXML` instance
 
 When a `SQLXML` instance is returned from a PL/Java function, or passed in to


### PR DESCRIPTION
Provide access for client code to features introduced in Java 22.

The Java 2 release notes include new XML features that should be exposed by PL/Java's `Adjusting.XML` API so they can be used by client code.

One new feature is already sufficiently exposed by the `setFirstSupportedProperty` method, so only a documentation note is added.