### PR TITLE
Pacify MSVC about `ereport(ERROR` control flow

### DIFF
--- a/pljava-so/src/main/c/Function.c
+++ b/pljava-so/src/main/c/Function.c
@@ -692,6 +692,7 @@ classMismatch:
 	ereport(ERROR, (errmsg(
 		"PL/Java UDT with oid %u declares input/output/send/recv functions "
 		"in more than one class", typeId)));
+	pg_unreachable(); /* MSVC otherwise is not convinced */
 }
 
 static Function Function_create(


### PR DESCRIPTION
MSVC on GitHub Actions has been reporting consistently that control can reach this point following an `ereport(ERROR`. Add a `pg_unreachable()` there.