### PR TITLE
Changes needed for PG 18

### DIFF
--- a/pljava-so/src/main/c/VarlenaWrapper.c
+++ b/pljava-so/src/main/c/VarlenaWrapper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2018-2025 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -33,7 +33,11 @@
 #include "pljava/JNICalls.h"
 
 #if PG_VERSION_NUM < 90600
-#define GetOldestSnapshot() NULL
+#define get_toast_snapshot() NULL
+#elif PG_VERSION_NUM < 180000
+#define get_toast_snapshot() GetOldestSnapshot()
+#else
+#include <access/toast_internals.h>
 #endif
 
 #define _VL_TYPE struct varlena *
@@ -145,7 +149,7 @@ jobject pljava_VarlenaWrapper_Input(
 		goto justDetoastEagerly;
 	if ( VARATT_IS_EXTERNAL_ONDISK(vl) )
 	{
-		pin = GetOldestSnapshot();
+		pin = get_toast_snapshot();
 		if ( NULL == pin )
 		{
 			/*


### PR DESCRIPTION
When `VarlenaWrapper` wants to save a TOASTed value that may possibly be wanted later, it can use the least memory if it just retains the TOAST pointer and registers a current snapshot in which it is visible. In PG 9.6, a `GetOldestSnapshot` function appeared and made that possible. As of PG 18, with postgres/postgres@4d82750, that function has vanished, but there is a new one, `get_toast_snapshot`, that appears to fit the bill. It's only declared in `access/toast_internals.h`, though, which isn't otherwise needed.

Addresses #524.