### PR TITLE
Consistent (SAX/DOM) wrapping of XML parse errors

### DIFF
--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/SQLXMLImpl.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/SQLXMLImpl.java
@@ -3933,6 +3933,10 @@ public abstract class SQLXMLImpl<V extends VarlenaWrapper> implements SQLXML
 						SAX2PROPERTY.LEXICAL_HANDLER.propertyUri(), lh);
 				xr.parse(sxs.getInputSource());
 			}
+			/*
+			 * If changing these wrapping conventions, change them also in
+			 * AdjustingDOMSource.get()
+			 */
 			catch ( SAXException e )
 			{
 				throw new SQLDataException(e.getMessage(), "22000", e);
@@ -5555,10 +5559,21 @@ public abstract class SQLXMLImpl<V extends VarlenaWrapper> implements SQLXML
 			}
 
 			Exception e = exceptions();
-			if ( null != e )
-				throw normalizedException(e);
 
-			return ds;
+			if ( null == e )
+				return ds;
+
+			/*
+			 * If changing these wrapping conventions, change them also in
+			 * XMLCopier.saxCopy()
+			 */
+			if ( e instanceof SAXException )
+				throw new SQLDataException(e.getMessage(), "22000", e);
+
+			if ( e instanceof IOException )
+				throw new SQLException(e.getMessage(), "58030", e);
+
+			throw normalizedException(e);
 		}
 
 		@Override


### PR DESCRIPTION
The logic that chooses wrapping `SQLException` subclass and `SQLstate` for XML parse exceptions and I/O exceptions in `XMLCopier.saxCopy` is now duplicated in `AdjustingDOMSource.get`, to eliminate the inconsistency that an XML parse error would be reported as a class 22 `SQLDataException` if using the SAX or StAX APIs, but as a class XX internal-error `SQLException` if using the DOM API.

Addresses issue #481.

This does change a user-visible behavior. It would be straightforward to make it depend on a flag, if there exists any code depending on the prior behavior. (I am judging that unlikely.)