### PR TITLE
Changes to build/use PL/Java on Java 23

### DIFF
--- a/pljava-api/src/main/java/org/postgresql/pljava/annotation/processing/DDRProcessor.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/annotation/processing/DDRProcessor.java
@@ -173,7 +173,7 @@ public class DDRProcessor extends AbstractProcessor
 		 * Update latest_tested to be the latest Java release on which this
 		 * annotation processor has been tested without problems.
 		 */
-		int latest_tested = 22;
+		int latest_tested = 23;
 		int ordinal_9 = SourceVersion.RELEASE_9.ordinal();
 		int ordinal_latest = latest_tested - 9 + ordinal_9;
 

--- a/pljava-so/src/main/c/Backend.c
+++ b/pljava-so/src/main/c/Backend.c
@@ -1942,7 +1942,7 @@ void Backend_warnJEP411(bool isCommit)
 			"Those changes will come in releases after Java 17."),
 		errhint(
 			"For migration planning, this version of PL/Java can still "
-			"enforce policy in Java versions up to and including 22, "
+			"enforce policy in Java versions up to and including 23, "
 			"and Java 17 and 21 are positioned as long-term support releases. "
 			"For details on how PL/Java will adapt, please bookmark "
 			"https://github.com/tada/pljava/wiki/JEP-411")

--- a/src/site/markdown/use/policy.md
+++ b/src/site/markdown/use/policy.md
@@ -373,7 +373,7 @@ release, so relying on it is not recommended.
 The developers of Java have elected to phase out important language features
 used by PL/Java to enforce policy. The changes will come in releases after
 Java 17. For migration planning, this version of PL/Java can still enable
-policy enforcement in Java versions up to and including 22, and Java 17 and 21
+policy enforcement in Java versions up to and including 23, and Java 17 and 21
 are positioned as long-term support releases. (There is a likelihood,
 increasing with later Java versions, even before policy stops being enforceable,
 that some internal privileged operations by Java itself, or other libraries,


### PR DESCRIPTION
These changes take care of building and using PL/Java on Java 23.

The JDK 23 release notes do not announce any new features that would need to be exposed in PL/Java's API for use by user code.

Naturally, no patch will begin using Java 23 features within PL/Java _itself_ until a future major release adopts a newer minimum build version.