### PR TITLE
Support building/using PL/Java on Java 25

### DIFF
--- a/pljava-api/src/main/java/org/postgresql/pljava/annotation/processing/DDRProcessor.java
+++ b/pljava-api/src/main/java/org/postgresql/pljava/annotation/processing/DDRProcessor.java
@@ -62,7 +62,7 @@ public class DDRProcessor extends AbstractProcessor
 		 * Update latest_tested to be the latest Java release on which this
 		 * annotation processor has been tested without problems.
 		 */
-		int latest_tested = 24;
+		int latest_tested = 25;
 		int ordinal_9 = SourceVersion.RELEASE_9.ordinal();
 		int ordinal_latest = latest_tested - 9 + ordinal_9;
 


### PR DESCRIPTION
The JDK 25 release notes do not announce any new features that would need to be exposed in PL/Java's API for use by user code.

Naturally, no patch will begin using Java 25 features within PL/Java itself until a future major release adopts a newer minimum build version.