### PR TITLE
Add output to simplify troubleshooting native build

### DIFF
--- a/pljava-pgxs/pom.xml
+++ b/pljava-pgxs/pom.xml
@@ -170,6 +170,8 @@ function executeReport(report, locale)
 			 */
 			"-locale",      locale.toString(),
 			"-quiet",
+			"--show-members", "package",
+			"--show-types",   "package",
 			/*
 			 * Options that are passed to the doclet.
 			 */

--- a/pljava-pgxs/src/main/java/org/postgresql/pljava/pgxs/AbstractPGXS.java
+++ b/pljava-pgxs/src/main/java/org/postgresql/pljava/pgxs/AbstractPGXS.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2020-2024 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -21,33 +21,59 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 /**
- * Class to act as a blueprint for platform specific build configurations in
- * pljava-so/pom.xml
+ * Class to act as a blueprint for platform-specific build configurations in a
+ * {@code pom.xml}.
+ *<p>
+ * A {@code scripted-goal} configuration in the POM should contain a script
+ * that somehow selects and supplies a concrete implementation of this abstract
+ * class.
+ *<p>
+ * In {@code pljava-so/pom.xml}, a block of {@code application/javascript} is
+ * supplied that contains a {@code configuration} array of JS objects, each of
+ * which has a {@code name} entry, a {@code probe} function returning true on
+ * some supported platform, and the necessary functions to serve as an
+ * implementation of this class. The script selects one whose probe succeeds
+ * and, using JSR 223 magic, makes an instance of this class from it.
+ *<p>
+ * The script can make use of convenience methods implemented here, and also
+ * a number of items (such as a {@code runCommand} function) presupplied in the
+ * script engine's binding scope by
+ * {@link PGXSUtils#getScriptEngine PGXSUtils.getScriptEngine} and by
+ * {@link ScriptingMojo#execute ScriptingMojo.execute}).
  */
 public abstract class AbstractPGXS
 {
+	/**
+	 * Performs platform-specific compilation of a set of {@code .c} files with
+	 * the specified compiler, target path, includes, defines, and flags.
+	 *<p>
+	 * An implementation should make any needed adjustments to the includes,
+	 * defines, and flags, format everything appropriately for the compiler
+	 * in question, execute it, and return an exit status (zero on success).
+	 */
+	public abstract int compile(
+		String compiler, List<String> files, Path targetPath,
+		List<String> includes, Map<String, String> defines, List<String> flags);
 
 	/**
-	 * Add instructions for compiling the pljava-so C files on your platform
-	 * by implementing this method in your configuration block.
+	 * Performs platform-specific linking of a set of object files with
+	 * the specified linker and flags, to produce the shared object at the
+	 * specified target path.
+	 *<p>
+	 * An implementation should make any needed adjustments to the flags, format
+	 * everything appropriately for the linker in question, execute it, and
+	 * return an exit status (zero on success).
 	 */
-	public abstract int compile(String compiler, List<String> files, Path targetPath,
-								 List<String> includes, Map<String, String> defines,
-								 List<String> flags);
-
-	/**
-	 * Add instructions for linking and producing the pljava-so shared library
-	 * artifact on your platform by implementing this method in your
-	 * configuration block.
-	 */
-	public abstract int link(String linker, List<String> flags, List<String> files, Path targetPath);
+	public abstract int link(
+		String linker, List<String> flags, List<String> files, Path targetPath);
 
 	/**
 	 * Returns a list with all items prefixed with correct include flag symbol.
 	 *
 	 * This is the default implementation for formatting the list of includes,
-	 * and prefixes the includes with -I. For compilers like MSVC that require
-	 * different symbols, override this method in your configuration block.
+	 * and prefixes the includes with {@code -I}. For compilers like MSVC that
+	 * require different formatting, the script should supply an overriding
+	 * implementation of this method.
 	 */
 	public List<String> formatIncludes(List<String> includesList)
 	{
@@ -56,12 +82,13 @@ public abstract class AbstractPGXS
 	}
 
 	/**
-	 * Returns a list with all defines prefixed correctly.
+	 * Returns a list with all defines represented correctly.
 	 *
-	 * This is the default implementation for formatting the list of defines.
-	 * Each item is prefixed with -D. If the define is associated with a value,
-	 * adds equal symbol also followed by the value. If your linker expects a
-	 * different format, override the method in your configuration block.
+	 * This is the default implementation for formatting the map of defines.
+	 * Each item is prefixed with {@code -D}. If the name is mapped to a
+	 * non-null value, an {@code =} is appended, followed by the value. For
+	 * compilers like MSVC that require different formatting, the script should
+	 * supply an overriding implementation of this method.
 	 */
 	public List<String> formatDefines(Map<String, String> definesMap)
 	{
@@ -76,11 +103,11 @@ public abstract class AbstractPGXS
 	}
 
 	/**
-	 * Returns the input pg_config property as a list of individual flags split
-	 * at whitespace, except when quoted, and the quotes removed.
+	 * Returns the requested {@code pg_config} property as a list of individual
+	 * flags split at whitespace, except when quoted, and the quotes removed.
 	 *<p>
 	 * The assumed quoting convention is single straight quotes around regions
-	 * to be protected, which do not have to be the entire argument. This method
+	 * to be protected, which do not have to be an entire argument. This method
 	 * doesn't handle a value that <em>contains</em> a single quote as content;
 	 * the intended convention for that case doesn't seem to be documented, and
 	 * PostgreSQL's own build breaks in such a case, so there is little need,

--- a/pljava-pgxs/src/main/java/org/postgresql/pljava/pgxs/PGXSUtils.java
+++ b/pljava-pgxs/src/main/java/org/postgresql/pljava/pgxs/PGXSUtils.java
@@ -159,9 +159,21 @@ public final class PGXSUtils
 		context.setAttribute("buildPaths",
 			(Function<List<String>, Map<String, String>>) this::buildPaths,
 			GLOBAL_SCOPE);
+
 		context.setAttribute("runCommand",
-			(ToIntFunction<ProcessBuilder>) this::runCommand,
-			GLOBAL_SCOPE);
+			(ToIntFunction<ProcessBuilder>) b ->
+			{
+				log.debug("To run: " + b.command());
+				return runCommand(b);
+			}, GLOBAL_SCOPE);
+
+		context.setAttribute("runWindowsCRuntimeCommand",
+			(ToIntFunction<ProcessBuilder>) b ->
+			{
+				log.debug("To run (needs WindowsCRuntime transformation): " +
+					b.command());
+				return runCommand(forWindowsCRuntime(b));
+			}, GLOBAL_SCOPE);
 
 		/*
 		 * Also provide a specialized method useful for a script that may

--- a/pljava-pgxs/src/main/java/org/postgresql/pljava/pgxs/PGXSUtils.java
+++ b/pljava-pgxs/src/main/java/org/postgresql/pljava/pgxs/PGXSUtils.java
@@ -46,7 +46,7 @@ import java.util.regex.Pattern;
 import static java.lang.System.getProperty;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Stream.iterate;
-import static javax.script.ScriptContext.GLOBAL_SCOPE;
+import static javax.script.ScriptContext.ENGINE_SCOPE;
 
 /**
  * Utility methods to simplify and hide the bland implementation details
@@ -77,11 +77,47 @@ public final class PGXSUtils
 	}
 
 	/**
-	 * Returns a ScriptEngine with some basic utilities for scripting.
+	 * Returns a ScriptEngine with some useful engine-scoped bindings
+	 * supplied for the convenience of the script.
+	 *<p>
+	 * These bindings are placed in the engine's scope:
+	 *<dl>
+	 * <dt>project<dd>The Maven project instance
+	 * <dt>utils<dd>This object
+	 * <dt>error, warn, info, debug<dd>Consumers of {@link CharSequence} that
+	 * will log a message through Maven with the corresponding severity
+	 * <dt>diag<dd>A BiConsumer of {@link Diagnostic.Kind} and a
+	 * {@link CharSequence}, to log a message through Maven with its severity
+	 * determined by the {@code Diagnostic.Kind}.
+	 * <dt>runCommand<dd>A function from {@link ProcessBuilder} to {@code int}
+	 * that will run the specified command and return its exit status. The
+	 * command and arguments are first logged through Maven at {@code debug}
+	 * level.
+	 * <dt>runWindowsCRuntimeCommand<dd>A function from {@link ProcessBuilder}
+	 * to {@code int} that will apply the
+	 * {@link #forWindowsCRuntime forWindowsCRuntime} transformation to the
+	 * arguments and then run the specified command and return its exit
+	 * status. The command and arguments are first logged through Maven at
+	 * {@code debug} level, and before the transformation is applied.
+	 * <dt>buildPaths<dd>Separates a list of pathnames into those that belong
+	 * on a class path and those that belong on a module path.
+	 * <dt>getPgConfigProperty<dd>Returns the output of {@code pg_config} when
+	 * run with the given single argument.
+	 * <dt>isProfileActive<dd>Predicate indicating whether a named Maven profile
+	 * is active.
+	 * <dt>quoteStringForC<dd>Transforms a {@code String} into a C string
+	 * literal representing it.
+	 * <dt>resolve<dd>A direct reference to the {code Path.resolve} overload
+	 * with {@code Path} parameter types, to work around some versions of
+	 * graaljs being unable to determine which overload a script intends.
+	 * <dt>setProjectProperty<dd>Sets a property of the Maven project to a
+	 * supplied value.
+	 *</dl>
 	 *
 	 * @param script the script block element in the configuration block of the
-	 *               plugin in the project
-	 * @return ScriptEngine based on the engine and mime type provided in the
+	 * plugin in the project object model. Its {@code mimetype} or
+	 * {@code engine} attribute will be used to find a suitable engine
+	 * @return ScriptEngine based on the engine and/or MIME type provided in the
 	 * script block
 	 */
 	ScriptEngine getScriptEngine(PlexusConfiguration script)
@@ -111,8 +147,9 @@ public final class PGXSUtils
 					" mimetype defined.");
 			else
 			{
-				ScriptEngineManager manager = new ScriptEngineManager(
-					new ScriptEngineLoader(ScriptingMojo.class.getClassLoader()));
+				ScriptEngineManager manager =
+					new ScriptEngineManager(new ScriptEngineLoader(
+						ScriptingMojo.class.getClassLoader()));
 
 				if (engineName != null)
 					engine = manager.getEngineByName(engineName);
@@ -137,6 +174,15 @@ public final class PGXSUtils
 			log.error(e);
 		}
 
+		ScriptContext context = engine.getContext();
+
+		/*
+		 * Give the script convenient access to the Maven project and this
+		 * object.
+		 */
+		context.setAttribute("project", project, ENGINE_SCOPE);
+		context.setAttribute("utils", this, ENGINE_SCOPE);
+
 		/*
 		 * Give the script some convenient methods for logging to the Maven log.
 		 * Only supply the versions with one CharSequence parameter, in case of
@@ -144,36 +190,14 @@ public final class PGXSUtils
 		 * have another way to get access to the Log instance and use its other
 		 * methods; these are just for convenience.
 		 */
-		ScriptContext context = engine.getContext();
-		context.setAttribute("debug",
-			(Consumer<CharSequence>) log::debug, GLOBAL_SCOPE);
 		context.setAttribute("error",
-			(Consumer<CharSequence>) log::error, GLOBAL_SCOPE);
+			(Consumer<CharSequence>) log::error, ENGINE_SCOPE);
 		context.setAttribute("warn",
-			(Consumer<CharSequence>) log::warn, GLOBAL_SCOPE);
+			(Consumer<CharSequence>) log::warn, ENGINE_SCOPE);
 		context.setAttribute("info",
-			(Consumer<CharSequence>) log::info, GLOBAL_SCOPE);
-		context.setAttribute("isProfileActive",
-			(Function<String, Boolean>) this::isProfileActive,
-			GLOBAL_SCOPE);
-		context.setAttribute("buildPaths",
-			(Function<List<String>, Map<String, String>>) this::buildPaths,
-			GLOBAL_SCOPE);
-
-		context.setAttribute("runCommand",
-			(ToIntFunction<ProcessBuilder>) b ->
-			{
-				log.debug("To run: " + b.command());
-				return runCommand(b);
-			}, GLOBAL_SCOPE);
-
-		context.setAttribute("runWindowsCRuntimeCommand",
-			(ToIntFunction<ProcessBuilder>) b ->
-			{
-				log.debug("To run (needs WindowsCRuntime transformation): " +
-					b.command());
-				return runCommand(forWindowsCRuntime(b));
-			}, GLOBAL_SCOPE);
+			(Consumer<CharSequence>) log::info, ENGINE_SCOPE);
+		context.setAttribute("debug",
+			(Consumer<CharSequence>) log::debug, ENGINE_SCOPE);
 
 		/*
 		 * Also provide a specialized method useful for a script that may
@@ -199,14 +223,62 @@ public final class PGXSUtils
 					break;
 				}
 			}
-			), GLOBAL_SCOPE);
+			), ENGINE_SCOPE);
 
 		/*
-		 * Give the script convenient access to the Maven project and this
-		 * object.
+		 * Supply a runCommand function to which the script can supply
+		 * a ProcessBuilder after configuring it as needed, and an alias
+		 * runWindowsCRuntimeCommand that does the same, but applies the
+		 * forWindowsCRuntime transformation to the ProcessBuilder's arguments
+		 * first. Two aliases are used so that the command arguments can be
+		 * logged (at debug level) in either case, and before the transformation
+		 * is applied, in the Windows case.
 		 */
-		context.setAttribute("project", project, GLOBAL_SCOPE);
-		context.setAttribute("utils", this, GLOBAL_SCOPE);
+		context.setAttribute("runCommand",
+			(ToIntFunction<ProcessBuilder>) b ->
+			{
+				log.debug("To run: " + b.command());
+				return runCommand(b);
+			}, ENGINE_SCOPE);
+
+		context.setAttribute("runWindowsCRuntimeCommand",
+			(ToIntFunction<ProcessBuilder>) b ->
+			{
+				log.debug("To run (needs WindowsCRuntime transformation): " +
+					b.command());
+				return runCommand(forWindowsCRuntime(b));
+			}, ENGINE_SCOPE);
+
+		/*
+		 * Convenient access to some other methods provided here.
+		 */
+		context.setAttribute("buildPaths",
+			(Function<List<String>, Map<String, String>>) this::buildPaths,
+			ENGINE_SCOPE);
+
+		context.setAttribute("getPgConfigProperty",
+			(Function<String, String>) p ->
+			{
+				try
+				{
+					return getPgConfigProperty(p);
+				}
+				catch ( Exception e )
+				{
+					log.error(e);
+					return null;
+				}
+			}, ENGINE_SCOPE);
+
+		context.setAttribute("isProfileActive",
+			(Function<String, Boolean>) this::isProfileActive,
+			ENGINE_SCOPE);
+
+		context.setAttribute("quoteStringForC",
+			(Function<String, String>) this::quoteStringForC, ENGINE_SCOPE);
+
+		context.setAttribute("setProjectProperty",
+			(BiConsumer<String, String>)this::setProjectProperty, ENGINE_SCOPE);
 
 		/*
 		 * A graaljs bug (graalvm/graaljs#254) means that when you are passing
@@ -215,7 +287,7 @@ public final class PGXSUtils
 		 * (Path,Path) function to make it a little more blindingly obvious.
 		 */
 		context.setAttribute("resolve", (BinaryOperator<Path>)Path::resolve,
-			GLOBAL_SCOPE);
+			ENGINE_SCOPE);
 
 		return engine;
 	}
@@ -225,7 +297,7 @@ public final class PGXSUtils
 	 * escaped where appropriate using the C conventions.
 	 *
 	 * @param s string to be escaped
-	 * @return a C compatible String enclosed in double quotes
+	 * @return a C string literal representing <var>s</var>
 	 */
 	public String quoteStringForC (String s)
 	{
@@ -276,7 +348,8 @@ public final class PGXSUtils
 	}
 
 	/**
-	 * Returns the string decoded from input bytes using default platform charset.
+	 * Returns the string decoded from input bytes using default platform
+	 * charset.
 	 *
 	 * @param bytes byte array to be decoded
 	 * @return string decoded from input bytes
@@ -291,30 +364,27 @@ public final class PGXSUtils
 	}
 
 	/**
-	 * Returns the output, decoded using default platform charset, of the input
-	 * command executed with the input argument.
+	 * Returns the output, decoded using default platform charset, of the
+	 * {@code pg_config} command executed with the single supplied argument.
 	 * <p>
-	 * If the input parameter {@code pgConfigCommand} is empty or null,
-	 * {@code pg_config} is used as the default value. If multiple version of
-	 * {@code pg_config} are available or {@code pg_config} is not present on
-	 * the path, consider passing an absolute path to {@code pg_config}. It is
-	 * also recommended that only a single property be passed at a time.
+	 * If multiple versions of {@code pg_config} are available or
+	 * {@code pg_config} is not present on the path, the system property
+	 * {@code pgsql.pgconfig} should be set as an absolute path to the desired
+	 * executable.
 	 *
-	 * @param pgConfigCommand pg_config command to execute
 	 * @param pgConfigArgument argument to be passed to the command
 	 * @return output of the input command executed with the input argument
 	 * @throws IOException if unable to read output of the command
 	 * @throws InterruptedException if command does not complete successfully
 	 */
-	public String getPgConfigProperty (String pgConfigCommand,
-	                                   String pgConfigArgument)
+	public String getPgConfigProperty (String pgConfigArgument)
 		throws IOException, InterruptedException
 	{
-		if (pgConfigCommand == null || pgConfigCommand.isEmpty())
-			pgConfigCommand = "pg_config";
+		String pgConfigCommand =
+			System.getProperty("pgsql.pgconfig", "pg_config");
 
-		ProcessBuilder processBuilder = new ProcessBuilder(pgConfigCommand,
-			pgConfigArgument);
+		ProcessBuilder processBuilder =
+			new ProcessBuilder(pgConfigCommand, pgConfigArgument);
 		processBuilder.redirectError(ProcessBuilder.Redirect.INHERIT);
 		Process process = processBuilder.start();
 		process.getOutputStream().close();
@@ -365,8 +435,19 @@ public final class PGXSUtils
 	}
 
 	/**
-	 * Returns a ProcessBuilder with suitable defaults and arguments added from
-	 * input function.
+	 * Sets the value of a property for the current project.
+	 *
+	 * @param property key to use for property
+	 * @param value the value of property to set
+	 */
+	public void setProjectProperty (String property, String value)
+	{
+		project.getProperties().setProperty(property, value);
+	}
+
+	/**
+	 * Returns a ProcessBuilder with suitable defaults and arguments added
+	 * by the supplied <var>consumer</var>.
 	 *
 	 * @param consumer function which adds arguments to the ProcessBuilder
 	 * @return ProcessBuilder with input arguments and suitable defaults
@@ -408,7 +489,7 @@ public final class PGXSUtils
 	 * Returns true if the profile with given name exists and is active, false
 	 * otherwise.
 	 * <p>
-	 * A warning is logged if the no profile with the input name exists in the
+	 * A warning is logged if no profile with the input name exists in the
 	 * current project.
 	 *
 	 * @param profileName name of profile to check
@@ -431,8 +512,13 @@ public final class PGXSUtils
 	}
 
 	/**
-	 * Returns a map with two elements with {@code classpath} and {@code modulepath}
-	 * as keys and their joined string paths as the respective values.
+	 * Returns a two-element map with with {@code classpath} and
+	 * {@code modulepath} as keys and their joined string paths as the
+	 * respective values.
+	 *<p>
+	 * For each supplied element,
+	 * {@link #shouldPlaceOnModulepath shouldPlaceOnModulepath} is used to
+	 * determine which path the element is added to.
 	 *
 	 * @param elements list of elements to build classpath and modulepath from
 	 * @return a map containing the {@code classpath} and {@code modulepath}
@@ -449,7 +535,8 @@ public final class PGXSUtils
 			{
 				if (element.contains(pathSeparator))
 					log.warn(String.format("cannot add %s to path because " +
-						"it contains path separator %s", element, pathSeparator));
+						"it contains path separator %s",
+						element, pathSeparator));
 				else if (shouldPlaceOnModulepath(element))
 					modulepathElements.add(element);
 				else
@@ -469,11 +556,13 @@ public final class PGXSUtils
 	 * Returns true if the element should be placed on the module path.
 	 * <p>
 	 * An file path element should be placed on the module path if it points to
-	 * 1) a directory with a top level {@code module-info.class} file
-	 * 2) a {@code JAR} file having a {@code module-info.class} entry or the
+	 * <ol>
+	 * <li>a directory with a top level {@code module-info.class} file
+	 * <li>a {@code JAR} file having a {@code module-info.class} entry or the
 	 * {@code Automatic-Module-Name} as a manifest attribute
+	 * </ol>
 	 *
-	 * @param filePath the filepath to check whether is a module
+	 * @param filePath the filepath to check
 	 * @return true if input path should go on modulepath, false otherwise
 	 * @throws IOException any thrown by the underlying file operations
 	 */
@@ -504,9 +593,10 @@ public final class PGXSUtils
 	}
 
 	/**
-	 * Returns the list of files with given extension in the input directory.
+	 * Returns a list of files with given extension in and below
+	 * the input directory.
 	 *
-	 * @param sourceDirectory to list files inside
+	 * @param sourceDirectory root of the tree of files to list
 	 * @param extension to filter files to be selected
 	 * @return list of strings of absolute paths of files
 	 */
@@ -529,9 +619,9 @@ public final class PGXSUtils
 	}
 
 	/*
-	 * The same method is duplicated in pljava-packaging/Node.java . While making
-	 * changes to this method, review the other occurrence also and replicate the
-	 * changes there if desirable.
+	 * This method is duplicated in pljava-packaging/Node.java. If making
+	 * changes to this method, review the other occurrence also and replicate
+	 * the changes there if desirable.
 	 */
 	/**
 	 * Adjust the command arguments of a {@code ProcessBuilder} so that they
@@ -539,7 +629,7 @@ public final class PGXSUtils
 	 * the argument parsing algorithm of the usual C run-time code, when it is
 	 * known that the command will not be handled first by {@code cmd}.
 	 *<p>
-	 * This transformation must account for the way the C runtime will
+	 * This transformation must account for the way the Windows C runtime will
 	 * ultimately parse the parameters apart, and also for the behavior of
 	 * Java's runtime in assembling the command line that the invoked process
 	 * will receive.
@@ -548,7 +638,7 @@ public final class PGXSUtils
 	 * should result from parsing.
 	 * @return The same ProcessBuilder, with the argument list rewritten as
 	 * necessary to produce the original list as a result of Windows C runtime
-	 * parsing,
+	 * parsing.
 	 * @throws IllegalArgumentException if the ProcessBuilder does not have at
 	 * least the first command element (the executable to run)
 	 * @throws UnsupportedOperationException if the arguments passed, or system

--- a/pljava-pgxs/src/main/java/org/postgresql/pljava/pgxs/ReportScriptingMojo.java
+++ b/pljava-pgxs/src/main/java/org/postgresql/pljava/pgxs/ReportScriptingMojo.java
@@ -27,13 +27,14 @@ import javax.script.ScriptEngine;
 import java.util.Locale;
 
 /**
- * Maven plugin goal to use JavaScript for configuring
+ * Maven plugin goal to use JavaScript (or another JSR 223 script engine)
+ * for configuring
  * {@link org.apache.maven.reporting.MavenReport} during the
  * {@link LifecyclePhase#SITE}.
  * <p>
- * This plugin goal intends to allow the use of JavaScript during {@code SITE}
+ * This plugin goal intends to allow the use of scripting in the {@code SITE}
  * lifecycle phase with the help of {@link ReportScript}. The motivation behind
- * this is the inability to use Maven AntRun during {@code SITE} phase.
+ * this is the inability to use Maven AntRun in the {@code SITE} phase.
  */
 @Mojo(name = "scripted-report")
 @Execute(phase = LifecyclePhase.NONE)
@@ -80,15 +81,17 @@ public class ReportScriptingMojo extends AbstractMavenReport
 	}
 
 	/**
-	 * Returns the path relative to the target site directory of the this report.
+	 * Queries the script for the report output path relative to the target site
+	 * directory.
+	 * <p>
 	 * This value will be used by {@code Maven} to provide a link to the report
 	 * from {@code index.html}.
 	 * <p>
 	 * Calls {@code setReportScript} to ensure that the instance of
 	 * {@link ReportScript} is available. Invokes
-	 * {@code fun getOutputName(report)} defined in the JavaScript snippet
-	 * associated with the report. No default implementation is provided. User
-	 * must implement the method in JavaScript.
+	 * {@code getOutputName(report)} defined by the script snippet
+	 * associated with the report. No default implementation is provided; the
+	 * script must implement this method.
 	 */
 	@Override
 	public String getOutputName ()
@@ -98,15 +101,15 @@ public class ReportScriptingMojo extends AbstractMavenReport
 	}
 
 	/**
-	 * Returns false if this report will produce output through a
-	 * supplied {@link Sink}, true if it is 'external', producing its output
-	 * some other way.
+	 * Queries the script to return false if this report will produce output
+	 * through a supplied {@link Sink}, or true if it is 'external', producing
+	 * its output some other way.
 	 * <p>
 	 * Calls {@code setReportScript} to ensure that the instance of
 	 * {@link ReportScript} is available. Invokes
-	 * {@code fun isExternalReport(report)} if defined in the javascript
-	 * snippet associated with the report. Otherwise, the {@code super}
-	 * implementation is invoked effectively.
+	 * {@code isExternalReport(report)} if defined in the script
+	 * snippet associated with the report. Otherwise, the implementation
+	 * inherited by this class is effectively invoked.
 	 */
 	@Override
 	public boolean isExternalReport ()
@@ -116,14 +119,14 @@ public class ReportScriptingMojo extends AbstractMavenReport
 	}
 
 	/**
-	 * Returns the name of this report used by {@code Maven} for displaying in
-	 * {@code index.html}.
+	 * Queries the script for the name of this report to be used
+	 * by {@code Maven} for display in {@code index.html}.
 	 * <p>
 	 * Calls {@code setReportScript} to ensure that the instance of
 	 * {@link ReportScript} is available. Invokes
-	 * {@code fun getName(report, locale)} defined in the javascript
-	 * snippet associated with the report. No default implementation is provided
-	 * . User must implement the method in javascript.
+	 * {@code getName(report, locale)} defined by the script
+	 * snippet associated with the report. No default implementation is
+	 * provided; the script must implement this method.
 	 */
 	@Override
 	public String getName (Locale locale)
@@ -133,14 +136,14 @@ public class ReportScriptingMojo extends AbstractMavenReport
 	}
 
 	/**
-	 * Returns the description of this report, used by {@code Maven} to display
-	 * report description in {@code index.html}.
+	 * Queries the script for the description of this report, to be used
+	 * by {@code Maven} for display in {@code index.html}.
 	 * <p>
 	 * Calls {@code setReportScript} to ensure that the instance of
 	 * {@link ReportScript} is available. Invokes
-	 * {@code fun getDescription(report, locale)} defined in the javascript
-	 * snippet associated with the report. No default implementation is provided
-	 * . User must implement the method in javascript.
+	 * {@code getDescription(report, locale)} defined in the script
+	 * snippet associated with the report. No default implementation is
+	 * provided; the script must implement this method.
 	 */
 	@Override
 	public String getDescription (Locale locale)
@@ -150,14 +153,15 @@ public class ReportScriptingMojo extends AbstractMavenReport
 	}
 
 	/**
-	 * Returns the category name of this report, used by {@code Maven} to display
-	 * the report under the correct in {@code index.html}.
+	 * Queries the script for the category name of this report, used
+	 * by {@code Maven} to place the report under the correct heading
+	 * in {@code index.html}.
 	 * <p>
 	 * Calls {@code setReportScript} to ensure that the instance of
 	 * {@link ReportScript} is available. Invokes
-	 * {@code fun getCategoryName(report)} if defined in the javascript
-	 * snippet associated with the report. Otherwise, the {@code super}
-	 * implementation is invoked effectively.
+	 * {@code getCategoryName(report)} if defined by the script
+	 * snippet associated with the report. Otherwise, the implementation
+	 * inherited by this class is effectively invoked.
 	 */
 	@Override
 	public String getCategoryName ()
@@ -167,13 +171,13 @@ public class ReportScriptingMojo extends AbstractMavenReport
 	}
 
 	/**
-	 * Returns true if a report can be generated, false otherwise.
+	 * Queries the script as to whether this report can be generated.
 	 * <p>
 	 * Calls {@code setReportScript} to ensure that the instance of
 	 * {@link ReportScript} is available. Invokes
-	 * {@code fun canGenerateReport(report)} if defined in the javascript
-	 * snippet. Otherwise, the {@code super} implementation is invoked
-	 * effectively.
+	 * {@code canGenerateReport(report)} if defined by the script
+	 * snippet. Otherwise, the implementation inherited by this class is
+	 * effectively invoked.
 	 */
 	@Override
 	public boolean canGenerateReport ()
@@ -186,9 +190,9 @@ public class ReportScriptingMojo extends AbstractMavenReport
 	 * {@inheritDoc}
 	 * <p>
 	 * Calls {@code setReportScript} to ensure that the instance of
-	 * {@link ReportScript} is available. Invokes the
-	 * {@code fun executeReport(report, locale)} with the instance of the
-	 * current report.
+	 * {@link ReportScript} is available. Invokes its
+	 * {@code executeReport(report, locale)}, passing this instance and
+	 * the supplied locale.
 	 */
 	@Override
 	protected void executeReport (Locale locale) throws MavenReportException
@@ -229,7 +233,7 @@ public class ReportScriptingMojo extends AbstractMavenReport
 	/**
 	 * Default implementation for
 	 * {@link ReportScript#isExternalReport(ReportScriptingMojo)}. Invoked if
-	 * {@code fun isExternalReport(report)} is not defined in the javascript
+	 * {@code isExternalReport(report)} is not defined in the script
 	 * snippet associated with the report.
 	 */
 	boolean isExternalReportDefault ()
@@ -240,7 +244,7 @@ public class ReportScriptingMojo extends AbstractMavenReport
 	/**
 	 * Default implementation of
 	 * {@link ReportScript#getCategoryName(ReportScriptingMojo)}. Invoked if
-	 * {@code fun getCategoryName(report)} is not defined in the javascript
+	 * {@code getCategoryName(report)} is not defined in the script
 	 * snippet associated with the report.
 	 */
 	String getCategoryNameDefault ()
@@ -251,7 +255,7 @@ public class ReportScriptingMojo extends AbstractMavenReport
 	/**
 	 * Default implementation of
 	 * {@link ReportScript#canGenerateReport(ReportScriptingMojo)}. Invoked if
-	 * {@code fun canGenerateReport(report)} is not defined in the javascript
+	 * {@code canGenerateReport(report)} is not defined in the script
 	 * snippet associated with the report.
 	 */
 	boolean canGenerateReportDefault ()
@@ -263,16 +267,17 @@ public class ReportScriptingMojo extends AbstractMavenReport
 	 * Wraps the input object in a {@link MavenReportException}.
 	 *
 	 * The exception returned is constructed as follows:
-	 * 1) If {@code object} is null, the exception message indicates the same.
-	 * 2) If {@code object} is already a {@link MavenReportException}, return it
-	 * as is.
-	 * 3) If {@code object} is any other {@link Throwable}, set it as the cause
-	 * for the exception.
-	 * {@link MavenReportException} with {@code object} as its cause.
-	 * 4) If {@code object} is a {@link String}, set it as the message of the
-	 * exception.
-	 * 5) For all other case, the message of the exception is set in this format
-	 * , Class Name of object: String representation of object.
+	 *<ul>
+	 * <li>If {@code object} is null, the exception message indicates the same.
+	 * <li>If {@code object} is already a {@link MavenReportException}, it is
+	 * returned as is.
+	 * <li>If {@code object} is any other {@link Throwable}, it is used as
+	 * the wrapping exception's cause.
+	 * <li>If {@code object} is a {@link String}, it is used as
+	 * the wrapping exception's message.
+	 * <li>If it is any other object, the wrapping exception's message is set in
+	 * this format: Class mame of object: String representation of object.
+	 *</ul>
 	 *
 	 * @param object to wrap in MavenReportException
 	 * @return object wrapped inside a {@link MavenReportException}
@@ -286,7 +291,8 @@ public class ReportScriptingMojo extends AbstractMavenReport
 		else if (object instanceof Throwable)
 		{
 			Throwable t = (Throwable) object;
-			MavenReportException exception = new MavenReportException(t.getMessage());
+			MavenReportException exception =
+				new MavenReportException(t.getMessage());
 			exception.initCause(t);
 			return exception;
 		}

--- a/pljava-pgxs/src/main/java/org/postgresql/pljava/pgxs/ReportScriptingMojo.java
+++ b/pljava-pgxs/src/main/java/org/postgresql/pljava/pgxs/ReportScriptingMojo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2020-2024 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -70,7 +70,6 @@ public class ReportScriptingMojo extends AbstractMavenReport
 			utils = new PGXSUtils(project, getLog());
 			ScriptEngine engine = utils.getScriptEngine(script);
 			String scriptText = script.getValue();
-			getLog().debug(scriptText);
 			engine.eval(scriptText);
 			reportScript = ((Invocable)engine).getInterface(ReportScript.class);
 		}

--- a/pljava-pgxs/src/main/java/org/postgresql/pljava/pgxs/ScriptingMojo.java
+++ b/pljava-pgxs/src/main/java/org/postgresql/pljava/pgxs/ScriptingMojo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2020-2024 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -66,7 +66,6 @@ public class ScriptingMojo extends AbstractMojo
 			utils = new PGXSUtils(project, getLog());
 			String scriptText = script.getValue();
 			ScriptEngine engine = utils.getScriptEngine(script);
-			getLog().debug(scriptText);
 
 			engine.getContext().setAttribute("session", session,
 				ScriptContext.GLOBAL_SCOPE);

--- a/pljava-pgxs/src/main/java/org/postgresql/pljava/pgxs/ScriptingMojo.java
+++ b/pljava-pgxs/src/main/java/org/postgresql/pljava/pgxs/ScriptingMojo.java
@@ -25,18 +25,20 @@ import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.configuration.PlexusConfiguration;
 
 import javax.script.Invocable;
-import javax.script.ScriptContext;
 import javax.script.ScriptEngine;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
+import static javax.script.ScriptContext.ENGINE_SCOPE;
+
 /**
- * Maven plugin goal to use JavaScript during any of build lifecycle phases.
+ * Maven plugin goal to use JavaScript (or another JSR 223 script engine)
+ * during any of build lifecycle phases.
  * <p>
- * The Mojo provides a limited subset of the functionality provided Maven AntRun
- * Plugin. This is intentional to simplify usage as this maven plugin is
- * specifically targeted at building Pl/Java native code.
+ * The Mojo provides a limited subset of the functionality of the Maven AntRun
+ * Plugin. This is intentional to simplify usage, as this Maven plugin is
+ * specifically targeted at building PL/Java native code.
  */
 @Mojo(name = "scripted-goal", defaultPhase = LifecyclePhase.COMPILE,
       requiresDependencyResolution = ResolutionScope.TEST)
@@ -55,8 +57,17 @@ public class ScriptingMojo extends AbstractMojo
 	private PGXSUtils utils;
 
 	/**
-	 * Executes the javascript code inside {@code script} tag inside plugin
+	 * Executes the script code inside the {@code script} tag in the plugin
 	 * configuration.
+	 *<p>
+	 * Uses {@link PGXSUtils#getScriptEngine PGXSUtils.getScriptEngine}
+	 * to instantiate the engine, and then makes these items available in
+	 * the engine's scope (in addition to those placed there by
+	 * {@link PGXSUtils#getScriptEngine getScriptEngine} itself):
+	 *<dl>
+	 * <dt>session<dd>The Maven session object
+	 * <dt>plugin<dd>This object
+	 *</dl>
 	 */
 	@Override
 	public void execute () throws MojoExecutionException, MojoFailureException
@@ -67,19 +78,14 @@ public class ScriptingMojo extends AbstractMojo
 			String scriptText = script.getValue();
 			ScriptEngine engine = utils.getScriptEngine(script);
 
-			engine.getContext().setAttribute("session", session,
-				ScriptContext.GLOBAL_SCOPE);
-			engine.getContext().setAttribute("plugin", this,
-				ScriptContext.GLOBAL_SCOPE);
-			engine.put("quoteStringForC",
-				(Function<String, String>) utils::quoteStringForC);
-			engine.put("setProjectProperty",
-				(BiConsumer<String, String>) this::setProjectProperty);
-			engine.put("getPgConfigProperty",
-				(Function<String, String>) this::getPgConfigProperty);
+			engine.getContext().setAttribute("session", session, ENGINE_SCOPE);
+			engine.getContext().setAttribute("plugin", this, ENGINE_SCOPE);
+
 			engine.eval(scriptText);
 
-			GoalScript goal = ((Invocable) engine).getInterface(GoalScript.class);
+			GoalScript goal =
+				((Invocable) engine).getInterface(GoalScript.class);
+
 			AbstractMojoExecutionException exception = goal.execute();
 			if (exception != null)
 				throw exception;
@@ -95,63 +101,33 @@ public class ScriptingMojo extends AbstractMojo
 	}
 
 	/**
-	 * Sets the value of a property for the current project.
-	 *
-	 * @param property key to use for property
-	 * @param value the value of property to set
-	 */
-	public void setProjectProperty (String property, String value)
-	{
-		project.getProperties().setProperty(property, value);
-	}
-
-	/**
-	 * Returns the value of a pg_config property.
-	 *
-	 * @param property property whose value is to be retrieved from pg_config
-	 * @return output of pg_config executed with the input property as argument
-	 */
-	public String getPgConfigProperty (String property)
-	{
-		try
-		{
-			String pgConfigCommand = System.getProperty("pgsql.pgconfig");
-			return utils.getPgConfigProperty(pgConfigCommand, property);
-		}
-		catch (Exception e)
-		{
-			getLog().error(e);
-			return null;
-		}
-	}
-
-	/**
-	 * Wraps the input object in a {@link AbstractMojoExecutionException}.
+	 * Wraps the input object in an {@link AbstractMojoExecutionException}.
 	 *
 	 * The returned exception is constructed as follows:
-	 * 1) If {@code object} is null, then {@link MojoExecutionException} is used
-	 * to wrap and the message indicates that null value was thrown by the script.
-	 * 2) If {@code object} is already a {@link MojoExecutionException}, return
-	 * it as is.
-	 * 3) If {@code object} is already a {@link MojoFailureException}, return it
-	 * as is.
+	 *<ul>
+	 * <li>If {@code object} is null, then {@link MojoExecutionException} is
+	 * used to wrap and the message indicates that a null value was thrown
+	 * by the script.
+	 * <li>If {@code object} is already a {@link MojoExecutionException}, it is
+	 * returned as is.
+	 * <li>If {@code object} is already a {@link MojoFailureException}, it is
+	 * returned as is.
+	 * <li>For the steps below, the wrapping exception is chosen according to
+	 * the value of the {@code scriptFailure} parameter.
+	 * <li>If {@code object} is any other {@link Throwable}, set it as
+	 * the wrapping exception's cause.
+	 * <li>If {@code object} is a {@link String}, set it as the wrapping
+	 * exception's message.
+	 * <li>For any other object, the message of the exception is set in
+	 * this format: Class name of object: String representation of object.
+	 *</ul>
 	 *
-	 * For the steps, below the wrapping exception is chosen according to the
-	 * the value of {@code scriptFailure} parameter.
-	 *
-	 * 4) If {@code object} is any other {@link Throwable}, set it as the cause
-	 * for the exception.
-	 * 5) If {@code object} is a {@link String}, set it as the message of the
-	 * exception.
-	 * 6) For all other case, the message of the exception is set in this format
-	 * , Class Name of object: String representation of object.
-	 *
-	 * @param object to wrap in AbstractMojoExecutionException
-	 * @param scriptFailure if true, use a MojoExecutionException for wrapping
-	 *                      otherwise use MojoFailureException. this parameter
-	 *                      is ignored, if the object is null or instance of
+	 * @param object an object to wrap in an AbstractMojoExecutionException
+	 * @param scriptFailure if true, use a MojoExecutionException for wrapping,
+	 *                      otherwise use MojoFailureException. This parameter
+	 *                      is ignored if the object is null or an instance of
 	 *                      MojoExecutionException or MojoFailureException
-	 * @return object wrapped inside a {@link AbstractMojoExecutionException}
+	 * @return object wrapped inside an {@link AbstractMojoExecutionException}
 	 */
 	public AbstractMojoExecutionException exceptionWrap(Object object,
 														boolean scriptFailure)

--- a/pljava-so/pom.xml
+++ b/pljava-so/pom.xml
@@ -66,6 +66,8 @@
 		Paths.get(base_dir_path, "..", "pljava", "target", "javah-include").toString()
 	));
 
+	utils.reportPostgreSQLVersion(includedir_server);
+
 	var base_defines = new HashMap();
 	base_defines.put("PLJAVA_SO_VERSION", project.parent.version);
 	if ( cc.equalsIgnoreCase("gcc") )

--- a/pljava-so/pom.xml
+++ b/pljava-so/pom.xml
@@ -241,7 +241,7 @@
 					l.addAll(files);
 				});
 				compileProcess.directory(output_dir.toFile());
-				return runCommand(utils.forWindowsCRuntime(compileProcess));
+				return runWindowsCRuntimeCommand(compileProcess);
 			},
 
 			link : function(cc, flags, files, target_path) {
@@ -258,7 +258,7 @@
 					l.addAll(of("-L" + pkglibdir, "-Bdynamic", "-lpostgres"));
 				});
 				linkingProcess.directory(target_path.toFile());
-				return runCommand(utils.forWindowsCRuntime(linkingProcess));
+				return runWindowsCRuntimeCommand(linkingProcess);
 			}
 		},
 


### PR DESCRIPTION
Add to the build scripting for `pljava-so` so that the detailed `PG_VERSION_STR` will appear in the Maven output to clarify what PG version has been found to build against.

This should simplify responding to issues like #487, where the first obvious question is "what version of PostgreSQL is this being built against, anyway?".

The version is logged at Maven's `INFO` level, so should be present in the output with no special effort.

Also log, at Maven's `DEBUG` level, the actual arguments being supplied to the compiler and linker. These will only be seen if Maven is run with `-X`, which therefore can be useful if some more thorny build issue needs to be investigated.

Improve javadoc in `pljava-pgxs`, to serve as a better reference for what the functions and objects used in the `pljava-so` POM build script are for.