### PR TITLE
Implement Windows MSVC and MinGW-w64 tests in GitHub Actions CI

### DIFF
--- a/.github/workflows/ci-lazypg.yml
+++ b/.github/workflows/ci-lazypg.yml
@@ -24,19 +24,19 @@ jobs:
     strategy:
       matrix:
         oscc:
-          - os: ubuntu-latest
-            cc: gcc
-          - os: macos-13
-            cc: clang
-            pg: 17
-          - os: macos-14
-            cc: clang
-            pg: 17
-#         - os: windows-latest
-#           cc: msvc
+#         - os: ubuntu-latest
+#           cc: gcc
+#         - os: macos-13
+#           cc: clang
+#           pg: 17
+#         - os: macos-14
+#           cc: clang
+#           pg: 17
+          - os: windows-latest
+            cc: msvc
 #         - os: windows-latest
 #           cc: mingw
-        java: [11, 17, 21, 23]
+        java: [21]
 
     steps:
 
@@ -169,6 +169,22 @@ jobs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       with:
         path: pljava
+
+    - name: Set plethora of MSVC environment variables (Windows MSVC)
+      if: ${{ 'Windows' == runner.os && 'msvc' == matrix.oscc.cc }}
+      uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756
+
+    - name: Build PL/Java (Windows MSVC)
+      if: ${{ 'Windows' == runner.os && 'msvc' == matrix.oscc.cc }}
+      working-directory: pljava
+      # shell: cmd because of the issue described for ilammy/msvc-dev-cmd
+      # with Actions bash prepending stuff to the just-carefully-created PATH
+      shell: cmd
+      run: |
+        mvn clean install --batch-mode ^
+          -Dpgsql.pgconfig="%PGCONFIG%" ^
+          -Psaxon-examples -Ppgjdbc ^
+          -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
 
     - name: Build PL/Java (Linux, macOS)
       if: ${{ 'Windows' != runner.os }}

--- a/.github/workflows/ci-lazypg.yml
+++ b/.github/workflows/ci-lazypg.yml
@@ -24,19 +24,24 @@ jobs:
     strategy:
       matrix:
         oscc:
-#         - os: ubuntu-latest
-#           cc: gcc
-#         - os: macos-13
-#           cc: clang
-#           pg: 17
-#         - os: macos-14
-#           cc: clang
-#           pg: 17
-#         - os: windows-latest
-#           cc: msvc
+          - os: ubuntu-latest
+            cc: gcc
+          - os: macos-13
+            cc: clang
+            pg: 17
+          - os: macos-14
+            cc: clang
+            pg: 17
+          - os: windows-latest
+            cc: msvc
           - os: windows-latest
             cc: mingw
-        java: [21]
+        java: [11, 17, 21, 23]
+        exclude:
+          - oscc: {os: windows-latest}
+            java: 17
+          - oscc: {os: windows-latest}
+            java: 23
 
     steps:
 

--- a/.github/workflows/ci-lazypg.yml
+++ b/.github/workflows/ci-lazypg.yml
@@ -32,10 +32,10 @@ jobs:
 #         - os: macos-14
 #           cc: clang
 #           pg: 17
-          - os: windows-latest
-            cc: msvc
 #         - os: windows-latest
-#           cc: mingw
+#           cc: msvc
+          - os: windows-latest
+            cc: mingw
         java: [21]
 
     steps:
@@ -86,7 +86,8 @@ jobs:
           echo >>"$GITHUB_ENV" "ABS_JSHELL=$JAVA_HOME/bin/jshell"
         fi
 
-    - name: Set PGCONFIG in environment, installing PostgreSQL if needed
+    - name: Set PGCONFIG in environment, getting PostgreSQL if needed (!mingw)
+      if: ${{ 'mingw' != matrix.oscc.cc }}
       shell: bash
       env:
         PGVER: ${{ matrix.oscc.pg }}
@@ -110,6 +111,15 @@ jobs:
           pfx=$(brew --prefix postgresql@"$PGVER")
           echo >>"$GITHUB_ENV" PGCONFIG="$pfx/bin/pg_config"
         fi
+
+    - name: Set PGCONFIG in environment, getting gcc and PostgreSQL (mingw)
+      if: ${{ 'mingw' == matrix.oscc.cc }}
+      shell: C:\shells\msys2bash.cmd {0}
+      run: |
+        pacman -S --noconfirm \
+          mingw-w64-x86_64-gcc \
+          mingw-w64-x86_64-postgresql
+        echo >>"$GITHUB_ENV" PGCONFIG='c:\msys64\mingw64\bin\pg_config'
 
     - name: Report Java, Maven, and PostgreSQL versions
       shell: bash
@@ -198,46 +208,9 @@ jobs:
     - name: Build PL/Java (Windows MinGW-w64)
       if: ${{ 'Windows' == runner.os && 'mingw' == matrix.oscc.cc }}
       working-directory: pljava
-      #
-      # GitHub Actions will allow 'bash' as a shell choice, even on a Windows
-      # runner, in which case it's the bash from Git for Windows. That isn't the
-      # same as the msys64\usr\bin\bash that we want; what's more, while both
-      # rely on a cygwin DLL, they don't rely on the same one, and an attempt
-      # to exec one from the other leads to a "fatal error - cygheap base
-      # mismatch". So, the bash we want has to be started by something other
-      # than the bash we've got. In this case, set shell: to a command that
-      # will use cmd to start the right bash.
-      #
-      # Some of the MinGW magic is set up by the bash profile run at "login", so
-      # bash must be started with -l. That profile ends with a cd $HOME, so to
-      # avoid changing the current directory, set HOME=. first (credit for that:
-      # https://superuser.com/a/806371). As set above, . is really the pljava
-      # working-directory, so the bash script should start by resetting HOME to
-      # the path of its parent.
-      #
-      # The runner is provisioned with a very long PATH that includes separate
-      # bin directories for pre-provisioned packages. The MinGW profile replaces
-      # that with a much shorter path, so mvn and pg_config below must be given
-      # as absolute paths (using M2 and PGBIN supplied in the environment) or
-      # they won't be found. As long as mvn itself can be found, it is able
-      # to find java without difficulty, using the JAVA_HOME that is also in
-      # the environment.
-      #
-      # Those existing variables in the environment are all spelled in Windows
-      # style with drive letters, colons, and backslashes, rather than the MinGW
-      # unixy style, but the mingw bash doesn't seem to object.
-      #
-      # If you use the runner-supplied bash to examine the environment, you will
-      # see MSYSTEM=MINGW64 already in it, but that apparently is something the
-      # runner-supplied bash does. It must be set here before invoking the MinGW
-      # bash directly.
-      #
-      env:
-        HOME: .
-        MSYSTEM: MINGW64
-      shell: 'cmd /C "c:\msys64\usr\bin\bash -l "{0}""'
+      shell: C:\shells\msys2bash.cmd {0}
       run: |
-        HOME=$( (cd .. && pwd) )
+        PATH='/c/msys64/mingw64/bin:'"$PATH"
         "$M2"/mvn clean install --batch-mode \
           -Dpgsql.pgconfig="$PGCONFIG" \
           -Psaxon-examples -Ppgjdbc \

--- a/CI/integration
+++ b/CI/integration
@@ -123,7 +123,7 @@ Path libjvm = (
   ? Stream.of("libjli.dylib", "jli/libjli.dylib")
     .map(s -> javaLibDir.resolve(s))
     .filter(Files::exists).findFirst().get()
-  : javaLibDir.resolve(s_isWindows ? "jvm.dll" : "server/libjvm.so")
+  : javaLibDir.resolve(s_isWindows ? "server\\jvm.dll" : "server/libjvm.so")
 );
 
 // Use deprecated major() here because feature() first appears in Java 10


### PR DESCRIPTION
Starts were made back in 2020 on Windows tests in the GitHub Actions workflows, but they were not completed. Appveyor continued to be used for Windows CI, but at the cost of less parallelism among the matrix of tests and therefore slower results.

With this PR, the GitHub Actions workflow is now covering Linux (x64), Windows (x64, using MSVC or MinGW-w64), and Mac OS (x64 and arm64).