### PR TITLE
CI: macos-latest: now without PostgreSQL

### DIFF
--- a/.github/workflows/ci-runnerpg.yml
+++ b/.github/workflows/ci-runnerpg.yml
@@ -3,7 +3,10 @@
 # does not have a PostgreSQL version in the build matrix. The version that's
 # preinstalled is the version you get.
 
-name: PL/Java CI with PostgreSQL version supplied by the runner
+name: CI with runner-supplied PostgreSQL version
+
+permissions:
+  contents: read
 
 on:
   push:
@@ -22,7 +25,7 @@ jobs:
         oscc:
           - os: ubuntu-latest
             cc: gcc
-          - os: macos-latest
+          - os: macos-12
             cc: clang
 #         - os: windows-latest
 #           cc: msvc


### PR DESCRIPTION
Per the 'roadmap' announced in actions/runner-images#9255, `macos-latest` now points to `macos-14` as of Q2, and the `macos-14` image does not supply any version of PostgreSQL (or any database; its much-shorter installed-software list might not be an oversight). Bad news for the quick workflow that relies on the runner's installed version.

Limit the MacOS CI to the `macos-12` runner for now. That should hold until the image is removed in Q4. A workflow that installs a specified PostgreSQL version may be needed after that.

Also, shorten the name of the workflow. It was too long to read in the online display of checks.

And add a restrictive `permissions:` entry, which was missing, and its absence is not secure-by-default.