### PR TITLE
Tighten implementation of `SnippetTiebreaker`

### DIFF
--- a/pljava-api/src/main/java/org/postgresql/pljava/annotation/processing/TypeTiebreaker.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/annotation/processing/TypeTiebreaker.java
@@ -13,6 +13,7 @@
 package org.postgresql.pljava.annotation.processing;
 
 import java.util.Comparator;
+import static java.util.Comparator.comparing;
 import java.util.Map;
 
 import javax.lang.model.type.TypeMirror;
@@ -24,22 +25,23 @@ import javax.lang.model.type.TypeMirror;
 class TypeTiebreaker
 implements Comparator<Vertex<Map.Entry<TypeMirror, DBType>>>
 {
+	private static final Comparator<Vertex<Map.Entry<TypeMirror, DBType>>> VCMP;
+
+	static
+	{
+		Comparator<Map.Entry<TypeMirror, DBType>> ecmp =
+			comparing(
+				(Map.Entry<TypeMirror, DBType> e) -> e.getValue().toString())
+			.thenComparing(e -> e.getKey().toString());
+
+		VCMP = comparing(v -> v.payload, ecmp);
+	}
+
 	@Override
 	public int compare(
 		Vertex<Map.Entry<TypeMirror, DBType>> o1,
 		Vertex<Map.Entry<TypeMirror, DBType>> o2)
 	{
-		Map.Entry<TypeMirror, DBType> m1 = o1.payload;
-		Map.Entry<TypeMirror, DBType> m2 = o2.payload;
-		int diff =
-			m1.getValue().toString().compareTo( m2.getValue().toString());
-		if ( 0 != diff )
-			return diff;
-		diff = m1.getKey().toString().compareTo( m2.getKey().toString());
-		if ( 0 != diff )
-			return diff;
-		assert
-			m1 == m2 : "Two distinct type mappings compare equal by tiebreaker";
-		return 0;
+		return VCMP.compare(o1, o2);
 	}
 }


### PR DESCRIPTION
The comparator could return a premature result if one `Snippet` or both being compared has a null implementor name, resulting in an output ordering that could depend on the sequence of comparisons performed. While it would still reflect the dependency graph and thus work, it would frustrate reproducible-build expectations.

The case is unlikely to be seen in practice, as an implementor name can only be made null by explicit `implementor=""` in an annotation or `‑Addr.implementor=-` when invoking the Java compiler.

Nonetheless, the tiebreaker method can be made more simple and convincing by taking advantage of the Java 8 additions to `Comparator`.

Addresses #527.

For consistency's sake, also `Comparator`-ize `TypeTiebreaker`.