### PR TITLE
Streamline anachronistic `Ptr2Long` union usage

### DIFF
--- a/pljava-so/src/main/c/DualState.c
+++ b/pljava-so/src/main/c/DualState.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2018-2025 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -88,20 +88,16 @@ void pljava_DualState_cleanEnqueuedInstances(void)
  */
 void pljava_DualState_nativeRelease(void *ro)
 {
-	Ptr2Long p2l;
-
 	/*
-	 * This static assertion does not need to be in every file
-	 * that uses Ptr2Long, but it should be somewhere once, so here it is.
+	 * This static assertion does not need to be in every file that uses
+	 * PointerGetJLong, but it should be somewhere once, so here it is.
 	 */
-	StaticAssertStmt(sizeof p2l.ptrVal <= sizeof p2l.longVal,
-					 "Pointer will not fit in long on this platform");
+	StaticAssertStmt(sizeof (uintptr_t) <= sizeof (jlong),
+					 "uintptr_t will not fit in jlong on this platform");
 
-	p2l.longVal = 0L;
-	p2l.ptrVal = ro;
 	JNI_callStaticVoidMethodLocked(s_DualState_class,
 								   s_DualState_resourceOwnerRelease,
-								   p2l.longVal);
+								   PointerGetJLong(ro));
 }
 
 void pljava_DualState_initialize(void)
@@ -284,9 +280,7 @@ Java_org_postgresql_pljava_internal_DualState_00024SinglePfree__1pfree(
 	JNIEnv* env, jobject _this, jlong pointer)
 {
 	BEGIN_NATIVE_NO_ERRCHECK
-	Ptr2Long p2l;
-	p2l.longVal = pointer;
-	pfree(p2l.ptrVal);
+	pfree(JLongGet(void *, pointer));
 	END_NATIVE
 }
 
@@ -302,9 +296,7 @@ Java_org_postgresql_pljava_internal_DualState_00024SingleMemContextDelete__1memC
 	JNIEnv* env, jobject _this, jlong pointer)
 {
 	BEGIN_NATIVE_NO_ERRCHECK
-	Ptr2Long p2l;
-	p2l.longVal = pointer;
-	MemoryContextDelete(p2l.ptrVal);
+	MemoryContextDelete(JLongGet(void *, pointer));
 	END_NATIVE
 }
 
@@ -320,9 +312,7 @@ Java_org_postgresql_pljava_internal_DualState_00024SingleFreeTupleDesc__1freeTup
 	JNIEnv* env, jobject _this, jlong pointer)
 {
 	BEGIN_NATIVE_NO_ERRCHECK
-	Ptr2Long p2l;
-	p2l.longVal = pointer;
-	FreeTupleDesc(p2l.ptrVal);
+	FreeTupleDesc(JLongGet(void *, pointer));
 	END_NATIVE
 }
 
@@ -338,9 +328,7 @@ Java_org_postgresql_pljava_internal_DualState_00024SingleHeapFreeTuple__1heapFre
 	JNIEnv* env, jobject _this, jlong pointer)
 {
 	BEGIN_NATIVE_NO_ERRCHECK
-	Ptr2Long p2l;
-	p2l.longVal = pointer;
-	heap_freetuple(p2l.ptrVal);
+	heap_freetuple(JLongGet(void *, pointer));
 	END_NATIVE
 }
 
@@ -356,9 +344,7 @@ Java_org_postgresql_pljava_internal_DualState_00024SingleFreeErrorData__1freeErr
 	JNIEnv* env, jobject _this, jlong pointer)
 {
 	BEGIN_NATIVE_NO_ERRCHECK
-	Ptr2Long p2l;
-	p2l.longVal = pointer;
-	FreeErrorData(p2l.ptrVal);
+	FreeErrorData(JLongGet(void *, pointer));
 	END_NATIVE
 }
 
@@ -374,11 +360,9 @@ Java_org_postgresql_pljava_internal_DualState_00024SingleSPIfreeplan__1spiFreePl
 	JNIEnv* env, jobject _this, jlong pointer)
 {
 	BEGIN_NATIVE_NO_ERRCHECK
-	Ptr2Long p2l;
-	p2l.longVal = pointer;
 	PG_TRY();
 	{
-		SPI_freeplan(p2l.ptrVal);
+		SPI_freeplan(JLongGet(void *, pointer));
 	}
 	PG_CATCH();
 	{
@@ -400,8 +384,6 @@ Java_org_postgresql_pljava_internal_DualState_00024SingleSPIcursorClose__1spiCur
 	JNIEnv* env, jobject _this, jlong pointer)
 {
 	BEGIN_NATIVE_NO_ERRCHECK
-	Ptr2Long p2l;
-	p2l.longVal = pointer;
 	PG_TRY();
 	{
 		/*
@@ -413,7 +395,7 @@ Java_org_postgresql_pljava_internal_DualState_00024SingleSPIcursorClose__1spiCur
 		 */
 		if ( NULL != currentInvocation && ! currentInvocation->errorOccurred
 			&& ! currentInvocation->inExprContextCB )
-			SPI_cursor_close(p2l.ptrVal);
+			SPI_cursor_close(JLongGet(void *, pointer));
 	}
 	PG_CATCH();
 	{

--- a/pljava-so/src/main/c/DualState.c
+++ b/pljava-so/src/main/c/DualState.c
@@ -296,7 +296,7 @@ Java_org_postgresql_pljava_internal_DualState_00024SingleMemContextDelete__1memC
 	JNIEnv* env, jobject _this, jlong pointer)
 {
 	BEGIN_NATIVE_NO_ERRCHECK
-	MemoryContextDelete(JLongGet(void *, pointer));
+	MemoryContextDelete(JLongGet(MemoryContext, pointer));
 	END_NATIVE
 }
 
@@ -312,7 +312,7 @@ Java_org_postgresql_pljava_internal_DualState_00024SingleFreeTupleDesc__1freeTup
 	JNIEnv* env, jobject _this, jlong pointer)
 {
 	BEGIN_NATIVE_NO_ERRCHECK
-	FreeTupleDesc(JLongGet(void *, pointer));
+	FreeTupleDesc(JLongGet(TupleDesc, pointer));
 	END_NATIVE
 }
 
@@ -328,7 +328,7 @@ Java_org_postgresql_pljava_internal_DualState_00024SingleHeapFreeTuple__1heapFre
 	JNIEnv* env, jobject _this, jlong pointer)
 {
 	BEGIN_NATIVE_NO_ERRCHECK
-	heap_freetuple(JLongGet(void *, pointer));
+	heap_freetuple(JLongGet(HeapTuple, pointer));
 	END_NATIVE
 }
 
@@ -344,7 +344,7 @@ Java_org_postgresql_pljava_internal_DualState_00024SingleFreeErrorData__1freeErr
 	JNIEnv* env, jobject _this, jlong pointer)
 {
 	BEGIN_NATIVE_NO_ERRCHECK
-	FreeErrorData(JLongGet(void *, pointer));
+	FreeErrorData(JLongGet(ErrorData *, pointer));
 	END_NATIVE
 }
 
@@ -362,7 +362,7 @@ Java_org_postgresql_pljava_internal_DualState_00024SingleSPIfreeplan__1spiFreePl
 	BEGIN_NATIVE_NO_ERRCHECK
 	PG_TRY();
 	{
-		SPI_freeplan(JLongGet(void *, pointer));
+		SPI_freeplan(JLongGet(SPIPlanPtr, pointer));
 	}
 	PG_CATCH();
 	{
@@ -395,7 +395,7 @@ Java_org_postgresql_pljava_internal_DualState_00024SingleSPIcursorClose__1spiCur
 		 */
 		if ( NULL != currentInvocation && ! currentInvocation->errorOccurred
 			&& ! currentInvocation->inExprContextCB )
-			SPI_cursor_close(JLongGet(void *, pointer));
+			SPI_cursor_close(JLongGet(Portal, pointer));
 	}
 	PG_CATCH();
 	{

--- a/pljava-so/src/main/c/Function.c
+++ b/pljava-so/src/main/c/Function.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2023 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2025 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -708,7 +708,6 @@ static Function Function_create(
 	jstring lname = String_createJavaStringFromNTS(NameStr(lngStruct->lanname));
 	bool ltrust = lngStruct->lanpltrusted;
 	jstring schemaName;
-	Ptr2Long p2l;
 	Datum d;
 	jobject invocable;
 
@@ -724,14 +723,12 @@ static Function Function_create(
 
 	self = /* will rely on the fact that allocInstance zeroes memory */
 		(Function)PgObjectClass_allocInstance(s_FunctionClass,TopMemoryContext);
-	p2l.longVal = 0;
-	p2l.ptrVal = (void *)self;
 
 	PG_TRY();
 	{
 		invocable =
 			JNI_callStaticObjectMethod(s_Function_class, s_Function_create,
-			p2l.longVal, Type_coerceDatum(s_pgproc_Type, d), lname,
+			PointerGetJLong(self), Type_coerceDatum(s_pgproc_Type, d), lname,
 			schemaName,
 			trusted ? JNI_TRUE : JNI_FALSE,
 			forTrigger ? JNI_TRUE : JNI_FALSE,
@@ -1149,7 +1146,6 @@ JNIEXPORT jboolean JNICALL
 	jint numParams, jint returnType, jstring returnJType,
 	jintArray paramTypes, jobjectArray paramJTypes, jobjectArray outJTypes)
 {
-	Ptr2Long p2l;
 	Function self;
 	MemoryContext ctx;
 	jstring jtn;
@@ -1158,8 +1154,7 @@ JNIEXPORT jboolean JNICALL
 	uint16 primParams = 0;
 	bool returnTypeIsOutParameter = false;
 
-	p2l.longVal = wrappedPtr;
-	self = (Function)p2l.ptrVal;
+	self = JLongGet(Function, wrappedPtr);
 	ctx = GetMemoryChunkContext(self);
 
 	BEGIN_NATIVE_NO_ERRCHECK
@@ -1258,13 +1253,11 @@ JNIEXPORT void JNICALL
 	JNIEnv *env, jclass jFunctionClass, jlong wrappedPtr, jobject schemaLoader,
 	jclass clazz, jboolean readOnly, jint funcInitial, jint udtId)
 {
-	Ptr2Long p2l;
 	Function self;
 	HeapTuple typeTup;
 	Form_pg_type pgType;
 
-	p2l.longVal = wrappedPtr;
-	self = (Function)p2l.ptrVal;
+	self = JLongGet(Function, wrappedPtr);
 
 	BEGIN_NATIVE_NO_ERRCHECK
 	PG_TRY();
@@ -1329,7 +1322,6 @@ JNIEXPORT void JNICALL
 	JNIEnv *env, jclass jFunctionClass, jlong wrappedPtr,
 	jobjectArray resolvedTypes, jobjectArray explicitTypes, jint index)
 {
-	Ptr2Long p2l;
 	Function self;
 	Type origType;
 	Type replType;
@@ -1353,8 +1345,7 @@ JNIEXPORT void JNICALL
 	bool actOnReturnType = ( -1 == index ||  -2 == index );
 	bool coerceOutAndSingleton = ( -2 == index );
 
-	p2l.longVal = wrappedPtr;
-	self = (Function)p2l.ptrVal;
+	self = JLongGet(Function, wrappedPtr);
 
 	BEGIN_NATIVE_NO_ERRCHECK
 	PG_TRY();

--- a/pljava-so/src/main/c/HashMap.c
+++ b/pljava-so/src/main/c/HashMap.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2020 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2025 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -134,10 +134,8 @@ static void StringKey_init(StringKey self, const char* keyVal)
  */
 static uint32 _OpaqueKey_hashCode(HashKey self)
 {
-	Ptr2Long p2l;
-	p2l.longVal = 0L; /* ensure that the rest is zeroed out */
-	p2l.ptrVal = ((OpaqueKey)self)->key;
-	return (uint32)(p2l.longVal >> 3);
+	uintptr_t p = (uintptr_t) ((OpaqueKey)self)->key;
+	return (uint32)(p >> 3);
 }
 
 /*

--- a/pljava-so/src/main/c/SQLInputFromTuple.c
+++ b/pljava-so/src/main/c/SQLInputFromTuple.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2019 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2025 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -24,20 +24,14 @@ static jmethodID s_SQLInputFromTuple_init;
 
 jobject pljava_SQLInputFromTuple_create(HeapTupleHeader hth)
 {
-	Ptr2Long p2lht;
-	Ptr2Long p2lro;
+	jlong heapTup = PointerGetJLong(hth);
+	jlong lifespan = PointerGetJLong(currentInvocation);
 	jobject result;
 	jobject jtd = pljava_SingleRowReader_getTupleDesc(hth);
 
-	p2lht.longVal = 0L;
-	p2lro.longVal = 0L;
-
-	p2lht.ptrVal = hth;
-	p2lro.ptrVal = currentInvocation;
-
 	result =
 		JNI_newObjectLocked(s_SQLInputFromTuple_class, s_SQLInputFromTuple_init,
-			pljava_DualState_key(), p2lro.longVal, p2lht.longVal, jtd);
+			pljava_DualState_key(), lifespan, heapTup, jtd);
 
 	JNI_deleteLocalRef(jtd);
 	return result;

--- a/pljava-so/src/main/c/SQLOutputToChunk.c
+++ b/pljava-so/src/main/c/SQLOutputToChunk.c
@@ -1,8 +1,14 @@
 /*
- * Copyright (c) 2004, 2005, 2006 TADA AB - Taby Sweden
- * Distributed under the terms shown in the file COPYRIGHT
- * found in the root folder of this project or at
- * http://eng.tada.se/osprojects/COPYRIGHT.html
+ * Copyright (c) 2004-2025 Tada AB and other contributors, as listed below.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the The BSD 3-Clause License
+ * which accompanies this distribution, and is available at
+ * http://opensource.org/licenses/BSD-3-Clause
+ *
+ * Contributors:
+ *   Tada AB
+ *   Chapman Flack
  *
  * @author Thomas Hallgren
  */
@@ -19,14 +25,11 @@ static jmethodID s_Buffer_position;
 jobject SQLOutputToChunk_create(StringInfo data, bool isJavaBasedScalar)
 {
 	jobject dbb;
-	Ptr2Long p2l;
-	p2l.longVal = 0L; /* ensure that the rest is zeroed out */
-	p2l.ptrVal = data;
 	dbb = JNI_newDirectByteBuffer(data->data, data->maxlen);
 	if ( 0 < data->len )
 		JNI_callObjectMethodLocked(dbb, s_Buffer_position, data->len);
 	return JNI_newObject(s_SQLOutputToChunk_class, s_SQLOutputToChunk_init,
-		p2l.longVal, dbb, isJavaBasedScalar ? JNI_TRUE : JNI_FALSE);
+		PointerGetJLong(data), dbb, isJavaBasedScalar ? JNI_TRUE : JNI_FALSE);
 }
 
 void SQLOutputToChunk_close(jobject stream)
@@ -77,15 +80,11 @@ void SQLOutputToChunk_initialize(void)
 JNIEXPORT jobject JNICALL Java_org_postgresql_pljava_jdbc_SQLOutputToChunk__1ensureCapacity
   (JNIEnv *env, jclass cls, jlong hdl, jobject bb, jint pos, jint needed)
 {
-	Ptr2Long p2l;
-	StringInfo str;
+	StringInfo str = JLongGet(StringInfo, hdl);
 	char *oldp;
 	int oldmax;
 
 	BEGIN_NATIVE
-	p2l.ptrVal = (void *)0; /* ensure that the rest is zeroed out */
-	p2l.longVal = hdl;
-	str = (StringInfo)p2l.ptrVal;
 	str->len = pos;
 	oldp = str->data;
 	oldmax = str->maxlen;

--- a/pljava-so/src/main/c/SQLOutputToTuple.c
+++ b/pljava-so/src/main/c/SQLOutputToTuple.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2019 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2025 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -31,15 +31,15 @@ jobject SQLOutputToTuple_create(TupleDesc td)
 
 HeapTuple SQLOutputToTuple_getTuple(jobject sqlOutput)
 {
-	Ptr2Long p2l;
+	jlong jTup;
 	if(sqlOutput == 0)
 		return 0;
 
-	p2l.longVal = JNI_callLongMethod(sqlOutput, s_SQLOutputToTuple_getTuple);
-	if(p2l.longVal == 0)
+	jTup = JNI_callLongMethod(sqlOutput, s_SQLOutputToTuple_getTuple);
+	if(jTup == 0)
 		return 0;
 
-	return (HeapTuple)p2l.ptrVal;
+	return JLongGet(HeapTuple, jTup);
 }
 
 /* Make this datatype available to the postgres system.

--- a/pljava-so/src/main/c/VarlenaWrapper.c
+++ b/pljava-so/src/main/c/VarlenaWrapper.c
@@ -117,10 +117,10 @@ jobject pljava_VarlenaWrapper_Input(
 	MemoryContext mc;
 	MemoryContext prevcxt;
 	_VL_TYPE vl;
-	Ptr2Long p2lro;
-	Ptr2Long p2lcxt;
-	Ptr2Long p2lpin;
-	Ptr2Long p2ldatum;
+	jlong jro;
+	jlong jcxt;
+	jlong jpin;
+	jlong jdatum;
 	Size parked;
 	Size actual;
 	Snapshot pin = NULL;
@@ -183,19 +183,14 @@ justDetoastEagerly:
 constructResult:
 	MemoryContextSwitchTo(prevcxt);
 
-	p2lro.longVal = 0L;
-	p2lcxt.longVal = 0L;
-	p2lpin.longVal = 0L;
-	p2ldatum.longVal = 0L;
-
-	p2lro.ptrVal = ro;
-	p2lcxt.ptrVal = mc;
-	p2lpin.ptrVal = pin;
-	p2ldatum.ptrVal = vl;
+	jro = PointerGetJLong(ro);
+	jcxt = PointerGetJLong(mc);
+	jpin = PointerGetJLong(pin);
+	jdatum = PointerGetJLong(vl);
 
 	vr = JNI_newObjectLocked(s_VarlenaWrapper_Input_class,
 		s_VarlenaWrapper_Input_init, pljava_DualState_key(),
-		p2lro.longVal, p2lcxt.longVal, p2lpin.longVal, p2ldatum.longVal,
+		jro, jcxt, jpin, jdatum,
 		(jlong)parked, (jlong)actual, dbb);
 
 	if ( NULL != dbb )
@@ -222,9 +217,9 @@ jobject pljava_VarlenaWrapper_Output(MemoryContext parent, ResourceOwner ro)
 	jobject vos;
 	jobject dbb;
 	MemoryContext mc;
-	Ptr2Long p2lro;
-	Ptr2Long p2lcxt;
-	Ptr2Long p2ldatum;
+	jlong jro;
+	jlong jcxt;
+	jlong jdatum;
 
 	mc = AllocSetContextCreate(parent, "PL/Java VarlenaWrapper.Output",
 		 ALLOCSET_START_SMALL_SIZES);
@@ -246,13 +241,9 @@ jobject pljava_VarlenaWrapper_Output(MemoryContext parent, ResourceOwner ro)
 	evosh->tail->next = evosh->tail;
 	/* evosh->tail->size will be filled in by _nextBuffer() later */
 
-	p2lro.longVal = 0L;
-	p2lcxt.longVal = 0L;
-	p2ldatum.longVal = 0L;
-
-	p2lro.ptrVal = ro;
-	p2lcxt.ptrVal = mc;
-	p2ldatum.ptrVal = DatumGetPointer(EOHPGetRWDatum(&(evosh->hdr)));
+	jro = PointerGetJLong(ro);
+	jcxt = PointerGetJLong(mc);
+	jdatum = PointerGetJLong(DatumGetPointer(EOHPGetRWDatum(&(evosh->hdr))));
 
 	/*
 	 * The data bytes begin right after the node header struct.
@@ -261,7 +252,7 @@ jobject pljava_VarlenaWrapper_Output(MemoryContext parent, ResourceOwner ro)
 
 	vos = JNI_newObjectLocked(s_VarlenaWrapper_Output_class,
 			s_VarlenaWrapper_Output_init, pljava_DualState_key(),
-			p2lro.longVal, p2lcxt.longVal, p2ldatum.longVal, dbb);
+			jro, jcxt, jdatum, dbb);
 	JNI_deleteLocalRef(dbb);
 
 	return vos;
@@ -277,12 +268,12 @@ jobject pljava_VarlenaWrapper_Output(MemoryContext parent, ResourceOwner ro)
  */
 Datum pljava_VarlenaWrapper_adopt(jobject vlw)
 {
-	Ptr2Long p2l;
+	jlong adopted;
 
-	p2l.longVal = JNI_callLongMethodLocked(vlw, s_VarlenaWrapper_adopt,
+	adopted = JNI_callLongMethodLocked(vlw, s_VarlenaWrapper_adopt,
 					pljava_DualState_key());
 
-	return PointerGetDatum(p2l.ptrVal);
+	return PointerGetDatum(JLongGet(Pointer, adopted));
 }
 
 static Size VOS_get_flat_size(ExpandedObjectHeader *eohptr)
@@ -396,11 +387,8 @@ Java_org_postgresql_pljava_internal_VarlenaWrapper_00024Input_00024State__1unreg
   (JNIEnv *env, jobject _this, jlong snapshot, jlong ro)
 {
 	BEGIN_NATIVE_NO_ERRCHECK
-	Ptr2Long p2lsnap;
-	Ptr2Long p2lro;
-	p2lsnap.longVal = snapshot;
-	p2lro.longVal = ro;
-	UnregisterSnapshotFromOwner(p2lsnap.ptrVal, p2lro.ptrVal);
+	UnregisterSnapshotFromOwner(
+		JLongGet(Snapshot, snapshot), JLongGet(ResourceOwner, ro));
 	END_NATIVE
 }
 
@@ -413,36 +401,26 @@ JNIEXPORT jobject JNICALL
 Java_org_postgresql_pljava_internal_VarlenaWrapper_00024Input_00024State__1detoast
   (JNIEnv *env, jobject _this, jlong vl, jlong cxt, jlong snap, jlong resOwner)
 {
-	Ptr2Long p2lvl;
-	Ptr2Long p2lcxt;
-	Ptr2Long p2lsnap;
-	Ptr2Long p2lro;
-	Ptr2Long p2ldetoasted;
+	_VL_TYPE vlp = JLongGet(_VL_TYPE, vl);
 	_VL_TYPE detoasted;
 	MemoryContext prevcxt;
 	jobject dbb = NULL;
 
 	BEGIN_NATIVE_NO_ERRCHECK
 
-	p2lvl.longVal = vl;
-	p2lcxt.longVal = cxt;
-	p2lsnap.longVal = snap;
-	p2lro.longVal = resOwner;
+	prevcxt = MemoryContextSwitchTo(JLongGet(MemoryContext, cxt));
 
-	prevcxt = MemoryContextSwitchTo((MemoryContext)p2lcxt.ptrVal);
-
-	detoasted = (_VL_TYPE) PG_DETOAST_DATUM_COPY(PointerGetDatum(p2lvl.ptrVal));
-	p2ldetoasted.longVal = 0L;
-	p2ldetoasted.ptrVal = detoasted;
+	detoasted = (_VL_TYPE) PG_DETOAST_DATUM_COPY(PointerGetDatum(vlp));
 
 	MemoryContextSwitchTo(prevcxt);
 
 	JNI_setLongField(_this,
-		s_VarlenaWrapper_Input_State_varlena, p2ldetoasted.longVal);
-	pfree(p2lvl.ptrVal);
+		s_VarlenaWrapper_Input_State_varlena, PointerGetJLong(detoasted));
+	pfree(vlp);
 
 	if ( 0 != snap )
-		UnregisterSnapshotFromOwner(p2lsnap.ptrVal, p2lro.ptrVal);
+		UnregisterSnapshotFromOwner(
+			JLongGet(Snapshot, snap), JLongGet(ResourceOwner, resOwner));
 
 	dbb = JNI_newDirectByteBuffer(
 		VARDATA(detoasted), VARSIZE_ANY_EXHDR(detoasted));
@@ -468,24 +446,18 @@ Java_org_postgresql_pljava_internal_VarlenaWrapper_00024Input_00024State__1detoa
 JNIEXPORT jlong JNICALL Java_org_postgresql_pljava_internal_VarlenaWrapper_00024Input_00024State__1fetch
   (JNIEnv *env, jobject _this, jlong varlena, jlong memContext)
 {
-	Ptr2Long p2lvl;
-	Ptr2Long p2lcxt;
+	_VL_TYPE vl = JLongGet(_VL_TYPE, varlena);
 	MemoryContext prevcxt;
-	_VL_TYPE fetched;
-
-	p2lvl.longVal = varlena;
-	p2lcxt.longVal = memContext;
+	_VL_TYPE fetched = NULL;
 
 	BEGIN_NATIVE_NO_ERRCHECK;
-	prevcxt = MemoryContextSwitchTo((MemoryContext) p2lcxt.ptrVal);
-	fetched = detoast_external_attr((_VL_TYPE) p2lvl.ptrVal);
-	pfree(p2lvl.ptrVal);
-	p2lvl.longVal = 0L;
-	p2lvl.ptrVal = fetched;
+	prevcxt = MemoryContextSwitchTo(JLongGet(MemoryContext, memContext));
+	fetched = detoast_external_attr(vl);
+	pfree(vl);
 	MemoryContextSwitchTo(prevcxt);
 	END_NATIVE;
 
-	return p2lvl.longVal;
+	return PointerGetJLong(fetched);
 }
 
 /*
@@ -500,12 +472,8 @@ Java_org_postgresql_pljava_internal_VarlenaWrapper_00024Output_00024State__1next
 {
 	ExpandedVarlenaOutputStreamHeader *evosh;
 	ExpandedVarlenaOutputStreamNode *node;
-	Ptr2Long p2l;
-	Datum d;
+	Datum d = PointerGetDatum(JLongGet(Pointer, varlenaPtr));
 	jobject dbb = NULL;
-
-	p2l.longVal = varlenaPtr;
-	d = PointerGetDatum(p2l.ptrVal);
 
 	evosh = (ExpandedVarlenaOutputStreamHeader *)DatumGetEOHP(d);
 	evosh->tail->size  = currentBufPosition;

--- a/pljava-so/src/main/c/type/Composite.c
+++ b/pljava-so/src/main/c/type/Composite.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2020 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2025 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -59,13 +59,11 @@ static jobject _createWriter(jobject tupleDesc)
 
 static HeapTuple _getTupleAndClear(jobject jrps)
 {
-	Ptr2Long p2l;
-
 	if(jrps == 0)
 		return 0;
 
-	p2l.longVal = JNI_callLongMethod(jrps, s_SingleRowWriter_getTupleAndClear);
-	return (HeapTuple)p2l.ptrVal;
+	return JLongGet(HeapTuple,
+		 JNI_callLongMethod(jrps, s_SingleRowWriter_getTupleAndClear));
 }
 
 /*

--- a/pljava-so/src/main/c/type/Portal.c
+++ b/pljava-so/src/main/c/type/Portal.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2019 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2025 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -40,19 +40,12 @@ static jmethodID s_Portal_init;
 jobject pljava_Portal_create(Portal portal, jobject jplan)
 {
 	jobject jportal;
-	Ptr2Long p2l;
-	Ptr2Long p2lro;
 	if(portal == 0)
 		return NULL;
 
-	p2l.longVal = 0L; /* ensure that the rest is zeroed out */
-	p2l.ptrVal = portal;
-
-	p2lro.longVal = 0L;
-	p2lro.ptrVal = portal->resowner;
-
 	jportal = JNI_newObjectLocked(s_Portal_class, s_Portal_init,
-		pljava_DualState_key(), p2lro.longVal, p2l.longVal, jplan);
+		pljava_DualState_key(),
+		PointerGetJLong(portal->resowner), PointerGetJLong(portal), jplan);
 
 	return jportal;
 }
@@ -122,9 +115,7 @@ Java_org_postgresql_pljava_internal_Portal__1getPortalPos(JNIEnv* env, jclass cl
 	jlong result = 0;
 	if(_this != 0)
 	{
-		Ptr2Long p2l;
-		p2l.longVal = _this;
-		result = (jlong)((Portal)p2l.ptrVal)->portalPos;
+		result = (jlong)JLongGet(Portal, _this)->portalPos;
 	}
 	return result;
 }
@@ -141,7 +132,6 @@ Java_org_postgresql_pljava_internal_Portal__1fetch(JNIEnv* env, jclass clazz, jl
 	if(_this != 0)
 	{
 		BEGIN_NATIVE
-		Ptr2Long p2l;
 		STACK_BASE_VARS
 		STACK_BASE_PUSH(env)
 
@@ -155,11 +145,10 @@ Java_org_postgresql_pljava_internal_Portal__1fetch(JNIEnv* env, jclass clazz, jl
 		 */
 		pljava_DualState_cleanEnqueuedInstances();
 
-		p2l.longVal = _this;
 		PG_TRY();
 		{
 			Invocation_assertConnect();
-			SPI_cursor_fetch((Portal)p2l.ptrVal, forward == JNI_TRUE,
+			SPI_cursor_fetch(JLongGet(Portal, _this), forward == JNI_TRUE,
 				(long)count);
 			result = (jlong)SPI_processed;
 		}
@@ -186,9 +175,7 @@ Java_org_postgresql_pljava_internal_Portal__1getName(JNIEnv* env, jclass clazz, 
 	if(_this != 0)
 	{
 		BEGIN_NATIVE
-		Ptr2Long p2l;
-		p2l.longVal = _this;
-		result = String_createJavaStringFromNTS(((Portal)p2l.ptrVal)->name);
+		result = String_createJavaStringFromNTS(JLongGet(Portal, _this)->name);
 		END_NATIVE
 	}
 	return result;
@@ -206,9 +193,7 @@ Java_org_postgresql_pljava_internal_Portal__1getTupleDesc(JNIEnv* env, jclass cl
 	if(_this != 0)
 	{
 		BEGIN_NATIVE
-		Ptr2Long p2l;
-		p2l.longVal = _this;
-		result = pljava_TupleDesc_create(((Portal)p2l.ptrVal)->tupDesc);
+		result = pljava_TupleDesc_create(JLongGet(Portal, _this)->tupDesc);
 		END_NATIVE
 	}
 	return result;
@@ -225,9 +210,7 @@ Java_org_postgresql_pljava_internal_Portal__1isAtStart(JNIEnv* env, jclass clazz
 	jboolean result = JNI_FALSE;
 	if(_this != 0)
 	{
-		Ptr2Long p2l;
-		p2l.longVal = _this;
-		result = (jboolean)((Portal)p2l.ptrVal)->atStart;
+		result = (jboolean)JLongGet(Portal, _this)->atStart;
 	}
 	return result;
 }
@@ -243,9 +226,7 @@ Java_org_postgresql_pljava_internal_Portal__1isAtEnd(JNIEnv* env, jclass clazz, 
 	jboolean result = JNI_FALSE;
 	if(_this != 0)
 	{
-		Ptr2Long p2l;
-		p2l.longVal = _this;
-		result = (jboolean)((Portal)p2l.ptrVal)->atEnd;
+		result = (jboolean)JLongGet(Portal, _this)->atEnd;
 	}
 	return result;
 }
@@ -262,15 +243,14 @@ Java_org_postgresql_pljava_internal_Portal__1move(JNIEnv* env, jclass clazz, jlo
 	if(_this != 0)
 	{
 		BEGIN_NATIVE
-		Ptr2Long p2l;
 		STACK_BASE_VARS
 		STACK_BASE_PUSH(env)
 
-		p2l.longVal = _this;
 		PG_TRY();
 		{
 			Invocation_assertConnect();
-			SPI_cursor_move((Portal)p2l.ptrVal, forward == JNI_TRUE, (long)count);
+			SPI_cursor_move(
+				JLongGet(Portal, _this), forward == JNI_TRUE, (long)count);
 			result = (jlong)SPI_processed;
 		}
 		PG_CATCH();

--- a/pljava-so/src/main/c/type/Relation.c
+++ b/pljava-so/src/main/c/type/Relation.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2019 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2025 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -34,24 +34,15 @@ static jmethodID s_Relation_init;
  */
 jobject pljava_Relation_create(Relation r)
 {
-	Ptr2Long p2lr;
-	Ptr2Long p2lro;
-
 	if ( NULL == r )
 		return NULL;
-
-	p2lr.longVal = 0L;
-	p2lr.ptrVal = r;
-
-	p2lro.longVal = 0L;
-	p2lro.ptrVal = currentInvocation;
 
 	return JNI_newObjectLocked(
 			s_Relation_class,
 			s_Relation_init,
 			pljava_DualState_key(),
-			p2lro.longVal,
-			p2lr.longVal);
+			PointerGetJLong(currentInvocation),
+			PointerGetJLong(r));
 }
 
 void pljava_Relation_initialize(void)
@@ -99,10 +90,7 @@ JNIEXPORT jstring JNICALL
 Java_org_postgresql_pljava_internal_Relation__1getName(JNIEnv* env, jclass clazz, jlong _this)
 {
 	jstring result = 0;
-	Relation self;
-	Ptr2Long p2l;
-	p2l.longVal = _this;
-	self = (Relation)p2l.ptrVal;
+	Relation self = JLongGet(Relation, _this);
 
 	if(self != 0)
 	{
@@ -132,10 +120,7 @@ JNIEXPORT jstring JNICALL
 Java_org_postgresql_pljava_internal_Relation__1getSchema(JNIEnv* env, jclass clazz, jlong _this)
 {
 	jstring result = 0;
-	Relation self;
-	Ptr2Long p2l;
-	p2l.longVal = _this;
-	self = (Relation)p2l.ptrVal;
+	Relation self = JLongGet(Relation, _this);
 
 	if(self != 0)
 	{
@@ -165,10 +150,7 @@ JNIEXPORT jobject JNICALL
 Java_org_postgresql_pljava_internal_Relation__1getTupleDesc(JNIEnv* env, jclass clazz, jlong _this)
 {
 	jobject result = 0;
-	Relation self;
-	Ptr2Long p2l;
-	p2l.longVal = _this;
-	self = (Relation)p2l.ptrVal;
+	Relation self = JLongGet(Relation, _this);
 
 	if(self != 0)
 	{
@@ -198,18 +180,12 @@ JNIEXPORT jobject JNICALL
 Java_org_postgresql_pljava_internal_Relation__1modifyTuple(JNIEnv* env, jclass clazz, jlong _this, jlong _tuple, jintArray _indexes, jobjectArray _values)
 {
 	jobject result = 0;
-	Relation self;
-	Ptr2Long p2lr;
-	p2lr.longVal = _this;
-	self = (Relation)p2lr.ptrVal;
+	Relation self = JLongGet(Relation, _this);
 
 	if(self != 0 && _tuple != 0)
 	{
-		Ptr2Long p2lt;
-		p2lt.longVal = _tuple;
-
 		BEGIN_NATIVE
-		HeapTuple tuple = (HeapTuple)p2lt.ptrVal;
+		HeapTuple tuple = JLongGet(HeapTuple, _tuple);
 		PG_TRY();
 		{
 			jint idx;

--- a/pljava-so/src/main/c/type/SingleRowReader.c
+++ b/pljava-so/src/main/c/type/SingleRowReader.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2019 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2025 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -47,20 +47,13 @@ jobject pljava_SingleRowReader_getTupleDesc(HeapTupleHeader ht)
 
 jobject pljava_SingleRowReader_create(HeapTupleHeader ht)
 {
-	Ptr2Long p2lht;
-	Ptr2Long p2lro;
 	jobject result;
 	jobject jtd = pljava_SingleRowReader_getTupleDesc(ht);
 
-	p2lht.longVal = 0L;
-	p2lro.longVal = 0L;
-
-	p2lht.ptrVal = ht;
-	p2lro.ptrVal = currentInvocation;
-
 	result =
 		JNI_newObjectLocked(s_SingleRowReader_class, s_SingleRowReader_init,
-			pljava_DualState_key(), p2lro.longVal, p2lht.longVal, jtd);
+			pljava_DualState_key(), PointerGetJLong(currentInvocation),
+			PointerGetJLong(ht), jtd);
 
 	JNI_deleteLocalRef(jtd);
 	return result;
@@ -104,21 +97,17 @@ Java_org_postgresql_pljava_jdbc_SingleRowReader__1getObject(JNIEnv* env, jclass 
 	jobject result = 0;
 	if(hth != 0 && jtd != 0)
 	{
-		Ptr2Long p2lhth;
-		Ptr2Long p2ltd;
-		p2lhth.longVal = hth;
-		p2ltd.longVal = jtd;
 		BEGIN_NATIVE
 		PG_TRY();
 		{
 			Type type = pljava_TupleDesc_getColumnType(
-				(TupleDesc) p2ltd.ptrVal, (int) attrNo);
+				JLongGet(TupleDesc, jtd), (int) attrNo);
 			if (type != 0)
 			{
 				Datum binVal;
 				bool wasNull = false;
 				binVal = GetAttributeByNum(
-							(HeapTupleHeader)p2lhth.ptrVal,
+							JLongGet(HeapTupleHeader, hth),
 							(AttrNumber)attrNo, &wasNull);
 				if(!wasNull)
 					result = Type_coerceDatumAs(type, binVal, rqcls).l;

--- a/pljava-so/src/main/c/type/TriggerData.c
+++ b/pljava-so/src/main/c/type/TriggerData.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2019 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2025 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -31,33 +31,23 @@ static jmethodID s_TriggerData_getTriggerReturnTuple;
 
 jobject pljava_TriggerData_create(TriggerData* triggerData)
 {
-	Ptr2Long p2ltd;
-	Ptr2Long p2lro;
-
 	if ( NULL == triggerData )
 		return NULL;
-
-	p2ltd.longVal = 0L;
-	p2ltd.ptrVal = triggerData;
-
-	p2lro.longVal = 0L;
-	p2lro.ptrVal = currentInvocation;
 
 	return JNI_newObjectLocked(
 			s_TriggerData_class,
 			s_TriggerData_init,
 			pljava_DualState_key(),
-			p2lro.longVal,
-			p2ltd.longVal);
+			PointerGetJLong(currentInvocation),
+			PointerGetJLong(triggerData));
 }
 
 HeapTuple pljava_TriggerData_getTriggerReturnTuple(jobject jtd, bool* wasNull)
 {
-	Ptr2Long p2l;
 	HeapTuple ret = 0;
-	p2l.longVal = JNI_callLongMethod(jtd, s_TriggerData_getTriggerReturnTuple);
-	if(p2l.longVal != 0)
-		ret = heap_copytuple((HeapTuple)p2l.ptrVal); /* unconditional copy?? */
+	jlong jht = JNI_callLongMethod(jtd, s_TriggerData_getTriggerReturnTuple);
+	if(jht != 0)
+		ret = heap_copytuple(JLongGet(HeapTuple, jht));/* unconditional copy? */
 	else
 		*wasNull = true;
 	return ret;
@@ -165,10 +155,7 @@ JNIEXPORT jobject JNICALL
 Java_org_postgresql_pljava_internal_TriggerData__1getRelation(JNIEnv* env, jclass clazz, jlong _this)
 {
 	jobject result = 0;
-	TriggerData* self;
-	Ptr2Long p2l;
-	p2l.longVal = _this;
-	self = (TriggerData*)p2l.ptrVal;
+	TriggerData* self = JLongGet(TriggerData *, _this);
 	if(self != 0)
 	{
 		BEGIN_NATIVE
@@ -187,10 +174,7 @@ JNIEXPORT jobject JNICALL
 Java_org_postgresql_pljava_internal_TriggerData__1getTriggerTuple(JNIEnv* env, jclass clazz, jlong _this)
 {
 	jobject result = 0;
-	TriggerData* self;
-	Ptr2Long p2l;
-	p2l.longVal = _this;
-	self = (TriggerData*)p2l.ptrVal;
+	TriggerData* self = JLongGet(TriggerData *, _this);
 	if(self != 0)
 	{
 		BEGIN_NATIVE
@@ -209,10 +193,7 @@ JNIEXPORT jobject JNICALL
 Java_org_postgresql_pljava_internal_TriggerData__1getNewTuple(JNIEnv* env, jclass clazz, jlong _this)
 {
 	jobject result = 0;
-	TriggerData* self;
-	Ptr2Long p2l;
-	p2l.longVal = _this;
-	self = (TriggerData*)p2l.ptrVal;
+	TriggerData* self = JLongGet(TriggerData *, _this);
 	if(self != 0)
 	{
 		BEGIN_NATIVE
@@ -231,10 +212,7 @@ JNIEXPORT jobjectArray JNICALL
 Java_org_postgresql_pljava_internal_TriggerData__1getArguments(JNIEnv* env, jclass clazz, jlong _this)
 {
 	jobjectArray result = 0;
-	TriggerData* self;
-	Ptr2Long p2l;
-	p2l.longVal = _this;
-	self = (TriggerData*)p2l.ptrVal;
+	TriggerData* self = JLongGet(TriggerData *, _this);
 	if(self != 0)
 	{
 		char** cpp;
@@ -265,10 +243,7 @@ JNIEXPORT jstring JNICALL
 Java_org_postgresql_pljava_internal_TriggerData__1getName(JNIEnv* env, jclass clazz, jlong _this)
 {
 	jstring result = 0;
-	TriggerData* self;
-	Ptr2Long p2l;
-	p2l.longVal = _this;
-	self = (TriggerData*)p2l.ptrVal;
+	TriggerData* self = JLongGet(TriggerData *, _this);
 	if(self != 0)
 	{
 		BEGIN_NATIVE
@@ -287,10 +262,7 @@ JNIEXPORT jboolean JNICALL
 Java_org_postgresql_pljava_internal_TriggerData__1isFiredAfter(JNIEnv* env, jclass clazz, jlong _this)
 {
 	jboolean result = JNI_FALSE;
-	TriggerData* self;
-	Ptr2Long p2l;
-	p2l.longVal = _this;
-	self = (TriggerData*)p2l.ptrVal;
+	TriggerData* self = JLongGet(TriggerData *, _this);
 	if(self != 0)
 		result = (jboolean)TRIGGER_FIRED_AFTER(self->tg_event);
 	return result;
@@ -305,10 +277,7 @@ JNIEXPORT jboolean JNICALL
 Java_org_postgresql_pljava_internal_TriggerData__1isFiredBefore(JNIEnv* env, jclass clazz, jlong _this)
 {
 	jboolean result = JNI_FALSE;
-	TriggerData* self;
-	Ptr2Long p2l;
-	p2l.longVal = _this;
-	self = (TriggerData*)p2l.ptrVal;
+	TriggerData* self = JLongGet(TriggerData *, _this);
 	if(self != 0)
 		result = (jboolean)TRIGGER_FIRED_BEFORE(self->tg_event);
 	return result;
@@ -323,10 +292,7 @@ JNIEXPORT jboolean JNICALL
 Java_org_postgresql_pljava_internal_TriggerData__1isFiredForEachRow(JNIEnv* env, jclass clazz, jlong _this)
 {
 	jboolean result = JNI_FALSE;
-	TriggerData* self;
-	Ptr2Long p2l;
-	p2l.longVal = _this;
-	self = (TriggerData*)p2l.ptrVal;
+	TriggerData* self = JLongGet(TriggerData *, _this);
 	if(self != 0)
 		result = (jboolean)TRIGGER_FIRED_FOR_ROW(self->tg_event);
 	return result;
@@ -341,10 +307,7 @@ JNIEXPORT jboolean JNICALL
 Java_org_postgresql_pljava_internal_TriggerData__1isFiredForStatement(JNIEnv* env, jclass clazz, jlong _this)
 {
 	jboolean result = JNI_FALSE;
-	TriggerData* self;
-	Ptr2Long p2l;
-	p2l.longVal = _this;
-	self = (TriggerData*)p2l.ptrVal;
+	TriggerData* self = JLongGet(TriggerData *, _this);
 	if(self != 0)
 		result = (jboolean)TRIGGER_FIRED_FOR_STATEMENT(self->tg_event);
 	return result;
@@ -359,10 +322,7 @@ JNIEXPORT jboolean JNICALL
 Java_org_postgresql_pljava_internal_TriggerData__1isFiredByDelete(JNIEnv* env, jclass clazz, jlong _this)
 {
 	jboolean result = JNI_FALSE;
-	TriggerData* self;
-	Ptr2Long p2l;
-	p2l.longVal = _this;
-	self = (TriggerData*)p2l.ptrVal;
+	TriggerData* self = JLongGet(TriggerData *, _this);
 	if(self != 0)
 		result = (jboolean)TRIGGER_FIRED_BY_DELETE(self->tg_event);
 	return result;
@@ -377,10 +337,7 @@ JNIEXPORT jboolean JNICALL
 Java_org_postgresql_pljava_internal_TriggerData__1isFiredByInsert(JNIEnv* env, jclass clazz, jlong _this)
 {
 	jboolean result = JNI_FALSE;
-	TriggerData* self;
-	Ptr2Long p2l;
-	p2l.longVal = _this;
-	self = (TriggerData*)p2l.ptrVal;
+	TriggerData* self = JLongGet(TriggerData *, _this);
 	if(self != 0)
 		result = (jboolean)TRIGGER_FIRED_BY_INSERT(self->tg_event);
 	return result;
@@ -395,10 +352,7 @@ JNIEXPORT jboolean JNICALL
 Java_org_postgresql_pljava_internal_TriggerData__1isFiredByUpdate(JNIEnv* env, jclass clazz, jlong _this)
 {
 	jboolean result = JNI_FALSE;
-	TriggerData* self;
-	Ptr2Long p2l;
-	p2l.longVal = _this;
-	self = (TriggerData*)p2l.ptrVal;
+	TriggerData* self = JLongGet(TriggerData *, _this);
 	if(self != 0)
 		result = (jboolean)TRIGGER_FIRED_BY_UPDATE(self->tg_event);
 	return result;

--- a/pljava-so/src/main/c/type/Tuple.c
+++ b/pljava-so/src/main/c/type/Tuple.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2019 Tada AB and other contributors, as listed below.
+ * Copyright (c) 2004-2025 Tada AB and other contributors, as listed below.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the The BSD 3-Clause License
@@ -57,13 +57,10 @@ jobjectArray pljava_Tuple_createArray(HeapTuple* vals, jint size, bool mustCopy)
 jobject pljava_Tuple_internalCreate(HeapTuple ht, bool mustCopy)
 {
 	jobject jht;
-	Ptr2Long htH;
 
 	if(mustCopy)
 		ht = heap_copytuple(ht);
 
-	htH.longVal = 0L; /* ensure that the rest is zeroed out */
-	htH.ptrVal = ht;
 	/*
 	 * Passing (jlong)0 as the ResourceOwner means this will never be matched by a
 	 * nativeRelease call; that's appropriate (for now) as the Tuple copy is
@@ -72,7 +69,7 @@ jobject pljava_Tuple_internalCreate(HeapTuple ht, bool mustCopy)
 	 * XXX? this seems like a lot of tuple copying.
 	 */
 	jht = JNI_newObjectLocked(s_Tuple_class, s_Tuple_init,
-		pljava_DualState_key(), (jlong)0, htH.longVal);
+		pljava_DualState_key(), (jlong)0, PointerGetJLong(ht));
 	return jht;
 }
 
@@ -146,13 +143,11 @@ JNIEXPORT jobject JNICALL
 Java_org_postgresql_pljava_internal_Tuple__1getObject(JNIEnv* env, jclass cls, jlong _this, jlong _tupleDesc, jint index, jclass rqcls)
 {
 	jobject result = 0;
-	Ptr2Long p2l;
-	p2l.longVal = _this;
 
 	BEGIN_NATIVE
-	HeapTuple self = (HeapTuple)p2l.ptrVal;
-	p2l.longVal = _tupleDesc;
-	result = pljava_Tuple_getObject((TupleDesc)p2l.ptrVal, self, (int)index, rqcls);
+	HeapTuple self = JLongGet(HeapTuple, _this);
+	result = pljava_Tuple_getObject(JLongGet(TupleDesc, _tupleDesc), self,
+		(int)index, rqcls);
 	END_NATIVE
 	return result;
 }

--- a/pljava-so/src/main/include/pljava/pljava.h
+++ b/pljava-so/src/main/include/pljava/pljava.h
@@ -152,14 +152,14 @@ extern MemoryContext JavaMemoryContext;
  */
 #define ERRCODE_CLASS_SQLJRT MAKE_SQLSTATE('4','6','0','0','0')
 
-/*
- * Union used when coercing void* to jlong and vice versa
- */
-typedef union
+static inline jlong
+PointerGetJLong(const void *X)
 {
-	void*  ptrVal;
-	jlong  longVal; /* 64 bit quantity */
-} Ptr2Long;
+	return (jlong)(uintptr_t)(X);
+}
+
+#define JLongGet(T, X) \
+	(AssertVariableIsOfTypeMacro(X, jlong), (T)(uintptr_t)(X))
 
 struct Invocation_;
 typedef struct Invocation_ Invocation;


### PR DESCRIPTION
PostgreSQL itself has been requiring a C compiler that has `uintptr_t` since 9.0 (postgres/postgres@85d02a6). The PL/Java 1.6.x branch only supports back to PG 9.5, so there is no question the type is supported.

An existing static assert in `DualState.c` is hereby changed to assert that `sizeof(uintptr_t) <= sizeof(jlong)`; this is also assured for the present by a comment upstream in `postgres.h` section 1: "we require: sizeof(Datum) == sizeof(void *) == 4 or 8" (where `Datum` is `uintptr_t`).

In passing, specifically type as `SPIPlanPtr` some variables that had been typed `void *`. That was once their actual type in the SPI docs, but not since PG 8.2.

The few sites that ended up as `PointerGetDatum(JLongGet(Pointer,...))` are effectively a longwinded way of doing nothing, but I left them that way to clearly reflect that a pointer is involved, and avoid assuming `PointerGetDatum` will always be as simple as it currently is.