### PR TITLE
Other changes to build/use PL/Java on Java 24

### DIFF
--- a/pljava-api/src/main/java/org/postgresql/pljava/annotation/processing/DDRProcessor.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/annotation/processing/DDRProcessor.java
@@ -173,7 +173,7 @@ public class DDRProcessor extends AbstractProcessor
 		 * Update latest_tested to be the latest Java release on which this
 		 * annotation processor has been tested without problems.
 		 */
-		int latest_tested = 23;
+		int latest_tested = 24;
 		int ordinal_9 = SourceVersion.RELEASE_9.ordinal();
 		int ordinal_latest = latest_tested - 9 + ordinal_9;
 

--- a/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/UDTScalarIOTest.java
+++ b/pljava-examples/src/main/java/org/postgresql/pljava/example/annotation/UDTScalarIOTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2020 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2016-2025 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -15,6 +15,8 @@ import java.math.BigDecimal;
 import java.sql.Date;
 import java.sql.Time;
 import java.sql.Timestamp;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.MalformedURLException;
 
@@ -100,9 +102,11 @@ public class UDTScalarIOTest implements SQLData
 			s_utfgedicht = new byte[bb.limit()];
 			bb.get(s_utfgedicht);
 
-			s_url = new URL("http://tada.github.io/pljava/");
+			s_url = new URI("http://tada.github.io/pljava/").toURL();
 		}
-		catch ( CharacterCodingException | MalformedURLException e )
+		catch (
+			CharacterCodingException |
+			URISyntaxException | MalformedURLException e )
 		{
 			throw new RuntimeException(e);
 		}

--- a/pljava/src/main/java/org/postgresql/pljava/internal/Backend.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/Backend.java
@@ -50,6 +50,7 @@ public class Backend
 	public static final boolean WITHOUT_ENFORCEMENT =
 		"disallow".equals(System.getProperty("java.security.manager"));
 
+	@SuppressWarnings("deprecation") // Java >= 10: .feature()
 	static final int JAVA_MAJOR = Runtime.version().major();
 
 	static

--- a/pljava/src/main/java/org/postgresql/pljava/internal/InstallHelper.java
+++ b/pljava/src/main/java/org/postgresql/pljava/internal/InstallHelper.java
@@ -14,7 +14,8 @@ package org.postgresql.pljava.internal;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.IOException;
-import java.net.URL;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.MalformedURLException;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
@@ -182,9 +183,10 @@ public class InstallHelper
 		{
 			try
 			{
-				new URL("sqlj:x"); // sqlj scheme must exist when reading policy
+				// sqlj scheme must exist when reading policy
+				new URI("sqlj", "x", null).toURL();
 			}
-			catch ( MalformedURLException e )
+			catch ( MalformedURLException | URISyntaxException e )
 			{
 				throw new SecurityException(
 				"failed to create sqlj: URL scheme needed for security policy",
@@ -269,6 +271,7 @@ public class InstallHelper
 				prevURL = Security.getProperty( "policy.url." + prevIndex);
 				if ( null == prevURL )
 				{
+					@SuppressWarnings("deprecation") // Java >= 10: feature()
 					boolean hint =
 						(2 == urlIndex) && 24 <= Runtime.version().major();
 
@@ -332,6 +335,7 @@ public class InstallHelper
 			}
 		}
 
+		@SuppressWarnings("deprecation") // Java >= 10: feature()
 		int major = Runtime.version().major();
 
 		if ( 17 <= major )

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/SPIConnection.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/SPIConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2020 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2025 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -848,7 +848,9 @@ public class SPIConnection implements Connection
 		{
 			try
 			{
-				return (T)new URL((String)value);
+				@SuppressWarnings("deprecation") // PL/Java major rev or forever
+				T result = (T)new URL((String)value);
+				return result;
 			}
 			catch(MalformedURLException e)
 			{

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/SQLInputFromChunk.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/SQLInputFromChunk.java
@@ -285,7 +285,9 @@ public class SQLInputFromChunk implements SQLInput
 	{
 		try
 		{
-			return new URL(this.readString());
+			@SuppressWarnings("deprecation") //'til PL/Java major rev or forever
+			URL u = new URL(this.readString());
+			return u;
 		}
 		catch( Exception e )
 		{

--- a/pljava/src/main/java/org/postgresql/pljava/jdbc/SQLXMLImpl.java
+++ b/pljava/src/main/java/org/postgresql/pljava/jdbc/SQLXMLImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2024 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2018-2025 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -209,6 +209,7 @@ public abstract class SQLXMLImpl<V extends VarlenaWrapper> implements SQLXML
 	@Override
 	public void free() throws SQLException
 	{
+		@SuppressWarnings("unchecked") // javac 24 first to warn here
 		V backing = (V)s_backingVH.getAndSet(this, null);
 		if ( null == backing )
 			return;
@@ -290,6 +291,7 @@ public abstract class SQLXMLImpl<V extends VarlenaWrapper> implements SQLXML
 
 	protected V backingIfNotFreed() throws SQLException
 	{
+		@SuppressWarnings("unchecked") // javac 24 first to warn here
 		V backing = (V)s_backingVH.getAcquire(this);
 		if ( null == backing )
 			throw new SQLNonTransientException(
@@ -397,6 +399,7 @@ public abstract class SQLXMLImpl<V extends VarlenaWrapper> implements SQLXML
 	{
 		if ( null == o )
 			o = this;
+		@SuppressWarnings("unchecked") // javac 24 first to warn here
 		V backing = (V)s_backingVH.getAcquire(this);
 		if ( null != backing )
 			return backing.toString(o);

--- a/pljava/src/main/java/org/postgresql/pljava/management/Commands.java
+++ b/pljava/src/main/java/org/postgresql/pljava/management/Commands.java
@@ -450,6 +450,7 @@ public class Commands
 	{
 		try
 		{
+			@SuppressWarnings("deprecation") // until next PL/Java major rev
 			URL url = new URL(urlString);
 			URLConnection uc = url.openConnection();
 			uc.setRequestProperty("Accept",

--- a/pljava/src/main/java/org/postgresql/pljava/sqlj/Loader.java
+++ b/pljava/src/main/java/org/postgresql/pljava/sqlj/Loader.java
@@ -229,6 +229,7 @@ public class Loader extends ClassLoader
 			{
 				while(rs.next())
 				{
+					@SuppressWarnings("deprecation") // until PL/Java major rev
 					URL jarUrl = new URL("sqlj:" + rs.getString(2));
 					CodeSource cs = new CodeSource(jarUrl, (CodeSigner[])null);
 
@@ -353,12 +354,14 @@ public class Loader extends ClassLoader
 	{
 		try
 		{
-			return doPrivileged(() -> new URL(
+			@SuppressWarnings("deprecation") // Java >= 20: URL.of(uri,handler)
+			URL u = doPrivileged(() -> new URL(
 					"dbf",
 					"localhost",
 					-1,
 					"/" + entryId,
 					EntryStreamHandler.getInstance()));
+			return u;
 		}
 		catch(MalformedURLException e)
 		{


### PR DESCRIPTION
These changes (plus, importantly, PR #512) take care of building and using PL/Java on Java 24.

The JDK 24 release notes do not announce any new features that would need to be exposed in PL/Java's API for use by user code.

Naturally, no patch will begin using Java 24 features within PL/Java itself until a future major release adopts a newer minimum build version.
