### PR TITLE
Allow use (with deliberate opt-in) with no security policy enforcement, as on Java >= 24

### DIFF
--- a/CI/integration
+++ b/CI/integration
@@ -131,6 +131,8 @@ int jFeatureVersion = Runtime.version().major();
 
 String vmopts = "-enableassertions:org.postgresql.pljava... -Xcheck:jni";
 
+vmopts += " --limit-modules=org.postgresql.pljava.internal";
+
 if ( 24 <= jFeatureVersion ) {
   vmopts += " -Djava.security.manager=disallow"; // JEP 486
 } else if ( 18 <= jFeatureVersion )

--- a/CI/integration
+++ b/CI/integration
@@ -147,8 +147,10 @@ Map<String,String> serverOptions = new HashMap<>(Map.of(
   "pljava.vmoptions", vmopts,
   "pljava.libjvm_location", libjvm.toString()
 ));
-if ( 24 <= jFeatureVersion )
+if ( 24 <= jFeatureVersion ) {
   serverOptions.put("pljava.allow_unenforced", "java,java_tzset");
+  serverOptions.put("pljava.allow_unenforced_udt", "on");
+}
 
 Node n1 = Node.get_new_node("TestNode1");
 

--- a/CI/integration
+++ b/CI/integration
@@ -131,8 +131,10 @@ int jFeatureVersion = Runtime.version().major();
 
 String vmopts = "-enableassertions:org.postgresql.pljava... -Xcheck:jni";
 
-if ( 17 < jFeatureVersion )
-  vmopts += " -Djava.security.manager=allow";
+if ( 24 <= jFeatureVersion ) {
+  vmopts += " -Djava.security.manager=disallow"; // JEP 486
+} else if ( 18 <= jFeatureVersion )
+  vmopts += " -Djava.security.manager=allow"; // JEP 411
 
 if ( 23 <= jFeatureVersion )
   vmopts += " --sun-misc-unsafe-memory-access=deny"; // JEP 471

--- a/CI/integration
+++ b/CI/integration
@@ -142,6 +142,14 @@ if ( 23 <= jFeatureVersion )
 if ( 24 <= jFeatureVersion )
   vmopts += " --illegal-native-access=deny"; // JEP 472
 
+Map<String,String> serverOptions = new HashMap<>(Map.of(
+  "client_min_messages", "info",
+  "pljava.vmoptions", vmopts,
+  "pljava.libjvm_location", libjvm.toString()
+));
+if ( 24 <= jFeatureVersion )
+  serverOptions.put("pljava.allow_unenforced", "java,java_tzset");
+
 Node n1 = Node.get_new_node("TestNode1");
 
 if ( s_isWindows )
@@ -210,11 +218,7 @@ throws Exception
 
 try (
   AutoCloseable t1 = n1.initialized_cluster(tweaks);
-  AutoCloseable t2 = n1.started_server(Map.of(
-    "client_min_messages", "info",
-    "pljava.vmoptions", vmopts,
-    "pljava.libjvm_location", libjvm.toString()
-  ), tweaks);
+  AutoCloseable t2 = n1.started_server(serverOptions, tweaks);
 )
 {
   int pgMajorVersion;

--- a/pljava-api/src/main/java/org/postgresql/pljava/Session.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/Session.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2025 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -16,6 +16,8 @@ import java.security.AccessControlContext; // linked from javadoc
 
 import java.sql.Connection;
 import java.sql.SQLException;
+
+import java.util.Properties;
 
 /**
  * A Session brings together some useful methods and data for the current
@@ -35,6 +37,21 @@ import java.sql.SQLException;
  */
 public interface Session
 {
+	/**
+	 * Returns an unmodifiable defensive copy of the Java
+	 * {@link System#getProperties() system properties} taken early in PL/Java
+	 * startup before user code has an opportunity to write them.
+	 *<p>
+	 * When PL/Java is running without security policy enforcement, as on stock
+	 * Java 24 and later, using the frozen properties can simplify defensive
+	 * coding against the possibility of arbitrary property modifications.
+	 *
+	 * @return a {@link Properties} object that departs from the API spec by
+	 * throwing {@link UnsupportedOperationException} from any method if the
+	 * properties would otherwise be modified.
+	 */
+	Properties frozenSystemProperties();
+
 	/**
 	 * Adds the specified {@code listener} to the list of listeners that will
 	 * receive savepoint events. An {@link AccessControlContext} saved by this

--- a/pljava-api/src/main/java/org/postgresql/pljava/SessionManager.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/SessionManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2019 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2025 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -23,21 +23,41 @@ import static java.util.ServiceLoader.load;
  */
 public class SessionManager
 {
-	private static Session s_session;
-
 	/**
 	 * Returns the current session.
 	 */
 	public static Session current()
 	throws SQLException
 	{
-		if(s_session == null)
+		try
 		{
-			s_session = load(
-				Session.class.getModule().getLayer(), Session.class)
-				.findFirst().orElseThrow(() -> new SQLException(
-					"could not obtain PL/Java Session object"));
+			return Holder.s_session;
 		}
-		return s_session;
+		catch ( ExceptionInInitializerError e )
+		{
+			Throwable c = e.getCause();
+			if ( c instanceof SQLException )
+				throw (SQLException)c;
+			throw e;
+		}
+	}
+
+	private static class Holder
+	{
+		private static final Session s_session;
+
+		static {
+			try
+			{
+				s_session = load(
+					Session.class.getModule().getLayer(), Session.class)
+					.findFirst().orElseThrow(() -> new SQLException(
+						"could not obtain PL/Java Session object"));
+			}
+			catch ( SQLException e )
+			{
+				throw new ExceptionInInitializerError(e);
+			}
+		}
 	}
 }

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/JDBC42_21.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/JDBC42_21.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2018-2025 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -10,6 +10,10 @@
  *   Chapman Flack
  */
 package org.postgresql.pljava.example.annotation;
+
+import java.sql.SQLException;
+
+import org.postgresql.pljava.SessionManager;
 
 import org.postgresql.pljava.annotation.Function;
 import org.postgresql.pljava.annotation.SQLAction;
@@ -133,9 +137,10 @@ public class JDBC42_21
 	 * recent as the argument ('1.6', '1.7', '1.8', '9', '10', '11', ...).
 	 */
 	@Function(schema="javatest", provides="javaSpecificationGE")
-	public static boolean javaSpecificationGE(String want)
+	public static boolean javaSpecificationGE(String want) throws SQLException
 	{
-		String got = System.getProperty("java.specification.version");
+		String got = SessionManager.current().frozenSystemProperties()
+			.getProperty("java.specification.version");
 		if ( want.startsWith("1.") )
 			want = want.substring(2);
 		if ( got.startsWith("1.") )

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/Modules.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/Modules.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2025 Tada AB and other contributors, as listed below.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Chapman Flack
+ */
+package org.postgresql.pljava.example.annotation;
+
+import java.lang.module.ModuleDescriptor;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import java.util.Iterator;
+import java.util.Objects;
+
+import java.util.stream.Stream;
+
+import org.postgresql.pljava.ResultSetProvider;
+import org.postgresql.pljava.annotation.Function;
+import static org.postgresql.pljava.annotation.Function.Effects.STABLE;
+
+/**
+ * Example code to support querying for the modules in Java's boot layer.
+ */
+public class Modules implements ResultSetProvider.Large {
+	/**
+	 * Returns information on the named modules in Java's boot module layer.
+	 */
+	@Function(
+		effects = STABLE,
+		out = {
+			                   "name  pg_catalog.text",
+			"any_unqualified_exports  boolean",
+			  "any_unqualified_opens  boolean"
+		}
+	)
+	public static ResultSetProvider java_modules()
+	{
+		return new Modules(
+			ModuleLayer.boot().modules().stream().map(Module::getDescriptor)
+				.filter(Objects::nonNull));
+	}
+
+	private final Iterator<ModuleDescriptor> iterator;
+	private final Runnable closer;
+
+	private Modules(Stream<ModuleDescriptor> s)
+	{
+		iterator = s.iterator();
+		closer = s::close;
+	}
+
+	@Override
+	public boolean assignRowValues(ResultSet receiver, long currentRow)
+	throws SQLException
+	{
+		if ( ! iterator.hasNext() )
+			return false;
+
+		ModuleDescriptor md = iterator.next();
+
+		receiver.updateString(1, md.name());
+
+		receiver.updateBoolean(2,
+			md.exports().stream().anyMatch(e -> ! e.isQualified()));
+
+		receiver.updateBoolean(3,
+			md.isOpen() ||
+			md.opens().stream().anyMatch(o -> ! o.isQualified()));
+
+		return true;
+	}
+
+	@Override
+	public void close()
+	{
+		closer.run();
+	}
+}

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/PassXML.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/PassXML.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2024 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2018-2025 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -67,6 +67,7 @@ import javax.xml.validation.SchemaFactory;
 
 import org.postgresql.pljava.Adjusting;
 import static org.postgresql.pljava.Adjusting.XML.setFirstSupported;
+import org.postgresql.pljava.SessionManager;
 import org.postgresql.pljava.annotation.Function;
 import org.postgresql.pljava.annotation.MappedUDT;
 import org.postgresql.pljava.annotation.SQLAction;
@@ -643,7 +644,8 @@ public class PassXML implements SQLData
 			 */
 			if ( rlt instanceof StreamResult )
 				t.setOutputProperty(ENCODING,
-					System.getProperty("org.postgresql.server.encoding"));
+					SessionManager.current().frozenSystemProperties()
+					.getProperty("org.postgresql.server.encoding"));
 			else if ( Boolean.TRUE.equals(indent) )
 				logMessage("WARNING",
 					"indent requested, but howout specifies a non-stream " +
@@ -712,7 +714,8 @@ public class PassXML implements SQLData
 			 */
 			if ( howout < 5 )
 				t.setOutputProperty(ENCODING,
-					System.getProperty("org.postgresql.server.encoding"));
+					SessionManager.current().frozenSystemProperties()
+					.getProperty("org.postgresql.server.encoding"));
 			t.transform(src, rlt);
 		}
 		catch ( TransformerException te )

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/SPIActions.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/SPIActions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2020 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2025 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -127,20 +127,26 @@ public class SPIActions {
 		}
 	}
 
-	static void log(String msg) {
+	static void log(String msg) throws SQLException {
 		// GCJ has a somewhat serious bug (reported)
 		//
-		if ("GNU libgcj".equals(System.getProperty("java.vm.name"))) {
+		if ("GNU libgcj"
+				.equals(
+					SessionManager.current().frozenSystemProperties()
+						.getProperty("java.vm.name"))) {
 			System.out.print("INFO: ");
 			System.out.println(msg);
 		} else
 			Logger.getAnonymousLogger().info(msg);
 	}
 
-	static void warn(String msg) {
+	static void warn(String msg) throws SQLException {
 		// GCJ has a somewhat serious bug (reported)
 		//
-		if ("GNU libgcj".equals(System.getProperty("java.vm.name"))) {
+		if ("GNU libgcj"
+				.equals(
+					SessionManager.current().frozenSystemProperties()
+						.getProperty("java.vm.name"))) {
 			System.out.print("WARNING: ");
 			System.out.println(msg);
 		} else

--- a/pljava-so/src/main/c/Backend.c
+++ b/pljava-so/src/main/c/Backend.c
@@ -2101,10 +2101,10 @@ void Backend_warnJEP411(bool isCommit)
 			"enforce policy in Java versions up to and including 23, "
 			"and Java 17 and 21 are positioned as long-term support releases. "
 			"Java 24 and later can be used, if wanted, WITH ABSOLUTELY NO "
-			"EXPECTATIONS OF SECURITY, by adding "
+			"EXPECTATIONS OF SECURITY POLICY ENFORCEMENT, by adding "
 			"\"-Djava.security.manager=disallow\" in \"pljava.vmoptions\". "
 			"This mode should be considered only if all Java code to be used "
-			"is considered completely vetted and trusted. "
+			"is considered well vetted and trusted. "
 			"For details on how PL/Java will adapt, please bookmark "
 			"https://github.com/tada/pljava/wiki/JEP-411")
 	));

--- a/pljava-so/src/main/c/Backend.c
+++ b/pljava-so/src/main/c/Backend.c
@@ -144,6 +144,7 @@ extern void Session_initialize(void);
 extern void PgSavepoint_initialize(void);
 extern void XactListener_initialize(void);
 extern void SubXactListener_initialize(void);
+extern void SQLChunkIOOrder_initialize(void);
 extern void SQLInputFromChunk_initialize(void);
 extern void SQLOutputToChunk_initialize(void);
 extern void SQLOutputToTuple_initialize(void);
@@ -798,7 +799,7 @@ static void initsequencer(enum initstage is, bool tolerant)
 		/*FALLTHROUGH*/
 
 	case IS_PLJAVA_FOUND:
-		greeting = InstallHelper_hello();
+		greeting = InstallHelper_hello(); /*adjusts, freezes system properties*/
 		ereport(NULL != pljavaLoadPath ? NOTICE : DEBUG1, (
 				errmsg("PL/Java loaded"),
 				errdetail("versions:\n%s", greeting)));
@@ -1094,6 +1095,7 @@ static void initPLJavaClasses(void)
 	PgSavepoint_initialize();
 	XactListener_initialize();
 	SubXactListener_initialize();
+	SQLChunkIOOrder_initialize(); /* safely caches relevant system properties */
 	SQLInputFromChunk_initialize();
 	SQLOutputToChunk_initialize();
 	SQLOutputToTuple_initialize();

--- a/pljava-so/src/main/c/SQLChunkIOOrder.c
+++ b/pljava-so/src/main/c/SQLChunkIOOrder.c
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2025 TADA AB and other contributors, as listed below.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Chapman Flack
+ */
+#include <postgres.h>
+
+#include "pljava/PgObject.h"
+
+extern void SQLChunkIOOrder_initialize(void);
+void SQLChunkIOOrder_initialize(void)
+{
+	/*
+	 * Nothing more is needed here than to cause the class's static initializer
+	 * to run (at the chosen time, from native code, before user Java code could
+	 * have altered the needed system properties).
+	 *
+	 * The JNI_FindClass mentions that it initializes the named class, but only
+	 * says so in one place, does not clearly say it returns an initialized
+	 * class, and does not mention ExceptionInInitializerError as a possible
+	 * exception.
+	 *
+	 * GetStaticFieldID clearly says it causes an uninitialized class to be
+	 * initialized, and lists ExceptionInInitializerError as a possible
+	 * exception. So, just to be sure, a field ID is fetched here.
+	 */
+	jclass cls = PgObject_getJavaClass(
+		"org/postgresql/pljava/jdbc/SQLChunkIOOrder");
+	PgObject_getStaticJavaField(cls, "MIRROR_J2P", "Ljava/nio/ByteOrder;");
+}

--- a/pljava-so/src/main/include/pljava/pljava.h
+++ b/pljava-so/src/main/include/pljava/pljava.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2023 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2025 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -146,7 +146,11 @@ extern MemoryContext JavaMemoryContext;
  * 
  * Class 07 - Dynamic SQL Exception
  */
-#define ERRCODE_INVALID_DESCRIPTOR_INDEX		MAKE_SQLSTATE('0','7', '0','0','9')
+#define ERRCODE_INVALID_DESCRIPTOR_INDEX MAKE_SQLSTATE('0','7', '0','0','9')
+/*
+ * Class 46 - SQL/JRT
+ */
+#define ERRCODE_CLASS_SQLJRT MAKE_SQLSTATE('4','6','0','0','0')
 
 /*
  * Union used when coercing void* to jlong and vice versa

--- a/pljava/src/main/java/org/postgresql/pljava/elog/ELogFormatter.java
+++ b/pljava/src/main/java/org/postgresql/pljava/elog/ELogFormatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2020 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2025 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -29,8 +29,6 @@ public class ELogFormatter extends Formatter
 	private final static MessageFormat s_tsFormatter = new MessageFormat(
 			"{0,date,dd MMM yy} {0,time,HH:mm:ss} {1} {2}");
 
-	private final static String s_lineSeparator = System.getProperty("line.separator");
-
 	private final Date m_timestamp = new Date();
 	private final Object m_args[] = new Object[] { m_timestamp, null, null };
 	private final StringBuffer m_buffer = new StringBuffer();
@@ -54,9 +52,9 @@ public class ELogFormatter extends Formatter
 		Throwable thrown = record.getThrown();
 		if(thrown != null)
 		{
-			sb.append(s_lineSeparator);
 			StringWriter sw = new StringWriter();
 			PrintWriter pw = new PrintWriter(sw);
+			pw.println(); /* line.separator safely cached in JVM initPhase1 */
 			record.getThrown().printStackTrace(pw);
 			pw.close();
 			sb.append(sw.toString());

--- a/pljava/src/main/java/org/postgresql/pljava/internal/Backend.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/Backend.java
@@ -246,7 +246,11 @@ public class Backend
 	public static List<Identifier.Simple> getListConfigOption(String key)
 	throws SQLException
 	{
-		final Matcher m = s_gucList.matcher(getConfigOption(key));
+		String s = getConfigOption(key);
+		if ( null == s )
+			return null;
+
+		final Matcher m = s_gucList.matcher(s);
 		ArrayList<Identifier.Simple> al = new ArrayList<>();
 		while ( m.find() )
 		{

--- a/pljava/src/main/java/org/postgresql/pljava/internal/Backend.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/Backend.java
@@ -296,6 +296,11 @@ public class Backend
 		return doInPG(Backend::_isCreatingExtension);
 	}
 
+	public static boolean allowingUnenforcedUDT()
+	{
+		return doInPG(Backend::_allowingUnenforcedUDT);
+	}
+
 	/**
 	 * Returns the path of PL/Java's shared library.
 	 * @throws SQLException if for some reason it can't be determined.
@@ -342,6 +347,7 @@ public class Backend
 	private static native boolean _isCreatingExtension();
 	private static native String _myLibraryPath();
 	private static native void _pokeJEP411(Class<?> caller, Object token);
+	private static native boolean _allowingUnenforcedUDT();
 
 	private static class EarlyNatives
 	{

--- a/pljava/src/main/java/org/postgresql/pljava/internal/Backend.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/Backend.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2025 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -46,6 +46,9 @@ public class Backend
 	 * from PG, and null on any other thread.
 	 */
 	public static final ThreadLocal<Boolean> IAMPGTHREAD = new ThreadLocal<>();
+
+	public static final boolean WITHOUT_ENFORCEMENT =
+		"disallow".equals(System.getProperty("java.security.manager"));
 
 	static final int JAVA_MAJOR = Runtime.version().major();
 

--- a/pljava/src/main/java/org/postgresql/pljava/internal/Function.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/Function.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2023 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2016-2025 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -68,6 +68,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -82,6 +83,8 @@ import org.postgresql.pljava.ResultSetProvider;
 import org.postgresql.pljava.sqlgen.Lexicals.Identifier;
 
 import static org.postgresql.pljava.internal.Backend.doInPG;
+import static org.postgresql.pljava.internal.Backend.getListConfigOption;
+import static org.postgresql.pljava.internal.Backend.WITHOUT_ENFORCEMENT;
 import org.postgresql.pljava.internal.EntryPoints;
 import org.postgresql.pljava.internal.EntryPoints.Invocable;
 import static org.postgresql.pljava.internal.EntryPoints.invocable;
@@ -1507,17 +1510,37 @@ public class Function
 	 * conditions. No exception is made here for the few functions supplied by
 	 * PL/Java's own {@code Commands} class; they get a lid. It is reasonable to
 	 * ask them to use {@code doPrivileged} when appropriate.
+	 *<p>
+	 * When {@code WITHOUT_ENFORCEMENT} is true, any nonnull <var>language</var>
+	 * must be named in {@code pljava.allow_unenforced}. PL/Java's own functions
+	 * in the {@code Commands} class are exempt from that check.
 	 */
 	private static AccessControlContext accessControlContextFor(
 		Class<?> clazz, String language, boolean trusted)
+	throws SQLException
 	{
+		Identifier.Simple langIdent = null;
+		if ( null != language )
+			langIdent = Identifier.Simple.fromCatalog(language);
+
+		if ( WITHOUT_ENFORCEMENT  &&  null != langIdent
+			&&  clazz != Commands.class )
+		{
+			if ( Optional.ofNullable(
+					getListConfigOption("pljava.allow_unenforced")
+				).orElseGet(List::of).stream().noneMatch(langIdent::equals) )
+				throw new SQLNonTransientException(
+				"PL \"" + language + "\" not listed in " +
+				"pljava.allow_unenforced configuration setting", "46000");
+		}
+
 		Set<Principal> p =
-			(null == language)
+			(null == langIdent)
 			? Set.of()
 			: Set.of(
 				trusted
-				? new PLPrincipal.Sandboxed(language)
-				: new PLPrincipal.Unsandboxed(language)
+				? new PLPrincipal.Sandboxed(langIdent)
+				: new PLPrincipal.Unsandboxed(langIdent)
 			);
 
 		AccessControlContext acc = clazz.getClassLoader() instanceof Loader

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/SQLChunkIOOrder.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/SQLChunkIOOrder.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2016-2025 TADA AB and other contributors, as listed below.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Chapman Flack
+ */
+package org.postgresql.pljava.jdbc;
+
+import java.nio.ByteOrder;
+
+import java.sql.SQLNonTransientException;
+
+import java.util.Properties;
+
+/**
+ * Caches the scalar and mirror {@code MappedUDT} byte orders as determined by
+ * system properties during PL/Java startup.
+ *<p>
+ * This class is initialized from native code ahead of the
+ * {@link SQLInputFromChunk} and {@link SQLOutputToChunk} classes that depend
+ * on it. This happens before {@code InstallHelper} has taken and frozen its
+ * defensive copy of the Java system properties, and also before PL/Java user
+ * code has potentially run and changed them.
+ *<p>
+ * This defensive implementation is needed only for the "PL/Java with no
+ * security policy enforcement" case, as PL/Java's supplied policy file protects
+ * these properties from modification when policy is being enforced.
+ */
+class SQLChunkIOOrder
+{
+	private SQLChunkIOOrder() { } // do not instantiate
+
+	/**
+	 * Byte order for conversion of "mirror" UDT values in the
+	 * Java-to-PostgreSQL direction.
+	 */
+	static final ByteOrder MIRROR_J2P;
+
+	/**
+	 * Byte order for conversion of "mirror" UDT values in the
+	 * PostgreSQL-to-Java direction.
+	 */
+	static final ByteOrder MIRROR_P2J;
+
+	/**
+	 * Byte order for conversion of "scalar" UDT values in the
+	 * Java-to-PostgreSQL direction.
+	 */
+	static final ByteOrder SCALAR_J2P;
+
+	/**
+	 * Byte order for conversion of "scalar" UDT values in the
+	 * PostgreSQL-to-Java direction.
+	 */
+	static final ByteOrder SCALAR_P2J;
+
+	static
+	{
+		/*
+		 * Set the org.postgresql.pljava.udt.byteorder.{scalar,mirror}.{p2j,j2p}
+		 * properties. For shorthand, defaults can be given in shorter property
+		 * keys org.postgresql.pljava.udt.byteorder.{scalar,mirror} or even just
+		 * org.postgresql.pljava.udt.byteorder for an overall default. These
+		 * shorter keys are then removed from the system properties.
+		 */
+		Properties ps = System.getProperties();
+
+		String orderKey = "org.postgresql.pljava.udt.byteorder";
+		String orderAll = ps.getProperty(orderKey);
+		String orderMirror = ps.getProperty(orderKey + ".mirror");
+		String orderScalar = ps.getProperty(orderKey + ".scalar");
+
+		if ( null == orderMirror )
+			orderMirror = null != orderAll ? orderAll : "native";
+		if ( null == orderScalar )
+			orderScalar = null != orderAll ? orderAll : "big_endian";
+
+		System.clearProperty(orderKey);
+		System.clearProperty(orderKey + ".mirror");
+		System.clearProperty(orderKey + ".scalar");
+
+		try
+		{
+			MIRROR_J2P = toByteOrder(ps, orderKey + ".mirror.j2p", orderMirror);
+			MIRROR_P2J = toByteOrder(ps, orderKey + ".mirror.p2j", orderMirror);
+			SCALAR_J2P = toByteOrder(ps, orderKey + ".scalar.j2p", orderScalar);
+			SCALAR_P2J = toByteOrder(ps, orderKey + ".scalar.p2j", orderScalar);
+		}
+		catch ( SQLNonTransientException e )
+		{
+			throw new ExceptionInInitializerError(e);
+		}
+	}
+
+	private static ByteOrder toByteOrder(Properties ps, String k, String dfl)
+	throws SQLNonTransientException
+	{
+		switch ( (String)ps.computeIfAbsent(k, p -> dfl) )
+		{
+		case "big_endian": return ByteOrder.BIG_ENDIAN;
+		case "little_endian": return ByteOrder.LITTLE_ENDIAN;
+		case "native": return ByteOrder.nativeOrder();
+		default:
+			throw new SQLNonTransientException(
+				"System property " + k +
+				" must be big_endian, little_endian, or native", "F0000");
+		}
+	}
+}

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/SQLInputFromChunk.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/SQLInputFromChunk.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2019 TADA AB and other contributors, as listed below.
+ * Copyright (c) 2004-2025 TADA AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -20,7 +20,6 @@ import java.math.BigDecimal;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import java.nio.charset.CharsetDecoder;
 import java.sql.Array;
@@ -41,6 +40,9 @@ import java.sql.Timestamp;
 
 import org.postgresql.pljava.internal.Backend;
 
+import static org.postgresql.pljava.jdbc.SQLChunkIOOrder.MIRROR_P2J;
+import static org.postgresql.pljava.jdbc.SQLChunkIOOrder.SCALAR_P2J;
+
 /**
  * The SQLInputToChunk uses JNI to read from memory that has been allocated by
  * the PostgreSQL backend. A user should never make an attempt to create an
@@ -56,44 +58,10 @@ public class SQLInputFromChunk implements SQLInput
 {
 	private ByteBuffer m_bb;
 
-	private static ByteOrder scalarOrder;
-	private static ByteOrder mirrorOrder;
-
 	public SQLInputFromChunk(ByteBuffer bb, boolean isJavaBasedScalar)
 		throws SQLException
 	{
-		m_bb = bb;
-		if ( isJavaBasedScalar )
-		{
-			if ( null == scalarOrder )
-				scalarOrder = getOrder(true);
-			m_bb.order(scalarOrder);
-		}
-		else
-		{
-			if ( null == mirrorOrder )
-				mirrorOrder = getOrder(false);
-			m_bb.order(mirrorOrder);
-		}
-	}
-
-	private ByteOrder getOrder(boolean isJavaBasedScalar) throws SQLException
-	{
-		ByteOrder result;
-		String key = "org.postgresql.pljava.udt.byteorder."
-			+ ( isJavaBasedScalar ? "scalar" : "mirror" ) + ".p2j";
-		String val = System.getProperty(key);
-		if ( "big_endian".equals(val) )
-			result = ByteOrder.BIG_ENDIAN;
-		else if ( "little_endian".equals(val) )
-			result = ByteOrder.LITTLE_ENDIAN;
-		else if ( "native".equals(val) )
-			result = ByteOrder.nativeOrder();
-		else
-			throw new SQLNonTransientException(
-				"System property " + key +
-				" must be big_endian, little_endian, or native", "F0000");
-		return result;
+		m_bb = bb.order(isJavaBasedScalar ? SCALAR_P2J : MIRROR_P2J);
 	}
 
 	@Override

--- a/pljava/src/main/java/org/postgresql/pljava/nopolicy/FrozenProperties.java
+++ b/pljava/src/main/java/org/postgresql/pljava/nopolicy/FrozenProperties.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2025 Tada AB and other contributors, as listed below.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Chapman Flack
+ */
+package org.postgresql.pljava.nopolicy;
+
+import java.io.InputStream;
+import java.io.Reader;
+
+import static java.util.Arrays.copyOfRange;
+import java.util.Collection;
+import static java.util.Collections.unmodifiableCollection;
+import static java.util.Collections.unmodifiableSet;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+/**
+ * An unmodifiable subclass of {@link Properties}.
+ *<p>
+ * The overidden methods violate the superclass API specs to the extent that the
+ * specs allow modification, or the returning of modifiable sets or collections.
+ *<p>
+ * When any overridden method would, per the spec, modify the map, the method
+ * will throw {@link UnsupportedOperationException} instead.
+ */
+public final class FrozenProperties extends Properties
+{
+	/**
+	 * Constructs a {@code FrozenProperties} instance from an existing
+	 * {@link Properties} instance.
+	 * @param p the instance whose entries are to be copied
+	 */
+	public FrozenProperties(Properties p)
+	{
+		// super(p.size()); // has no @Since but first appears in Java 10
+		super.putAll(p);
+	}
+
+	@Override
+	public Object setProperty(String key, String value)
+	{
+		throw readonly();
+	}
+
+	@Override
+	public void load(Reader reader)
+	{
+		throw readonly();
+	}
+
+	@Override
+	public void load(InputStream inStream)
+	{
+		throw readonly();
+	}
+
+	@Override
+	public void loadFromXML(InputStream in)
+	{
+		throw readonly();
+	}
+
+	@Override
+	public void clear()
+	{
+		throw readonly();
+	}
+
+	@Override
+	public Object computeIfAbsent(
+		Object key, Function<Object,?> mappingFunction)
+	{
+		Object v = get(key);
+		if ( null != v )
+			return v;
+		v = mappingFunction.apply(key);
+		if ( null != v )
+			throw readonly();
+		return null;
+	}
+
+	@Override
+	public Object computeIfPresent(
+		Object key, BiFunction<Object,Object,?> remappingFunction)
+	{
+		Object v = get(key);
+		if ( null == v )
+			return null;
+		v = remappingFunction.apply(key, v); // if it throws, let it. Else:
+		throw readonly();
+	}
+
+	@Override
+	public Set<Map.Entry<Object,Object>> entrySet()
+	{
+		return unmodifiableSet(super.entrySet());
+	}
+
+	@Override
+	public Set<Object> keySet()
+	{
+		return unmodifiableSet(super.keySet());
+	}
+
+	@Override
+	public Object merge(Object key, Object value,
+		BiFunction<Object,Object,?> remappingFunction)
+	{
+		throw readonly();
+	}
+
+	@Override
+	public Object put(Object key, Object value)
+	{
+		throw readonly();
+	}
+
+	@Override
+	public void putAll(Map<?,?> t)
+	{
+		if ( 0 < t.size() )
+			throw readonly();
+	}
+
+	@Override
+	public Object remove(Object key)
+	{
+		Object v = get(key);
+		if ( null != v )
+			throw readonly();
+		return null;
+	}
+
+	@Override
+	public Collection<Object> values()
+	{
+		return unmodifiableCollection(super.values());
+	}
+
+	private static UnsupportedOperationException readonly()
+	{
+		UnsupportedOperationException e =
+			new UnsupportedOperationException("FrozenProperties modification");
+		StackTraceElement[] t = e.getStackTrace();
+		e.setStackTrace(copyOfRange(t, 1, t.length));
+		return e;
+	}
+}

--- a/pljava/src/main/java/org/postgresql/pljava/nopolicy/package-info.java
+++ b/pljava/src/main/java/org/postgresql/pljava/nopolicy/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Java classes needed to preserve any semblance of a reliable environment
+ * in Java 24 and later with no security policy enforcement.
+ * @author Chapman Flack
+ */
+package org.postgresql.pljava.nopolicy;

--- a/src/site/markdown/install/install.md.vm
+++ b/src/site/markdown/install/install.md.vm
@@ -97,8 +97,8 @@ you will have to become patient, and read the rest of this page.
 **You will most probably have to set `pljava.libjvm_location`.** See the
 next section.
 
-**It is useful to consider `pljava.vmoptions`.** See the
-[VM options page][vmop].
+**It is useful to consider `pljava.vmoptions`. For Java 18 or later it is
+necessary.** See the [VM options page][vmop].
 
 [vmop]: vmoptions.html
 
@@ -133,11 +133,27 @@ things right on the first try, you might set them after, too.) For example:
     Then set this variable to the full pathname, including the filename
     and extension.
 
+    The version of Java this variable points to will determine whether PL/Java
+    can operate [with security policy enforcement][policy] or must be used
+    [with no policy enforcement][unenforced].
+
+`pljava.allow_unenforced`
+: When using PL/Java with no policy enforcement, this variable must be set
+    as described on the [PL/Java with no policy enforcement][unenforced] page.
+
+`pljava.allow_unenforced_udt`
+: When using PL/Java with no policy enforcement, if PL/Java
+    [mapped user-defined types][mappedudt] are to be used, this variable must
+    be set as described on the
+    [PL/Java with no policy enforcement][unenforced] page.
+
 `pljava.vmoptions`
-: While it should not be necessary to set these before seeing the first signs
-    of life from PL/Java, there are useful options to consider setting here
-    before calling the installation complete. Some are described on the
-    [VM options page][vmop].
+: JVM options can be set here, a number of which are described on the
+    [VM options page][vmop]. For the most part, they are not essential to
+    seeing the first signs of life from PL/Java and can be left for tuning
+    later. However, on Java 18 and later, it is necessary to choose
+    a `-Djava.security.manager=...` setting before PL/Java will run at all.
+    Details are on the [VM options page][vmop].
 
 `pljava.module_path`
 : There is probably no need to set this variable unless installation locations
@@ -218,8 +234,10 @@ specify
 permissions. The exact permissions granted in either case can be customized
 in [`pljava.policy`][policy].
 
-__Note: For implications when running on Java 17 or later,
-please see [JEP 411][jep411]__.
+__Important: The above description applies when PL/Java is run
+[with policy enforcement][policy], available on Java 23 and older.
+On stock Java 24 and later, PL/Java can only be run with no policy enforcement,
+and the implications should be reviewed carefully [here][unenforced].__
 
 PostgreSQL, by default, would grant `USAGE` to `PUBLIC` on the `java` language,
 but PL/Java takes a more conservative approach on a new installation.
@@ -231,10 +249,15 @@ if a site prefers that traditional policy.
 In a repeat or upgrade installation (the language `java` already exists),
 no change will be made to the access permissions granted on it.
 
+When running [with no policy enforcement][unenforced], PL/Java allows only
+database superusers to create functions even in the `java` language,
+disregarding any `USAGE` grants.
+
 $h2 Special topics
 
 Be sure to read these additional sections if:
 
+* You intend to use [Java 24 or later][unenforced]
 * You are installing on [a system using SELinux][selinux]
 * You are installing on [Mac OS X][osx]
 * You are installing on [Ubuntu][ubu] and the self-extracting jar won't work
@@ -395,5 +418,6 @@ In this case, simply place the files in any location where you can make them
 readable by the user running `postgres`, and set the `pljava.*` variables
 accordingly.
 
-[jep411]: https://github.com/tada/pljava/wiki/JEP-411
 [policy]: ../use/policy.html
+[unenforced]: ../use/unenforced.html
+[mappedudt]: ../pljava-api/apidocs/org.postgresql.pljava/org/postgresql/pljava/annotation/MappedUDT.html

--- a/src/site/markdown/install/locatejvm.md
+++ b/src/site/markdown/install/locatejvm.md
@@ -27,6 +27,18 @@ by a process, this works:
 strace -e open java 2>&1 | grep libjvm
 ```
 
+## Version of the Java library selected
+
+The library pointed to be `pljava.libjvm_location` must be a Java 9 or later
+JVM for the PL/Java 1.6 series. The actual version of the library will determine
+what Java language features are available for PL/Java functions to use.
+
+The Java version also influences whether PL/Java can operate
+[with security policy enforcement][policy] or
+[with no policy enforcement][unenforced]. For stock Java 24 or later, it is only
+possible to operate with no enforcement, and the implications detailed for
+[PL/Java with no policy enforcement][unenforced] should be carefully reviewed.
+
 ## Using a less-specific path
 
 The methods above may find the `libjvm` object on a very specific path
@@ -47,3 +59,7 @@ generic one like `jre`, linked to whichever Java version is considered
 current. Using an alias that is too generic could possibly invite headaches
 if the default Java version is ever changed to one your PL/Java modules
 were not written for (or PL/Java itself was not built for).
+
+
+[policy]: ../use/policy.html
+[unenforced]: ../use/unenforced.html

--- a/src/site/markdown/install/smproperty.md
+++ b/src/site/markdown/install/smproperty.md
@@ -1,0 +1,49 @@
+# Available policy-enforcement settings by Java version
+
+In the PostgreSQL [configuration variable][variables] `pljava.vmoptions`,
+whether and how to set the `java.security.manager` property depends on
+the Java version in use (that is, on the version of the Java library that
+the `pljava.libjvm_location` configuration variable points to).
+
+There are two ways of setting the `java.security.manager` property that may be
+allowed or required depending on the Java version in use.
+
+`-Djava.security.manager=allow`
+: PL/Java's familiar operating mode in which
+    security policy is enforced. More on that mode can be found in
+    [Configuring permissions in PL/Java][policy].
+
+`-Djava.security.manager=disallow`
+: A mode required on Java 24 and later, in which there is no enforcement of
+    policy. Before setting up PL/Java in this mode, the implications in
+    [PL/Java with no policy enforcement][unenforced] should be carefully
+    reviewed.
+
+This table lays out the requirements by specific version of Java.
+
+|Java version|Available settings|
+|---------|:---|
+|9–11|There must be no appearance of `-Djava.security.manager` in `pljava.vmoptions`. Mode will be policy-enforcing.|
+|12–17|Either `-Djava.security.manager=allow` or `-Djava.security.manager=disallow` may appear in `pljava.vmoptions`. Default is policy-enforcing (same as `allow`) if neither appears.|
+|18–23|One of `-Djava.security.manager=allow` or `-Djava.security.manager=disallow` must appear in `pljava.vmoptions`, or PL/Java will fail to start. There is no default.|
+|24–|`-Djava.security.manager=disallow` must appear in `pljava.vmoptions`, or PL/Java will fail to start.|
+[Allowed `java.security.manager` settings by Java version]
+
+When `pljava.libjvm_location` points to a Java 17 or earlier JVM, there is
+no special VM option needed, and PL/Java will operate with policy enforcement
+by default. However, when `pljava.libjvm_location` points to a Java 18 or later
+JVM, `pljava.vmoptions` must contain either `-Djava.security.manager=allow` or
+`-Djava.security.manager=disallow`, to select operation with or without policy
+enforcement, respectively. No setting other than `allow` or `disallow` will
+work. Only `disallow` is available for stock Java 24 or later.
+
+The behavior with `allow` (and the default before Java 18) is further described
+in [Configuring permissions in PL/Java][policy].
+
+The behavior with `disallow`, the only mode offered for Java 24 and later,
+is detailed in [PL/Java with no policy enforcement][unenforced], which
+should be carefully reviewed when PL/Java will be used in this mode.
+
+[variables]: ../use/variables.html
+[policy]: ../use/policy.html
+[unenforced]: ../use/unenforced.html

--- a/src/site/markdown/install/vmoptions.md
+++ b/src/site/markdown/install/vmoptions.md
@@ -7,6 +7,26 @@ options are likely to be worth setting.
 If using [the OpenJ9 JVM][hsj9], be sure to look also at the
 [VM options specific to OpenJ9][vmoptJ9].
 
+## Selecting operation with or without security policy enforcement
+
+PL/Java can operate [with security policy enforcement][policy], its former
+default and only mode, or [with no policy enforcement][unenforced], the only
+mode available on stock Java 24 and later.
+
+When `pljava.libjvm_location` points to a Java 17 or earlier JVM, there is
+no special VM option needed, and PL/Java will operate with policy enforcement
+by default. However, when `pljava.libjvm_location` points to a Java 18 or later
+JVM, `pljava.vmoptions` must contain either `-Djava.security.manager=allow` or
+`-Djava.security.manager=disallow`, to select operation with or without policy
+enforcement, respectively. No setting other than `allow` or `disallow` will
+work. Only `disallow` is available for stock Java 24 or later.
+
+Before operating with `disallow`, the implications detailed in
+[PL/Java with no policy enforcement][unenforced] should be carefully reviewed.
+
+[policy]: ../use/policy.html
+[unenforced]: ../use/unenforced.html
+
 ## Adding to the set of readable modules
 
 By default, a small set of Java modules (including `java.base`,
@@ -24,6 +44,12 @@ modules that make up the full Java SE API, so `--add-modules=java.se` will make
 that full API available to PL/Java code without further thought. The cost,
 however, may be that PL/Java uses more memory and starts more slowly than if
 only a few needed modules were named.
+
+For just that reason, there is also a `--limit-modules` option that can be used
+to trim the set of readable modules to the minimum genuinely needed. More on the
+use of that option [here][limitmods].
+
+[limitmods]: ../use/jpms.html#Limiting_the_module_graph
 
 Third-party modular code can be made available by adding the modular jars
 to `pljava.module_path` (see [configuration variables](../use/variables.html))

--- a/src/site/markdown/install/vmoptions.md
+++ b/src/site/markdown/install/vmoptions.md
@@ -21,11 +21,15 @@ JVM, `pljava.vmoptions` must contain either `-Djava.security.manager=allow` or
 enforcement, respectively. No setting other than `allow` or `disallow` will
 work. Only `disallow` is available for stock Java 24 or later.
 
+For just how to configure specific Java versions, see
+[Available policy-enforcement settings by Java version][smprop].
+
 Before operating with `disallow`, the implications detailed in
 [PL/Java with no policy enforcement][unenforced] should be carefully reviewed.
 
 [policy]: ../use/policy.html
 [unenforced]: ../use/unenforced.html
+[smprop]: smproperty.html
 
 ## Adding to the set of readable modules
 

--- a/src/site/markdown/use/jpms.md
+++ b/src/site/markdown/use/jpms.md
@@ -113,6 +113,10 @@ no security policy enforcement, as required on stock Java 24 and later. The page
 [PL/Java with no policy enforcement][unenforced] should be carefully reviewed
 for other implications of running PL/Java that way.
 
+The supplied [examples jar][examples] provides a function, [java_modules][],
+that can be used to see what modules have been resolved into Java's boot module
+layer.
+
 ## Configuring the launch-time module path
 
 The configuration variable `pljava.module_path` controls the
@@ -147,3 +151,5 @@ character.
 [addm]: ../install/vmoptions.html#Adding_to_the_set_of_readable_modules
 [limitmods]: https://openjdk.org/jeps/261#Limiting-the-observable-modules
 [unenforced]: unenforced.html
+[examples]: ../examples/examples.html
+[java_modules]: ../pljava-examples/apidocs/index.html?org/postgresql/pljava/example/annotation/Modules.html

--- a/src/site/markdown/use/jpms.md
+++ b/src/site/markdown/use/jpms.md
@@ -117,6 +117,14 @@ The supplied [examples jar][examples] provides a function, [java_modules][],
 that can be used to see what modules have been resolved into Java's boot module
 layer.
 
+For more detail on why the boot layer includes the modules it does,
+`-Djdk.module.showModuleResolution=true` can be added temporarily in
+`pljava.vmoptions`, and a log of module requirements and bindings will be sent
+to the standard output of the backend process when PL/Java starts. PostgreSQL,
+however, may normally start backend processes with standard output going
+nowhere, so the logged information may be invisible unless running PostgreSQL
+in [a test harness][node].
+
 ## Configuring the launch-time module path
 
 The configuration variable `pljava.module_path` controls the
@@ -153,3 +161,4 @@ character.
 [unenforced]: unenforced.html
 [examples]: ../examples/examples.html
 [java_modules]: ../pljava-examples/apidocs/index.html?org/postgresql/pljava/example/annotation/Modules.html
+[node]: ../develop/node.html

--- a/src/site/markdown/use/jpms.md
+++ b/src/site/markdown/use/jpms.md
@@ -83,6 +83,36 @@ refer to any of the Java SE API. However, PL/Java instances may use less memory
 and start up more quickly if an effort is made to add only modules actually
 needed.
 
+### Limiting the module graph
+
+Less conveniently perhaps, but advantageously for memory footprint and quick
+startup, the [`--limit-modules`][limitmods] option can be used. As of this
+writing in early 2025, starting up a simple PL/Java installation on Java 24
+with no `--add-modules` option results in 48 modules resolved, and the 48
+include some unlikely choices for PL/Java purposes, such as `java.desktop`,
+`jdk.unsupported.desktop`, `jdk.javadoc`, and others.
+
+With the option `--limit-modules=org.postgresql.pljava.internal` added, only
+nine modules are resolved---the transitive closure of those required by PL/Java
+itself---and all of PL/Java's supplied examples successfully run.
+
+The `--add-modules` option can then be used to make any other actually-needed
+modules available again. Those named with `--add-modules` are implicitly added
+to those named with `--limit-modules`, so there is no need to change the
+`--limit-modules` setting when adding another module. For example,
+
+```
+--limit-modules=org.postgresql.pljava.internal --add-modules=java.net.http
+```
+
+will allow use of `java.net.http` in addition to the nine modules resolved for
+PL/Java itself.
+
+Limiting the module graph can be especially advisable when running PL/Java with
+no security policy enforcement, as required on stock Java 24 and later. The page
+[PL/Java with no policy enforcement][unenforced] should be carefully reviewed
+for other implications of running PL/Java that way.
+
 ## Configuring the launch-time module path
 
 The configuration variable `pljava.module_path` controls the
@@ -115,3 +145,5 @@ character.
 [jpms]: https://cr.openjdk.java.net/~mr/jigsaw/spec/
 [resolution]: https://docs.oracle.com/javase/9/docs/api/java/lang/module/package-summary.html#resolution
 [addm]: ../install/vmoptions.html#Adding_to_the_set_of_readable_modules
+[limitmods]: https://openjdk.org/jeps/261#Limiting-the-observable-modules
+[unenforced]: unenforced.html

--- a/src/site/markdown/use/policy.md
+++ b/src/site/markdown/use/policy.md
@@ -9,7 +9,8 @@ When using PL/Java with stock Java 24 or later, please see instead the
 To operate with policy enforcement as described here, no special configuration
 is needed on Java 17 and earlier, while on Java 18 through 23, an entry
 `-Djava.security.manager=allow` in [`pljava.vmoptions`][confvar] must be present
-for PL/Java to start.
+for PL/Java to start. For just how to configure specific Java versions, see
+[Available policy-enforcement settings by Java version][smprop].
 
 ## `TRUSTED` (and untrusted) procedural languages
 
@@ -403,3 +404,4 @@ For details on how PL/Java will adapt, please bookmark
 [trial]: trial.html
 [unenforced]: unenforced.html
 [jep411]: https://github.com/tada/pljava/wiki/JEP-411
+[smprop]: ../install/smproperty.html

--- a/src/site/markdown/use/policy.md
+++ b/src/site/markdown/use/policy.md
@@ -1,5 +1,16 @@
 # Configuring permissions in PL/Java
 
+This page describes how PL/Java operates when enforcing security policy,
+available when using Java 23 or earlier.
+
+When using PL/Java with stock Java 24 or later, please see instead the
+[PL/Java without policy enforcement][unenforced] page.
+
+To operate with policy enforcement as described here, no special configuration
+is needed on Java 17 and earlier, while on Java 18 through 23, an entry
+`-Djava.security.manager=allow` in [`pljava.vmoptions`][confvar] must be present
+for PL/Java to start.
+
 ## `TRUSTED` (and untrusted) procedural languages
 
 PostgreSQL allows a procedural language to be installed with or without
@@ -8,12 +19,11 @@ can be created in that language by any user (PostgreSQL role) with `USAGE`
 permission on that language, as configured with the SQL commands
 `GRANT USAGE ON LANGUAGE ...` and `REVOKE USAGE ON LANGUAGE ...`. For a
 language that is _not_ designated `TRUSTED`, only a database superuser
-may create functions that use it, no matter who has been granted `USAGE`
-on it.
+may create functions that use it. No `USAGE` permission can be granted on it.
 
 In either case, once any function has been created, that function may
 be executed by any user/role granted `EXECUTE` permission on the function
-itself; a language's `USAGE` privilege (plus superuser status, if the language
+itself; a language's `USAGE` privilege (or superuser status, if the language
 is not `TRUSTED`) is only needed to create a function that uses the language.
 
 Because PL functions execute in the database server, a general-purpose
@@ -121,7 +131,7 @@ installed with PL/Java.
 The `pljava.policy` file, by default, is used _instead of_ any `.java.policy`
 file in the OS user's home directory that Java would normally load. There
 probably is no such file in the `postgres` user's home directory, and if
-for any reason there is one, it probably is not tailored to PL/Java.
+for any reason there is one, it probably was not put there with PL/Java in mind.
 
 The [configuration variable][confvar] `pljava.policy_urls` can be
 used to name different, or additional, policy files.
@@ -371,8 +381,8 @@ That should be regarded as an implementation detail; it may change in a future
 release, so relying on it is not recommended.
 
 The developers of Java have elected to phase out important language features
-used by PL/Java to enforce policy. The changes will come in releases after
-Java 17. For migration planning, this version of PL/Java can still enable
+used by PL/Java to enforce policy. The functionality has been removed in
+Java 24. For migration planning, this version of PL/Java can still enable
 policy enforcement in Java versions up to and including 23, and Java 17 and 21
 are positioned as long-term support releases. (There is a likelihood,
 increasing with later Java versions, even before policy stops being enforceable,
@@ -391,4 +401,5 @@ For details on how PL/Java will adapt, please bookmark
 [sqljajl]: ../pljava/apidocs/org.postgresql.pljava.internal/org/postgresql/pljava/management/Commands.html#alias_java_language
 [tssec]: https://docs.oracle.com/en/java/javase/14/security/troubleshooting-security.html
 [trial]: trial.html
+[unenforced]: unenforced.html
 [jep411]: https://github.com/tada/pljava/wiki/JEP-411

--- a/src/site/markdown/use/unenforced.md
+++ b/src/site/markdown/use/unenforced.md
@@ -67,6 +67,9 @@ The string `-Djava.security.manager=disallow` must appear in the setting of
 [`pljava.vmoptions`][vmoptions] or PL/Java will be unable to start on Java 24
 or later.
 
+For details on what `java.security.manager` settings to use on other Java
+versions, see [Available policy-enforcement settings by Java version][smprop].
+
 ### in `pljava.allow_unenforced`
 
 Typically, a PL extension that provides only 'untrusted' execution will define
@@ -240,3 +243,4 @@ modification would otherwise result).
 [mappedudt]: ../pljava-api/apidocs/org.postgresql.pljava/org/postgresql/pljava/annotation/MappedUDT.html
 [examples]: ../examples/examples.html
 [java_modules]: ../pljava-examples/apidocs/index.html?org/postgresql/pljava/example/annotation/Modules.html
+[smprop]: ../install/smproperty.html

--- a/src/site/markdown/use/unenforced.md
+++ b/src/site/markdown/use/unenforced.md
@@ -203,6 +203,28 @@ exceptions are the finest-grained controls remaining in stock Java.
 For news of possible directions for policy enforcement in future PL/Java
 versions, please bookmark [this wiki page][jep411].
 
+### Defensive coding
+
+#### Java system properties
+
+It can be laborious to audit a code base for assumptions that a given Java
+system property has a value that is reliable. In the case of no policy
+enforcement, when any system property can be changed by any code at any time,
+best practice is to rely on defensive copies taken early, before arbitrary
+user code can have run.
+
+For example, `PrintWriter.println` uses a copy of the `line.separator` property
+taken early in the JVM's own initialization, so code that relies on `println` to
+write a newline will be more dependable than code using `line.separator`
+directly.
+
+PL/Java itself takes a defensive copy of all system properties early in its own
+startup, immediately after adding the properties that PL/Java sets. The
+`frozenSystemProperties` method of the `org.postgresql.pljava.Session` object
+returns this defensive copy, as a subclass of `java.util.Properties` that is
+unmodifiable (throwing `UnsupportedOperationException` from methods where a
+modification would otherwise result).
+
 [policy]: policy.html
 [jpms]: jpms.html
 [vmoptions]: ../install/vmoptions.html

--- a/src/site/markdown/use/unenforced.md
+++ b/src/site/markdown/use/unenforced.md
@@ -1,0 +1,214 @@
+# PL/Java with no policy enforcement
+
+This page describes how PL/Java operates when it is not enforcing any security
+policy, as when running on stock Java 24 or later.
+
+When the newest Java language features are not needed, it may be preferable to
+use a Java 23 or earlier JVM to retain PL/Java's historically fine-grained and
+configurable limits on what the Java code can do. For that case, please see
+instead the [configuring permissions in PL/Java][policy] page.
+
+## History: policy enforcement pre-Java 24
+
+PL/Java has historically been able to enforce configurable limits on the
+behavior of Java code, and to offer more than one "procedural language" with
+distinct names, such as `java` and `javau`, for declaring functions with
+different limits on what they can do. In PostgreSQL parlance, the language named
+without 'u' would be described as 'trusted', meaning any functions created in
+that language would run with strict limits. Such functions could be created by
+any PostgreSQL user granted `USAGE` permission on that language. The language
+named with 'u' would be described as 'untrusted' and impose fewer limits on what
+functions can do; accordingly, only PostgreSQL superusers would be allowed to
+create functions in such a language.
+
+PL/Java, going further than many PLs, allowed tailoring of the exact policies
+imposed for both `java` and `javau`, and also allowed creation of additional
+language aliases beyond those two, with different tailored policies for each.
+
+Those capabilities remain available when PL/Java is used with Java versions
+up through Java 23, and are described more fully in
+[configuring permissions in PL/Java][policy].
+
+## The present: Java 24 and later, no policy enforcement in PL/Java 1.6
+
+The Java language features necessary for policy enforcement in the PL/Java 1.6
+series have been removed from the language as of Java 24. It is possible to
+use Java 24 or later with an up-to-date 1.6-series PL/Java, but only by running
+with no policy enforcement at all.
+
+That does not mean only that PL/Java's 'trusted' and 'untrusted' languages are
+no longer different: it means that even the 'untrusted' language's more-relaxed
+former limits can no longer be enforced. When run with enforcement disabled,
+PL/Java is better described as a wholly-'untrusted' PL with nearly no limits on
+what the Java code can do.
+
+The only limits a Java 24 or later runtime can impose on what the Java code can
+do are those imposed by the isolation of modules in the
+[Java Platform Module System][jpms] and by a small number of VM options, which
+will be discussed further below.
+
+This picture is radically different from the historical one with enforcement. To
+run PL/Java in this mode may be a reasonable choice if Java 24 or later language
+features are wanted and if all of the Java code to be used is considered well
+vetted, thoroughly trusted, and defensively written.
+
+For news of possible directions for policy enforcement in future PL/Java
+versions, please bookmark [this wiki page][jep411].
+
+## Opting in to PL/Java with no enforcement
+
+For PL/Java to run with no policy enforcement (and, therefore, for it to run
+at all on Java 24 or later), specific configuration settings must be made to opt
+in.
+
+### In `pljava.vmoptions`
+
+The string `-Djava.security.manager=disallow` must appear in the setting of
+[`pljava.vmoptions`][vmoptions] or PL/Java will be unable to start on Java 24
+or later.
+
+### in `pljava.allow_unenforced`
+
+Typically, a PL extension that provides only 'untrusted' execution will define
+only a single, untrusted, PL name: `plpython3u` would be an example.
+
+PL/Java, however:
+
+* Has historically offered both a `javau` and a trusted `java` PL
+* Still can offer both, when run on a Java 23 or older JVM
+* May have been installed in a database with functions already created of both
+    types, and then switched to running on Java 24 and without enforcement
+* Can also be switched back to a Java 23 or older JVM and provide enforcement
+    again
+
+Therefore, a PL/Java installation still normally provides two (or more) named
+PLs, each being declared to PostgreSQL as either 'trusted' or not.
+
+When running with no enforcement, however:
+
+* Only PostgreSQL superusers can create functions, even using PL names shown as
+    'trusted', and without regard to any grants of `USAGE` on those PLs.
+
+    There may, however, be functions already defined in 'trusted' PLs that were
+    created by non-superusers with `USAGE` granted, at some earlier time when
+    PL/Java was running with enforcement. It may be important to audit those
+    functions' code before allowing them to run.
+
+* No PL/Java function at all will be allowed to run unless the name of its PL is
+    included in the `pljava.allow_unenforced` [configuration variable][vbls].
+
+* When there are existing PL/Java functions declared in more than one named PL,
+    they can be audited in separate batches, with the name of each PL added
+    to the `pljava.allow_unenforced` setting after the functions declared
+    in that PL have been approved. Or, individual functions, once approved, can
+    be redeclared with the PL name changed to one already listed in
+    `pljava.allow_unenforced`.
+
+* Creation of a new function, even by a superuser, with a PL name not listed in
+    `pljava.allow_unenforced` will normally raise an error when PL/Java is
+    running without enforcement. This will not be detected, however, at times
+    when `check_function_bodies` is `off`, so is better seen as a reminder than
+    as a form of security. The more-important check is the one made when
+    the function executes.
+
+### in `pljava.allow_unenforced_udt`
+
+Java methods for input and output conversion of PL/Java
+[mapped user-defined types][mappedudt], which are executed directly by PL/Java
+and have no SQL declarations to carry a PL name, are allowed to execute only if
+`pljava.allow_unenforced_udt` is `on`. The table `sqlj.typemap_entry` can be
+queried for a list of mapped UDT Java classes to audit before changing this
+setting to `on`.
+
+## Hardening for PL/Java with no policy enforcement
+
+### External hardening measures
+
+Developers of the Java language, in their rationale for removing the
+Java features needed for policy enforcement, have placed strong emphasis on
+available protections at the OS or container level, external to the process
+running Java. For the case of PL/Java, that would mean typical hardening
+measures such as running PostgreSQL in a container, using [SELinux][selinux],
+perhaps in conjunction with [sepgsql][], and so on.
+
+Those external measures, however, generally confine what the process can do as a
+whole. Because PL/Java executes within a PostgreSQL backend process, which must
+still be allowed to do everything PostgreSQL itself does, it is difficult for an
+external measure to restrict what Java code can do any more narrowly than that.
+
+### Java hardening measures
+
+Java features do remain that can be used to put some outer guardrails on what
+the Java code can do. They include some specific settings that can be made in
+`pljava.vmoptions`, and the module-isolation features of the
+[Java Platform Module System][jpms] generally. These should be conscientiously
+used:
+
+#### `--sun-misc-unsafe-memory-access=deny`
+
+This setting is first available in Java 23. It should be used whenever
+available, and especially in Java 24 or later with no policy enforcement.
+Without this setting, and in the absence of policy enforcement, any Java code
+can access memory in ways that break the Java object model.
+
+The only reason not to set this option would be when knowingly using a Java
+library that requires the access, if there is no update or alternative to using
+that library. More modern code would use later APIs for which access can be
+selectively granted to specific modules.
+
+#### `--illegal-native-access=deny`
+
+This setting is first available in Java 24 and should be used whenever
+available. Without this setting, in the absence of policy enforcement,
+any Java code can execute native code. There is arguably no good reason to
+relax this setting, as options already exist to selectively grant such access
+to specific modules that need it, if any.
+
+#### Module system protections
+
+Java's module system is one of the most important remaining mechanisms for
+limiting what Java code may be able to do. Keeping unneeded modules out of the
+module graph, advantageous already for startup speed and memory footprint,
+also means whatever those modules do won't be available to Java code.
+
+The `--limit-modules` VM option can be effectively used to resolve fewer modules
+when PL/Java loads. As of this writing, in early 2025, starting PL/Java with no
+`--add-modules` or `--limit-modules` options results in 48 modules in the graph,
+while a simple `--limit-modules=org.postgresql.pljava.internal` added to
+`pljava.vmoptions` reduces the graph to nine modules---all the transitive
+requirements of PL/Java itself---and all of PL/Java's supplied examples
+successfully run. Any additional modules needed for user code can be added back
+with `--add-modules`. More details at [Limiting the module graph][limiting].
+
+The `--sun-misc-unsafe-memory-access=deny` option mentioned above denies access
+to certain methods of the `sun.misc.Unsafe` class, which is supplied by
+the `jdk.unsupported` module. It may be preferable, when there is no other need
+for it, to also make sure `jdk.unsupported` is not present in the module graph
+at all.
+
+##### Modularize code needing special access
+
+It is currently less convenient in PL/Java 1.6 to provide user code in modular
+form: the `sqlj.install_jar` and `sqlj.set_classpath` functions manage a class
+path, not a module path. Supplying a module requires placing it on the file
+system and adding it to `pljava.module_path`.
+
+The extra inconvenience may be worthwhile in some cases where there is a subset
+of code that requires special treatment, such as an exception to the native
+access restriction. Placing just that code into a named module on the module
+path allows the exception to be made just for that module by name. With the
+removal of Java's former fine-grained policy permissions, such module-level
+exceptions are the finest-grained controls remaining in stock Java.
+
+For news of possible directions for policy enforcement in future PL/Java
+versions, please bookmark [this wiki page][jep411].
+
+[policy]: policy.html
+[jpms]: jpms.html
+[vmoptions]: ../install/vmoptions.html
+[vbls]: variables.html
+[jep411]: https://github.com/tada/pljava/wiki/JEP-411
+[selinux]: ../install/selinux.html
+[sepgsql]: https://www.postgresql.org/docs/17/sepgsql.html
+[limiting]: jpms.html#Limiting_the_module_graph
+[mappedudt]: ../pljava-api/apidocs/org.postgresql.pljava/org/postgresql/pljava/annotation/MappedUDT.html

--- a/src/site/markdown/use/unenforced.md
+++ b/src/site/markdown/use/unenforced.md
@@ -171,6 +171,10 @@ limiting what Java code may be able to do. Keeping unneeded modules out of the
 module graph, advantageous already for startup speed and memory footprint,
 also means whatever those modules do won't be available to Java code.
 
+The supplied [examples jar][examples] provides a function, [java_modules][],
+that can be used to see what modules have been resolved into Java's boot module
+layer.
+
 The `--limit-modules` VM option can be effectively used to resolve fewer modules
 when PL/Java loads. As of this writing, in early 2025, starting PL/Java with no
 `--add-modules` or `--limit-modules` options results in 48 modules in the graph,
@@ -234,3 +238,5 @@ modification would otherwise result).
 [sepgsql]: https://www.postgresql.org/docs/17/sepgsql.html
 [limiting]: jpms.html#Limiting_the_module_graph
 [mappedudt]: ../pljava-api/apidocs/org.postgresql.pljava/org/postgresql/pljava/annotation/MappedUDT.html
+[examples]: ../examples/examples.html
+[java_modules]: ../pljava-examples/apidocs/index.html?org/postgresql/pljava/example/annotation/Modules.html

--- a/src/site/markdown/use/use.md
+++ b/src/site/markdown/use/use.md
@@ -46,9 +46,14 @@ By default, PL/Java code can see a small set of Java modules, including
 
 ### Configuring permissions
 
-The permissions in effect for PL/Java functions can be tailored, independently
-for functions declared to the `TRUSTED` or untrusted language, as described
-[here](policy.html).
+When PL/Java is used with Java 23 or earlier, the permissions in effect
+for PL/Java functions can be tailored, independently for functions declared to
+the `TRUSTED` or untrusted language, as described [here](policy.html).
+
+When PL/Java is used with stock Java 24 or later, no such tailoring of
+permissions is possible, and the
+[PL/Java with no policy enforcement](unenforced.html) page should be carefully
+reviewed.
 
 #### Tailoring permissions for code migrated from PL/Java pre-1.6
 

--- a/src/site/markdown/use/variables.md
+++ b/src/site/markdown/use/variables.md
@@ -200,7 +200,8 @@ These PostgreSQL configuration variables can influence PL/Java's operation:
     setting, determining whether PL/Java will run
     [with security policy enforcement][policy] or
     [with no policy enforcement][unenforced], and those pages should be reviewed
-    for the implications of the choice.
+    for the implications of the choice. Details vary by Java version; see
+    [Available policy-enforcement settings by Java version][smprop].
 
 [pre92]: ../install/prepg92.html
 [depdesc]: https://github.com/tada/pljava/wiki/Sql-deployment-descriptor
@@ -215,3 +216,4 @@ These PostgreSQL configuration variables can influence PL/Java's operation:
 [policy]: policy.html
 [unenforced]: unenforced.html
 [mappedudt]: ../pljava-api/apidocs/org.postgresql.pljava/org/postgresql/pljava/annotation/MappedUDT.html
+[smprop]: ../install/smproperty.html

--- a/src/site/markdown/use/variables.md
+++ b/src/site/markdown/use/variables.md
@@ -30,6 +30,21 @@ These PostgreSQL configuration variables can influence PL/Java's operation:
     define what any values outside ASCII represent; it is usable, but
     [subject to limitations][sqlascii].
 
+`pljava.allow_unenforced`
+: Only used when PL/Java is run with no policy enforcement, this setting is
+    a list of language names (such as `javau` and `java`) in which functions
+    will be allowed to execute. This setting has an empty default, and should
+    only be changed after careful review of the
+    [PL/Java with no policy enforcement][unenforced] page.
+
+`pljava.allow_unenforced_udt`
+: Only used when PL/Java is run with no policy enforcement, this on/off
+    setting controls whether data conversion functions associated with
+    PL/Java [mapped user-defined types][mappedudt]
+    will be allowed to execute. This setting defaults to off, and should
+    only be changed after careful review of the
+    [PL/Java with no policy enforcement][unenforced] page.
+
 `pljava.debug`
 : A boolean variable that, if set `on`, stops the process on first entry to
     PL/Java before the Java virtual machine is started. The process cannot
@@ -92,6 +107,10 @@ These PostgreSQL configuration variables can influence PL/Java's operation:
     object (filename typically ending with `.so`, `.dll`, or `.dylib`).
     To determine the proper setting, see [finding the `libjvm` library][fljvm].
 
+    The version of the Java library pointed to by this variable will determine
+    whether PL/Java can run [with security policy enforcement][policy] or
+    [with no policy enforcement][unenforced].
+
 `pljava.module_path`
 : The module path to be passed to the Java application class loader. The default
     is computed from the PostgreSQL configuration and is usually correct, unless
@@ -109,9 +128,11 @@ These PostgreSQL configuration variables can influence PL/Java's operation:
     [PL/Java and the Java Platform Module System](jpms.html).
 
 `pljava.policy_urls`
-: A list of URLs to Java security [policy files](policy.html) determining
-    the permissions available to PL/Java functions. Each URL should be
-    enclosed in double quotes; any double quote that is literally part of
+: Only used when PL/Java is running [with security policy enforcement][policy].
+    When running [with no policy enforcement][unenforced], this variable is
+    ignored. It is a list of URLs to Java security [policy files][policy]
+    determining the permissions available to PL/Java functions. Each URL should
+    be enclosed in double quotes; any double quote that is literally part of
     the URL may be represented as two double quotes (in SQL style) or as
     `%22` in the URL convention. Between double-quoted URLs, a comma is the
     list delimiter.
@@ -174,7 +195,12 @@ These PostgreSQL configuration variables can influence PL/Java's operation:
     may be adjusted in a future PL/Java version.
 
     Some important settings can be made here, and are described on the
-    [VM options page][vmop].
+    [VM options page][vmop]. For Java 18 and later, this variable must include
+    a `-Djava.security.manager=allow` or `-Djava.security.manager=disallow]`
+    setting, determining whether PL/Java will run
+    [with security policy enforcement][policy] or
+    [with no policy enforcement][unenforced], and those pages should be reviewed
+    for the implications of the choice.
 
 [pre92]: ../install/prepg92.html
 [depdesc]: https://github.com/tada/pljava/wiki/Sql-deployment-descriptor
@@ -186,3 +212,6 @@ These PostgreSQL configuration variables can influence PL/Java's operation:
 [vmop]: ../install/vmoptions.html
 [sqlascii]: charsets.html#Using_PLJava_with_server_encoding_SQL_ASCII
 [addm]: ../install/vmoptions.html#Adding_to_the_set_of_readable_modules
+[policy]: policy.html
+[unenforced]: unenforced.html
+[mappedudt]: ../pljava-api/apidocs/org.postgresql.pljava/org/postgresql/pljava/annotation/MappedUDT.html


### PR DESCRIPTION
Java 24, with [JEP 486][jep486], completes the process, begun with [JEP 411][jep411], of completely gutting Java's ability to enforce security policy, heavily relied on by PL/Java.

With this PR, PL/Java can still be used with all of its familiar policy-enforcement features, as long as `pljava.libjvm_location` points to a Java 23 or earlier JVM, and can also be used—with explicit variable settings to deliberately opt in—with no policy enforcement at all. Only this 'unenforced' mode is available when `pljava.libjvm_location` points to a Java 24 or later JVM.

This, at least, gives a DBA a choice. If a 'trusted' PL with policy enforcement is more important than the very latest Java language features, continue to use PL/Java with a Java 23 or earlier JVM, such as the long-term-support Java 21 release. On the other hand, if the latest Java features are of interest and an 'untrusted' PL with few guardrails is acceptable, the same PL/Java installation can be used in that mode with a Java 24 or later JVM.

It is possible to switch modes at will, simply by changing the JVM that `pljava.libjvm_location` points to, and a few GUCs.

Because of that flexibility, PL/Java continues to create two PL entries, one called `javau` and the other called `java` and marked `TRUSTED`, even when running in unenforced mode. There may be functions already declared of both kinds carried over from earlier, and the distinction may be enforced again simply by pointing PL/Java at a Java 23 or earlier JVM again.

However, in unenforced mode, execution is equally unrestricted regardless of the PL name used or its `TRUSTED` designation. Also, in unenforced mode, only database superusers may create functions, even when the PL is marked `TRUSTED`, regardless of any grant of `USAGE` on the PL.

## Opting in

It would clearly be inappropriate for PL/Java to silently switch to unenforced mode just because the JVM has been updated from a pre-24 to a 24-or-later version. An admin needs to think deliberately about the implications, and perhaps audit some existing Java code, before deciding whether to use a 24-or-later JVM and opt in to unenforced execution.

### `-Djava.security.manager=`...

The primary choice of mode is whether `-Djava.security.manager=allow` (for the familiar, policy-enforcing mode) or `-Djava.security.manager=disallow` (for unenforced mode) appears in the `pljava.vmoptions` setting:

|Java version|Available settings|
|---------|:---|
|9–11|There must be no appearance of `-Djava.security.manager` in `pljava.vmoptions`. Mode will be policy-enforcing.|
|12–17|Either `-Djava.security.manager=allow` or `-Djava.security.manager=disallow` may appear in `pljava.vmoptions`. Default is policy-enforcing (same as `allow`) if neither appears.|
|18–23|One of `-Djava.security.manager=allow` or `-Djava.security.manager=disallow` must appear in `pljava.vmoptions`, or PL/Java will fail to start. There is no default.|
|24–|`-Djava.security.manager=disallow` must appear in `pljava.vmoptions`, or PL/Java will fail to start.|

However, simply starting PL/Java with `-Djava.security.manager=disallow` by itself will not allow any Java functions, or Java-based user-defined-type data conversion methods, to execute in unenforced mode. Those must be further approved, as follows.

### `pljava.allow_unenforced=`_PL name_,...

This GUC is a list of PL names, such as `javau` and `java` (there can be more, as PL./Java's policy-enforcing mode has allowed additional names to be created with [`SQLJ.ALIAS_JAVA_LANGUAGE`][sqljajl] and associated with differently-tailored policies).

No PL/Java function will be allowed to execute in unenforced mode unless the PL name in which it is declared appears in this list.

The list is empty by default. Not even `javau`—which should be the easiest call, as that PL was already considered untrusted—is allowed until added to this list by the admin. That is because even `javau` was subject to a security policy, albeit a more relaxed one, in policy-enforcing mode. In unenforced mode, even those guardrails are removed.

The per-PL-name granularity of this setting allows an admin to divide the work of auditing existing Java code, and add each PL to this list after the functions declared in it have been reviewed.

`CREATE FUNCTION` in a PL that is not named here will usually be reported as an error in unenforced mode, too. It won't be if `check_function_bodies` is `off`, though, so this should be seen more as a friendly reminder than as a form of security. If the `CREATE FUNCTION` succeeds, the function still cannot execute until the PL name is added to this list.

### `pljava.allow_unenforced_udt=`_on/off_

The `pljava.allow_unenforced` setting based on PL names will not affect the data-conversion `readSQL`/`writeSQL` Java methods of PL/Java-based [mapped user-defined types][mappedudt], because those do not have corresponding SQL declarations to associate a PL name. The `on`/`off` setting of `pljava.allow_unenforced_udt` controls the execution of all such UDT methods. Its default setting is `off`, so an admin can change it to `on` after review of any affected Java code.

## Hardening

New documentation on the unenforced mode includes hardening advice, essentially to milk every remaining Java integrity-supporting feature for all it's worth. Suggestions include the `--limit-modules` VM option to reduce the number of Java system modules visible to user code, and using the `--sun-misc-unsafe-memory-access=deny` and `--illegal-native-access=deny` VM options whenever the JVM version in use recognizes them. (Even in policy-enforcing mode, these techniques can still be recommended as part of a defense-in-depth approach.)

All Java system properties are writable in unenforced mode, so defensive early copying is recommended. There are many system properties that are often assumed to convey reliable information about the environment. PL/Java itself now creates an unmodifiable early copy of the system properties, before user code has executed, and makes it available to user code through a new method on the `Session` object.

PL/Java does not yet make it convenient to deploy user code as named modules (the SQL/JRT standard predated Java's module system), but it is possible, and can be advantageous if only a subset of the code requires some special treatment. Per-module VM options now seem to be the finest granularity of permission the developers of Java intend to support.

[jep411]: https://github.com/tada/pljava/wiki/JEP-411
[jep486]: https://openjdk.org/jeps/486
[sqljajl]: https://tada.github.io/pljava/pljava/apidocs/org.postgresql.pljava.internal/org/postgresql/pljava/management/Commands.html#alias_java_language
[mappedudt]: ../pljava-api/apidocs/org.postgresql.pljava/org/postgresql/pljava/annotation/MappedUDT.html
