### PR TITLE
Fix build errors with PostgreSQL v17

### DIFF
--- a/pljava-so/src/main/c/InstallHelper.c
+++ b/pljava-so/src/main/c/InstallHelper.c
@@ -90,7 +90,11 @@ bool pljavaViableXact()
 
 char *pljavaDbName()
 {
+#if PG_VERSION_NUM >= 170000
+	if ( AmAutoVacuumWorkerProcess() || AmBackgroundWorkerProcess() )
+#else
 	if ( IsAutoVacuumWorkerProcess() || IsBackgroundWorker )
+#endif
 	{
 		char *shortlived;
 		static char *longlived;
@@ -110,7 +114,11 @@ char *pljavaDbName()
 
 static char *origUserName()
 {
+#if PG_VERSION_NUM >= 170000
+	if ( AmAutoVacuumWorkerProcess() || AmBackgroundWorkerProcess() )
+#else
 	if ( IsAutoVacuumWorkerProcess() || IsBackgroundWorker )
+#endif
 	{
 		char *shortlived;
 		static char *longlived;
@@ -354,8 +362,12 @@ char *pljavaFnOidToLibPath(Oid fnOid, char **langName, bool *trusted)
 
 bool InstallHelper_shouldDeferInit()
 {
-	if ( IsBackgroundWorker || IsAutoVacuumWorkerProcess() )
-		return true;
+#if PG_VERSION_NUM >= 170000
+	if ( AmAutoVacuumWorkerProcess() || AmBackgroundWorkerProcess() )
+#else
+	if ( IsAutoVacuumWorkerProcess() || IsBackgroundWorker )
+#endif
+			return true;
 
 	if ( ! IsBinaryUpgrade )
 		return false;

--- a/pljava-so/src/main/c/PgSavepoint.c
+++ b/pljava-so/src/main/c/PgSavepoint.c
@@ -187,7 +187,6 @@ Java_org_postgresql_pljava_internal_PgSavepoint__1rollback(JNIEnv* env, jclass c
 	PG_TRY();
 	{
 		unwind(RollbackAndReleaseCurrentSubTransaction, xid, nestLevel);
-		SPI_restore_connection();
 	}
 	PG_CATCH();
 	{


### PR DESCRIPTION
Symbols renamed in PostgreSQL v17

_SPI_restore_connection_ was defined as a noop since PostgreSQL 10, and the compatibility macro has been removed.

[Commit removing compatibility macro](https://github.com/postgres/postgres/commit/75680c3d805e2323cd437ac567f0677fdfc7b680#diff-8e191e2481b10ecfde671fd489a0fb23f09a4259da9144e9a60292fdc7afeadbL108)
```
#define SPI_restore_connection()	((void) 0)
```

Closes #499 